### PR TITLE
修改hanjutv点赞显示，先去重再拼接点赞标记

### DIFF
--- a/danmu_api/configs/globals.js
+++ b/danmu_api/configs/globals.js
@@ -13,7 +13,7 @@ export const Globals = {
   accessedEnvVars: {},
 
   // 静态常量
-  VERSION: '1.15.0',
+  VERSION: '1.15.1',
   MAX_LOGS: 1000, // 日志存储，最多保存 1000 行
   MAX_ANIMES: 100,
   MAX_RECORDS: 100, // 请求记录最大数量

--- a/danmu_api/sources/hanjutv.js
+++ b/danmu_api/sources/hanjutv.js
@@ -253,8 +253,9 @@ export default class HanjutvSource extends BaseSource {
     return comments.map(c => ({
       cid: Number(c.did),
       p: `${(c.t / 1000).toFixed(2)},${c.tp === 2 ? 5 : c.tp},${Number(c.sc)},[hanjutv]`,
-      m: c.lc ? `${c.con} 👍${c.lc}` : c.con,
-      t: Math.round(c.t / 1000)
+      m: c.con,
+      t: Math.round(c.t / 1000),
+      like: c.lc
     }));
   }
 }


### PR DESCRIPTION
点赞数缩写显示(1200 -> 1.2k)，例如 ❤️ 2.9k。增加“超高赞高亮样式”规则（hanjutv 中 >=100 用 🔥，普通点赞仍用 ❤️），≥5 才显示，避免低赞干扰

close #189 