### PR TITLE
优化searchAnime和searchEpisodes函数，简化animeTitle的映射逻辑，并调整URL构建方式以提高可读性。

### DIFF
--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -2647,7 +2647,7 @@ async function searchEpisodes(url) {
   }
 
   // 先搜索动漫
-  let searchUrl = new URL(url.href.replace("/search/episodes", `/search/anime?keyword=${anime}`));
+  let searchUrl = new URL(`/search/anime?keyword=${anime}`, url.origin);
   const searchRes = await searchAnime(searchUrl);
   const searchData = await searchRes.json();
   
@@ -2666,7 +2666,7 @@ async function searchEpisodes(url) {
 
   // 遍历所有找到的动漫，获取它们的集数信息
   for (const animeItem of searchData.animes) {
-    const bangumiUrl = new URL(url.href.replace("/search/episodes", `/bangumi/${animeItem.bangumiId}`));
+    const bangumiUrl = new URL(`/bangumi/${animeItem.bangumiId}`, url.origin);
     const bangumiRes = await getBangumi(bangumiUrl.pathname);
     const bangumiData = await bangumiRes.json();
     


### PR DESCRIPTION
@huangxd-  目前 animateTitle 在识别中有用到，所以希望可以不加后缀。然后修改了上次提交错误的逻辑