### PR TITLE
修复小幻不能使用默认token不填写

### DIFF
--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -70,7 +70,7 @@ async function handleRequest(req, env, deployPlatform, clientIp) {
   // 如果 token 是默认值 87654321
   if (globals.token === "87654321") {
     // 检查第一段是否是已知的 API 路径（不是 token）
-    const knownApiPaths = ["api", "v1", "v2"];
+    const knownApiPaths = ["api", "v1", "v2", "search", "match", "bangumi", "comment"];
 
     if (parts.length > 0) {
       // 如果第一段是正确的默认 token


### PR DESCRIPTION
RT
因为智能处理路径前不填/api/v2小幻实际请求不包含api或v2