### PR TITLE
增加ESM兼容层，实现简单兼容Node.js低版本

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - **部署支持**：支持本地运行、Docker 容器化、Vercel 一键部署、Cloudflare 一键部署和 Docker 一键启动。
 
 ## 前置条件
-- Node.js（v20.19.0 或更高版本）
+- Node.js（v18.0.0 或更高版本）
 - npm
 - Docker（可选，用于容器化部署）
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ danmu_api/
 │   └── workflows/
 │       └── docker-image.yml
 ├── danmu_api/
+│   ├── esm-shim.js     # Node.js低版本兼容层
 │   ├── server.js       # 本地node启动脚本
 │   ├── worker.js       # 主 API 服务器代码
 │   ├── worker.test.js  # 测试文件

--- a/danmu_api/esm-shim.js
+++ b/danmu_api/esm-shim.js
@@ -1,0 +1,218 @@
+// danmu_api/esm-shim.js
+// 智能兼容 shim - 只在需要时才启用
+// 兼容 Node.js < v20.19.0 + node-fetch v3 的情况
+
+const Module = require('module');
+const path = require('path');
+const projectRoot = path.resolve(__dirname);
+
+// 比较版本号的辅助函数
+function compareVersion(version1, version2) {
+  const v1Parts = version1.split('.').map(Number);
+  const v2Parts = version2.split('.').map(Number);
+  
+  for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+    const v1Part = v1Parts[i] || 0;
+    const v2Part = v2Parts[i] || 0;
+    
+    if (v1Part > v2Part) return 1;
+    if (v1Part < v2Part) return -1;
+  }
+  
+  return 0;
+}
+
+// 环境检测函数
+function detectEnvironment() {
+  const nodeVersion = process.versions.node;
+  const isNodeCompatible = compareVersion(nodeVersion, '20.19.0') >= 0;
+  
+  let nodeFetchVersion = '2';
+  let isNodeFetchV3 = false;
+  let needsShim = false;
+  
+  try {
+    // 尝试检测 node-fetch 版本
+    const packagePath = require.resolve('node-fetch/package.json');
+    const pkg = require(packagePath);
+    nodeFetchVersion = pkg.version;
+    isNodeFetchV3 = pkg.version.startsWith('3.');
+    
+    // 核心逻辑：只有在 Node.js < v20.19.0 且使用 node-fetch v3 时才需要 shim
+    needsShim = !isNodeCompatible && isNodeFetchV3;
+    
+  } catch (e) {
+    // node-fetch 未安装或无法检测，假设不需要 shim
+    needsShim = false;
+    nodeFetchVersion = 'not found';
+  }
+  
+  return {
+    nodeVersion,
+    nodeFetchVersion,
+    isNodeCompatible,
+    isNodeFetchV3,
+    needsShim
+  };
+}
+
+// 检测环境
+const env = detectEnvironment();
+
+console.log(`[esm-shim] Environment: Node ${env.nodeVersion}, node-fetch ${env.nodeFetchVersion}`);
+console.log(`[esm-shim] Node.js compatible (>=20.19.0): ${env.isNodeCompatible}`);
+console.log(`[esm-shim] node-fetch v3: ${env.isNodeFetchV3}`);
+console.log(`[esm-shim] Needs shim: ${env.needsShim}`);
+
+// 只在需要时才启用 shim
+if (!env.needsShim) {
+  if (env.isNodeCompatible && env.isNodeFetchV3) {
+    console.log('[esm-shim] Node.js >=20.19.0 + node-fetch v3: optimal compatibility, shim disabled');
+  } else if (env.isNodeCompatible && !env.isNodeFetchV3) {
+    console.log('[esm-shim] Node.js >=20.19.0 + node-fetch v2: native compatibility, shim disabled');
+  } else if (!env.isNodeCompatible && !env.isNodeFetchV3) {
+    console.log('[esm-shim] Node.js <20.19.0 + node-fetch v2: no ESM issues, shim disabled');
+  } else {
+    console.log('[esm-shim] Shim disabled for optimal performance');
+  }
+  
+  // 导出空的加载函数，保持接口一致性
+  global.loadNodeFetch = async () => {
+    console.log('[esm-shim] loadNodeFetch called but not needed in this environment');
+    return Promise.resolve();
+  };
+  
+  // 直接返回，不安装任何 hook
+  return;
+}
+
+console.log('[esm-shim] Compatibility shim enabled for Node.js <20.19.0 + node-fetch v3');
+
+// 以下是 shim 逻辑，只在 Node.js < v20.19.0 + node-fetch v3 时执行
+let esbuild;
+try {
+  esbuild = require('esbuild');
+} catch (err) {
+  console.error('[esm-shim] missing dependency: run `npm install esbuild`');
+  throw err;
+}
+
+// ------------------- _compile hook -------------------
+const origCompile = Module.prototype._compile;
+Module.prototype._compile = function (content, filename) {
+  try {
+    if (
+      typeof filename === 'string' &&
+      filename.startsWith(projectRoot) &&
+      !filename.includes('node_modules') &&
+      /\b(?:import|export)\b/.test(content)
+    ) {
+      console.log(`[esm-shim] Transforming ESM syntax in: ${path.relative(projectRoot, filename)}`);
+      const out = esbuild.transformSync(content, {
+        loader: 'js',
+        format: 'cjs',
+        target: 'es2018',
+        sourcemap: 'inline',
+      });
+      return origCompile.call(this, out.code, filename);
+    }
+  } catch (e) {
+    console.error('[esm-shim] esbuild transform failed:', filename, e.message || e);
+  }
+  return origCompile.call(this, content, filename);
+};
+
+// ------------------- _load hook for node-fetch v3 -------------------
+let fetchCache = null;
+let fetchPromise = null;
+
+// 异步加载 node-fetch v3
+async function loadNodeFetchV3() {
+  if (fetchCache) return fetchCache;
+  if (fetchPromise) return fetchPromise;
+  
+  fetchPromise = (async () => {
+    try {
+      console.log('[esm-shim] Loading node-fetch v3 ESM module...');
+      const fetchModule = await import('node-fetch');
+      
+      fetchCache = {
+        default: fetchModule.default,
+        fetch: fetchModule.default,
+        Request: fetchModule.Request,
+        Response: fetchModule.Response, 
+        Headers: fetchModule.Headers,
+        FormData: fetchModule.FormData,
+        AbortError: fetchModule.AbortError,
+        FetchError: fetchModule.FetchError
+      };
+      
+      console.log('[esm-shim] node-fetch v3 loaded successfully');
+      return fetchCache;
+    } catch (error) {
+      console.error('[esm-shim] Failed to load node-fetch v3:', error.message);
+      throw error;
+    }
+  })();
+  
+  return fetchPromise;
+}
+
+// 创建 node-fetch v3 兼容层
+function createFetchCompat() {
+  const syncFetch = function(...args) {
+    if (!fetchCache) {
+      throw new Error(
+        '[esm-shim] node-fetch v3 must be loaded asynchronously first. ' +
+        'Call await global.loadNodeFetch() in your startup code.'
+      );
+    }
+    return fetchCache.fetch(...args);
+  };
+
+  // 为兼容层添加所有 node-fetch v3 的属性
+  const properties = ['Request', 'Response', 'Headers', 'FormData', 'AbortError', 'FetchError'];
+  
+  properties.forEach(prop => {
+    Object.defineProperty(syncFetch, prop, {
+      get() {
+        if (!fetchCache) {
+          throw new Error(
+            `[esm-shim] node-fetch v3.${prop} must be loaded asynchronously first. ` +
+            'Call await global.loadNodeFetch() in your startup code.'
+          );
+        }
+        return fetchCache[prop];
+      },
+      enumerable: true,
+      configurable: true
+    });
+  });
+
+  // 添加 default 属性以保持兼容性
+  Object.defineProperty(syncFetch, 'default', {
+    get() { return syncFetch; },
+    enumerable: true,
+    configurable: true
+  });
+
+  return syncFetch;
+}
+
+// 拦截 node-fetch 的 require 调用
+const origLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === 'node-fetch') {
+    console.log('[esm-shim] Intercepting node-fetch require');
+    
+    // 在这个环境下，我们知道是 node-fetch v3，直接返回兼容层
+    return createFetchCompat();
+  }
+
+  return origLoad.call(this, request, parent, isMain);
+};
+
+// 导出加载函数
+global.loadNodeFetch = loadNodeFetchV3;
+
+console.log('[esm-shim] ESM compatibility shim active with hooks installed');

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -1,47 +1,136 @@
-const http = require('http');
-const fetch = require('node-fetch');  // 使用 node-fetch 替换 undici
-const { Request, Response } = fetch;
-const worker = require('./worker.js');
+// server.js - 智能启动，根据环境自动选择最优方案
+require('./esm-shim'); // 总是加载，但内部会判断是否需要启用
 
