### PR TITLE
server.js 增加 GZIP 响应压缩，优化大型弹幕包传输性能

### DIFF
--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -352,11 +352,7 @@ function createServer() {
         }
       }
       // 发送最终数据
-      res.end(buffer);
-
-
-
-      
+      res.end(buffer);      
     } catch (error) {
       console.error('Server error:', error);
       res.statusCode = 500;


### PR DESCRIPTION
您好！我在适配移动端/盒子端播放器时发现，针对长剧集生成的大型弹幕 XML（通常 3MB-5MB），由于目前
server.js
是以纯文本形式“裸传”给设备的，导致在宽带环境不佳时下载非常缓慢（耗时几秒甚至更长）。

技术观察： 目前
server.js
的响应处理逻辑是：

javascript
// 发送响应体
const responseText = await webResponse.text();
res.end(responseText);
既然 API 从官源获取数据时已经利用了 GZIP（如 iQiyi 源），建议在分发给设备时也根据客户端的 Accept-Encoding: gzip 请求头，引入 Node 原生 zlib 模块进行响应压缩。

预期收益：

性能提升：3.4MB 的 XML 经过 GZIP 压缩后仅约 400KB，传输效率提升 8-10 倍。
零侵入性：遵循标准 HTTP 协商，不发送 gzip 头的旧客户端依然接收原始文本，不会产生兼容性问题。
不知道作者是否考虑针对这个点做一个性能优化？