### PR TITLE
更新准确的Node.js版本要求

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **部署支持**：支持本地运行、Docker 容器化、Vercel 一键部署、Cloudflare 一键部署和 Docker 一键启动。
 
 ## 前置条件
-- Node.js（v18 或更高版本）
+- Node.js（v20.19.0 或更高版本）
 - npm
 - Docker（可选，用于容器化部署）
 


### PR DESCRIPTION
被AI写的文档困扰了一晚水个pr没问题吧（）
经测试node-`v20.19.0`运行没问题
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/b7b8949a-e5f0-47f4-89b6-b412fbf2405c" />
node-`v20.19.0`的上一个小版本`v20.18.3`则报错`ERR_REQUIRE_ESM`
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/e94bd757-13cd-47d8-b2f1-c674861ee2b9" />

<img width="1170" height="367" alt="image" src="https://github.com/user-attachments/assets/b9dcd696-34fe-41b9-b73a-ec2c9220c8c2" />
说明这篇[Node.js中文网](https://nodejs.cn/api/errors/err_require_esm.html)变更历史是正确的，Node.js官网文档我也找过这个错误但是版本只保留了最新的