### PR TITLE
智能处理API路径，强兼小幻（划掉）

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,11 @@ Settings > Functions > Advanced Setting > Function Region 切换为 Hong Kong，
 <img src="https://i.mji.rip/2025/09/14/9fdf945fb247994518042691f60d7849.jpeg" style="width:400px" />
 <img src="https://i.mji.rip/2025/09/14/dbacc0cf9c8a839f16b8960de1f38f11.jpeg" style="width:400px" />
 
-> 注意：小幻在填写API的时候需要在API后面加上`/api/v2`，如`http://192.168.1.7:9321/87654321/api/v2`
+> 注意：
+>
+> ~~小幻在填写API的时候需要在API后面加上`/api/v2`，如`http://192.168.1.7:9321/87654321/api/v2`~~
+> 
+> （已对小幻做兼容，`/api/v2`可加可不加都可以正确处理）
 > 
 > 有很多人问FW能不能用，FW推荐直接使用插件，如果非要使用，则可以配合 `https://raw.githubusercontent.com/huangxd-/ForwardWidgets/refs/heads/main/widgets.fwd` 里的`danmu_api`插件使用
 

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -3400,6 +3400,39 @@ async function handleRequest(req, env) {
 
   log("log", path);
 
+  // 智能处理API路径前缀，确保最终有一个正确的 /api/v2
+  log('log', `[Path Check] Starting path normalization for: "${path}"`);
+  const pathBeforeCleanup = path; // 保存清理前的路径检查是否修改
+  
+  // 1. 清理：应对“用户填写/api/v2”+“客户端添加/api/v2”导致的重复前缀
+  while (path.startsWith('/api/v2/api/v2/')) {
+      log('log', `[Path Cleanup] Found redundant /api/v2 prefix. Cleaning...`);
+      // 从第二个 /api/v2 的位置开始截取，相当于移除第一个
+      path = path.substring('/api/v2'.length);
+  }
+  
+  // 打印日志：只有在发生清理时才显示清理后的路径，否则显示“无需清理”
+  if (path !== pathBeforeCleanup) {
+      log('log', `[Path Check] Path after cleanup: "${path}"`);
+  } else {
+      log('log', `[Path Check] Path after cleanup: No cleanup needed.`);
+  }
+  
+  // 2. 补全：如果路径缺少前缀（例如请求原始路径为 /search/anime），则补全
+  const pathBeforePrefixCheck = path;
+  
+  if (!path.startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
+      log('log', `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
+      path = '/api/v2' + path;
+  }
+    
+  // 打印日志：只有在发生添加前缀时才显示添加后的路径，否则显示“无需补全”
+  if (path === pathBeforePrefixCheck) {
+      log('log', `[Path Check] Prefix Check: No prefix addition needed.`);
+  }
+  
+  log('log', `[Path Check] Final normalized path: "${path}"`);
+  
   // GET /
   if (path === "/" && method === "GET") {
     return handleHomepage();

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -3406,7 +3406,7 @@ async function handleRequest(req, env) {
       const pathBeforeCleanup = path; // 保存清理前的路径检查是否修改
       
       // 1. 清理：应对“用户填写/api/v2”+“客户端添加/api/v2”导致的重复前缀
-      while (path。startsWith('/api/v2/api/v2/')) {
+      while (path.startsWith('/api/v2/api/v2/')) {
           log('log', `[Path Check] Found redundant /api/v2 prefix. Cleaning...`);
           // 从第二个 /api/v2 的位置开始截取，相当于移除第一个
           path = path.substring('/api/v2'.length);
@@ -3421,7 +3421,7 @@ async function handleRequest(req, env) {
       
       // 2. 补全：如果路径缺少前缀（例如请求原始路径为 /search/anime），则补全
       const pathBeforePrefixCheck = path;
-      if (!path。startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
+      if (!path.startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
           log('log', `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
           path = '/api/v2' + path;
       }

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -3422,7 +3422,7 @@ async function handleRequest(req, env) {
       // 2. 补全：如果路径缺少前缀（例如请求原始路径为 /search/anime），则补全
       const pathBeforePrefixCheck = path;
       if (!path.startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
-          log('log', `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
+          log('log', `[Path Check] Path is missing /api/v2 prefix. Adding...`);
           path = '/api/v2' + path;
       }
         

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -3401,37 +3401,38 @@ async function handleRequest(req, env) {
   log("log", path);
 
   // 智能处理API路径前缀，确保最终有一个正确的 /api/v2
-  log('log', `[Path Check] Starting path normalization for: "${path}"`);
-  const pathBeforeCleanup = path; // 保存清理前的路径检查是否修改
-  
-  // 1. 清理：应对“用户填写/api/v2”+“客户端添加/api/v2”导致的重复前缀
-  while (path.startsWith('/api/v2/api/v2/')) {
-      log('log', `[Path Cleanup] Found redundant /api/v2 prefix. Cleaning...`);
-      // 从第二个 /api/v2 的位置开始截取，相当于移除第一个
-      path = path.substring('/api/v2'.length);
+  if (path !== "/" && path !== "/api/logs") {
+      log('log'， `[Path Check] Starting path normalization for: "${path}"`);
+      const pathBeforeCleanup = path; // 保存清理前的路径检查是否修改
+      
+      // 1. 清理：应对“用户填写/api/v2”+“客户端添加/api/v2”导致的重复前缀
+      while (path。startsWith('/api/v2/api/v2/')) {
+          log('log', `[Path Check] Found redundant /api/v2 prefix. Cleaning...`);
+          // 从第二个 /api/v2 的位置开始截取，相当于移除第一个
+          path = path.substring('/api/v2'.length);
+      }
+      
+      // 打印日志：只有在发生清理时才显示清理后的路径，否则显示“无需清理”
+      if (path !== pathBeforeCleanup) {
+          log('log'， `[Path Check] Path after cleanup: "${path}"`);
+      } else {
+          log('log', `[Path Check] Path after cleanup: No cleanup needed.`);
+      }
+      
+      // 2. 补全：如果路径缺少前缀（例如请求原始路径为 /search/anime），则补全
+      const pathBeforePrefixCheck = path;
+      if (!path。startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
+          log('log'， `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
+          path = '/api/v2' + path;
+      }
+        
+      // 打印日志：只有在发生添加前缀时才显示添加后的路径，否则显示“无需补全”
+      if (path === pathBeforePrefixCheck) {
+          log('log', `[Path Check] Prefix Check: No prefix addition needed.`);
+      }
+      
+      log('log', `[Path Check] Final normalized path: "${path}"`);
   }
-  
-  // 打印日志：只有在发生清理时才显示清理后的路径，否则显示“无需清理”
-  if (path !== pathBeforeCleanup) {
-      log('log', `[Path Check] Path after cleanup: "${path}"`);
-  } else {
-      log('log', `[Path Check] Path after cleanup: No cleanup needed.`);
-  }
-  
-  // 2. 补全：如果路径缺少前缀（例如请求原始路径为 /search/anime），则补全
-  const pathBeforePrefixCheck = path;
-  
-  if (!path.startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
-      log('log', `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
-      path = '/api/v2' + path;
-  }
-    
-  // 打印日志：只有在发生添加前缀时才显示添加后的路径，否则显示“无需补全”
-  if (path === pathBeforePrefixCheck) {
-      log('log', `[Path Check] Prefix Check: No prefix addition needed.`);
-  }
-  
-  log('log', `[Path Check] Final normalized path: "${path}"`);
   
   // GET /
   if (path === "/" && method === "GET") {

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -3402,7 +3402,7 @@ async function handleRequest(req, env) {
 
   // 智能处理API路径前缀，确保最终有一个正确的 /api/v2
   if (path !== "/" && path !== "/api/logs") {
-      log('log'， `[Path Check] Starting path normalization for: "${path}"`);
+      log('log', `[Path Check] Starting path normalization for: "${path}"`);
       const pathBeforeCleanup = path; // 保存清理前的路径检查是否修改
       
       // 1. 清理：应对“用户填写/api/v2”+“客户端添加/api/v2”导致的重复前缀
@@ -3414,7 +3414,7 @@ async function handleRequest(req, env) {
       
       // 打印日志：只有在发生清理时才显示清理后的路径，否则显示“无需清理”
       if (path !== pathBeforeCleanup) {
-          log('log'， `[Path Check] Path after cleanup: "${path}"`);
+          log('log', `[Path Check] Path after cleanup: "${path}"`);
       } else {
           log('log', `[Path Check] Path after cleanup: No cleanup needed.`);
       }
@@ -3422,7 +3422,7 @@ async function handleRequest(req, env) {
       // 2. 补全：如果路径缺少前缀（例如请求原始路径为 /search/anime），则补全
       const pathBeforePrefixCheck = path;
       if (!path。startsWith('/api/v2') && path !== '/' && !path.startsWith('/api/logs')) {
-          log('log'， `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
+          log('log', `[Path Prefix] Path is missing /api/v2 prefix. Adding...`);
           path = '/api/v2' + path;
       }
         


### PR DESCRIPTION
介于小幻的API使用老生常谈的问题了所以尝试用AI狠狠的做了兼容（）还挺好实现的测试没啥问题然后还针对了极端情况，
常规是缺失会自动加上/api/v2，极端情况是用户多填客户端自动加/api/v2造成有两个/api/v2这种情况也会自动去除其中一个，确保最终都是正确的API请求，小幻目前加了后缀的用户也不用改因为这种情况下是正确API会绕过不处理。