-const server = http.createServer(async (req, res) => {
-  try {
-    // Construct the full URL
-    const fullUrl = `http://${req.headers.host}${req.url}`;
+const http = require('http');
+
+// 比较版本号的辅助函数
+function compareVersion(version1, version2) {
+  const v1Parts = version1.split('.').map(Number);
+  const v2Parts = version2.split('.').map(Number);
+  
+  for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+    const v1Part = v1Parts[i] || 0;
+    const v2Part = v2Parts[i] || 0;
     
-    // Convert Node.js request body to a string for POST/PUT requests
-    let body;
-    if (req.method === 'POST' || req.method === 'PUT') {
-      body = await new Promise((resolve) => {
-        let data = '';
-        req.on('data', chunk => data += chunk);
-        req.on('end', () => resolve(data));
+    if (v1Part > v2Part) return 1;
+    if (v1Part < v2Part) return -1;
+  }
+  
+  return 0;
+}
+
+// 检测是否需要异步启动
+function needsAsyncStartup() {
+  try {
+    const nodeVersion = process.versions.node;
+    const isNodeCompatible = compareVersion(nodeVersion, '20.19.0') >= 0;
+    
+    // 尝试检测 node-fetch 版本
+    const packagePath = require.resolve('node-fetch/package.json');
+    const pkg = require(packagePath);
+    const isNodeFetchV3 = pkg.version.startsWith('3.');
+    
+    // 核心逻辑：只有在 Node.js < v20.19.0 + node-fetch v3 时才需要异步启动
+    const needsAsync = !isNodeCompatible && isNodeFetchV3;
+    
+    console.log(`[server] Environment check: Node ${nodeVersion}, node-fetch ${pkg.version}`);
+    console.log(`[server] Node.js compatible (>=20.19.0): ${isNodeCompatible}`);
+    console.log(`[server] node-fetch v3: ${isNodeFetchV3}`);
+    console.log(`[server] Needs async startup: ${needsAsync}`);
+    
+    return needsAsync;
+    
+  } catch (e) {
+    // 无法检测或者 node-fetch 不存在，使用同步启动
+    console.log('[server] Cannot detect node-fetch, using sync startup');
+    return false;
+  }
+}
+
+// 核心服务器逻辑（抽取为函数，避免重复）
+function createServer() {
+  const fetch = require('node-fetch');
+  const { Request, Response } = fetch;
+  const worker = require('./worker.js');
+
+  return http.createServer(async (req, res) => {
+    try {
+      // Construct the full URL
+      const fullUrl = `http://${req.headers.host}${req.url}`;
+      
+      // Convert Node.js request body to a string for POST/PUT requests
+      let body;
+      if (req.method === 'POST' || req.method === 'PUT') {
+        body = await new Promise((resolve) => {
+          let data = '';
+          req.on('data', chunk => data += chunk);
+          req.on('end', () => resolve(data));
+        });
+      }
+
+      // Create a Web API-compatible Request object
+      const webRequest = new Request(fullUrl, {
+        method: req.method,
+        headers: req.headers,
+        body: body || undefined,
       });
+
+      // Call the worker's fetch handler
+      const webResponse = await worker.default.fetch(webRequest, {}, {});
+
+      // Convert Web API Response to Node.js response
+      res.statusCode = webResponse.status;
+      webResponse.headers.forEach((value, key) => {
+        res.setHeader(key, value);
+      });
+      const responseText = await webResponse.text();
+      res。end(responseText);
+    } catch (error) {
+      console。error('Server error:'， error);
+      res。statusCode = 500;
+      res.end('Internal Server Error');
+    }
+  });
+}
+
+// 同步启动（适用于兼容环境）
+function startServerSync() {
+  console。log('[server] Starting server synchronously (optimal path)');
+  
+  const server = createServer();
+  
+  server.listen(9321, '0.0.0.0'， () => {
+    console.log('Server running on http://0.0.0.0:9321');
+  });
+}
+
+// 异步启动（适用于需要兼容的环境：Node.js < v20.19.0 + node-fetch v3）
+async function startServerAsync() {
+  try {
+    console。log('[server] Starting server asynchronously (compatibility mode for Node.js <20.19.0 + node-fetch v3)');
+    
+    // 预加载 node-fetch v3
+    if (typeof global.loadNodeFetch === 'function') {
+      console.log('[server] Pre-loading node-fetch v3...');
+      await global。loadNodeFetch();
+      console.log('[server] node-fetch v3 loaded successfully');
     }
 
-    // Create a Web API-compatible Request object
-    const webRequest = new Request(fullUrl, {
-      method: req.method,
-      headers: req.headers,
-      body: body || undefined,
+    const server = createServer();
+    
+    server.listen(9321， '0.0.0.0'， () => {
+      console。log('Server running on http://0.0.0.0:9321 (compatibility mode)');
     });
 
-    // Call the worker's fetch handler
-    const webResponse = await worker.default.fetch(webRequest, {}, {});
-
-    // Convert Web API Response to Node.js response
-    res.statusCode = webResponse.status;
-    webResponse.headers.forEach((value, key) => {
-      res.setHeader(key, value);
-    });
-    const responseText = await webResponse.text();
-    res.end(responseText);
   } catch (error) {
-    console.error('Server error:', error);
-    res.statusCode = 500;
-    res.end('Internal Server Error');
+    console.error('[server] Failed to start server:', error);
+    process.exit(1);
   }
-});
+}
 
-server.listen(9321, '0.0.0.0', () => {
-  console.log('Server running on http://0.0.0.0:9321');
-});
+// 智能选择启动方式
+if (needsAsyncStartup()) {
+  startServerAsync();
+} else {
+  startServerSync();
+}

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -84,10 +84,10 @@ function createServer() {
         res.setHeader(key, value);
       });
       const responseText = await webResponse.text();
-      res。end(responseText);
+      res.end(responseText);
     } catch (error) {
-      console。error('Server error:'， error);
-      res。statusCode = 500;
+      console.error('Server error:', error);
+      res.statusCode = 500;
       res.end('Internal Server Error');
     }
   });
@@ -95,11 +95,11 @@ function createServer() {
 
 // 同步启动（适用于兼容环境）
 function startServerSync() {
-  console。log('[server] Starting server synchronously (optimal path)');
+  console.log('[server] Starting server synchronously (optimal path)');
   
   const server = createServer();
   
-  server.listen(9321, '0.0.0.0'， () => {
+  server.listen(9321, '0.0.0.0', () => {
     console.log('Server running on http://0.0.0.0:9321');
   });
 }
@@ -107,19 +107,19 @@ function startServerSync() {
 // 异步启动（适用于需要兼容的环境：Node.js < v20.19.0 + node-fetch v3）
 async function startServerAsync() {
   try {
-    console。log('[server] Starting server asynchronously (compatibility mode for Node.js <20.19.0 + node-fetch v3)');
+    console.log('[server] Starting server asynchronously (compatibility mode for Node.js <20.19.0 + node-fetch v3)');
     
     // 预加载 node-fetch v3
     if (typeof global.loadNodeFetch === 'function') {
       console.log('[server] Pre-loading node-fetch v3...');
-      await global。loadNodeFetch();
+      await global.loadNodeFetch();
       console.log('[server] node-fetch v3 loaded successfully');
     }
 
     const server = createServer();
     
-    server.listen(9321， '0.0.0.0'， () => {
-      console。log('Server running on http://0.0.0.0:9321 (compatibility mode)');
+    server.listen(9321, '0.0.0.0', () => {
+      console.log('Server running on http://0.0.0.0:9321 (compatibility mode)');
     });
 
   } catch (error) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "esbuild": "^0.25.10",
     "node-fetch": "^3.3.2"
   }
 }


### PR DESCRIPTION
Closes #3 
用claude ai尝试兼容了下Node.js低版本，
方案是新增了一个`esm-shim.js`作为兼容层，如果判断Node.js版本低于v20.19.0就会启用兼容层转换ESM语法，如果高于就不会启用兼容层走以前的方式，这一方案理论上不影响所有原有代码，也不影响未来代码语法，因为兼容层会智能转换所有需要的。
这一方案兼容的Node.js最低版本回到了v18，因为转换用的esbuild依赖版本需要Node.js > v18，理论上降低esbuild版本就能兼容更低版本但懒得测了（）我测了Node.js v18和Node.js v20.19.0以上都是没问题的。
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/50df4130-b44a-4836-be0d-74b49499b2de" />
<img width="1223" height="638" alt="image" src="https://github.com/user-attachments/assets/aa74b640-1a29-4bb0-86a3-af550572658a" />


因为要判断版本智能开关兼容层所以还改了启动脚本，所以可能需要严谨的测试相关部署方式？我也不懂有没有影响我测了Vercel是没问题的，理论上应该没影响，然后ai写的代码也肯定不优雅可能需要严谨审查，如果这一方案不妥就不合并了。