### PR TITLE
修复hanjutv分页游标不前进导致的循环卡住

### DIFF
--- a/danmu_api/sources/hanjutv.js
+++ b/danmu_api/sources/hanjutv.js
@@ -468,6 +468,9 @@ export default class HanjutvSource extends BaseSource {
         if (nextAxis >= maxAxis) {
           break; // 如果 nextAxis 达到或超过最大值，退出循环
         }
+        if (nextAxis <= fromAxis) {
+          break; // 如果 nextAxis 未前进，退出循环，避免卡死
+        }
         fromAxis = nextAxis;
       }
 


### PR DESCRIPTION
变更内容：在 getEpisodeDanmu 分页循环中增加 nextAxis <= fromAxis 时的退出条件，防止异常游标导致请求无限循环。