### PR TITLE
优化韩剧TV s5 搜索容错策略

### DIFF
--- a/danmu_api/sources/hanjutv.js
+++ b/danmu_api/sources/hanjutv.js
@@ -21,6 +21,7 @@ export default class HanjutvSource extends BaseSource {
     this.defaultRefer = "2JGztvGjRVpkxcr0T4ZWG2k+tOlnHmDGUNMwAGSeq548YV2FMbs0h0bXNi6DJ00L";
     this.webUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36";
     this.appUserAgent = "HanjuTV/6.8 (23127PN0CC; Android 16; Scale/2.00)";
+    this.s5StableUid = createHanjutvUid();
   }
 
   getWebHeaders() {
@@ -158,37 +159,56 @@ export default class HanjutvSource extends BaseSource {
   }
 
   async searchWithS5Api(keyword) {
-    const uid = createHanjutvUid();
-    const headers = await createHanjutvSearchHeaders(uid);
     const q = encodeURIComponent(keyword);
 
-    const resp = await httpGet(`https://hxqapi.hiyun.tv/api/search/s5?k=${q}&srefer=search_input&type=0&page=1`, {
-      headers,
-      timeout: 10000,
-      retries: 1,
-    });
+    const requestWithUid = async (uid) => {
+      const headers = await createHanjutvSearchHeaders(uid);
+      const resp = await httpGet(`https://hxqapi.hiyun.tv/api/search/s5?k=${q}&srefer=search_input&type=0&page=1`, {
+        headers,
+        timeout: 10000,
+        retries: 1,
+      });
 
-    const payload = resp?.data;
-    if (!payload || typeof payload !== "object") {
-      throw new Error("s5 响应为空");
-    }
-
-    if (typeof payload.data === "string" && payload.data.length > 0) {
-      let decoded;
-      try {
-        decoded = await decodeHanjutvEncryptedPayload(payload, uid);
-      } catch (error) {
-        throw new Error(`s5 响应解密失败: ${error.message}`);
+      const payload = resp?.data;
+      if (!payload || typeof payload !== "object") {
+        throw new Error("s5 响应为空");
       }
 
-      const items = this.extractSearchItems(decoded);
-      if (items.length === 0) throw new Error("s5 解密后无有效结果");
+      if (typeof payload.data === "string" && payload.data.length > 0) {
+        let decoded;
+        try {
+          decoded = await decodeHanjutvEncryptedPayload(payload, uid);
+        } catch (error) {
+          throw new Error(`s5 响应解密失败: ${error.message}`);
+        }
+
+        const items = this.extractSearchItems(decoded);
+        if (items.length === 0) throw new Error("s5 解密后无有效结果");
+        return items;
+      }
+
+      const plainItems = this.extractSearchItems(payload);
+      if (plainItems.length === 0) throw new Error("s5 无有效结果");
+      return plainItems;
+    };
+
+    const currentUid = this.s5StableUid || createHanjutvUid();
+
+    try {
+      const items = await requestWithUid(currentUid);
+      this.s5StableUid = currentUid;
+      return items;
+    } catch (error) {
+      const message = String(error?.message || "");
+      const shouldRotateUid = message.startsWith("s5 响应解密失败:") || message === "s5 解密后无有效结果";
+      if (!shouldRotateUid) throw error;
+
+      const rotatedUid = createHanjutvUid();
+      log("debug", `[Hanjutv] s5 命中可轮换错误，切换 uid 重试一次: ${message}`);
+      const items = await requestWithUid(rotatedUid);
+      this.s5StableUid = rotatedUid;
       return items;
     }
-
-    const plainItems = this.extractSearchItems(payload);
-    if (plainItems.length === 0) throw new Error("s5 无有效结果");
-    return plainItems;
   }
 
   async searchWithLegacyApi(keyword) {


### PR DESCRIPTION
## 变更背景
韩剧TV `s5` 搜索接密因随机UID会出现随机波动：偶发出现“解密失败”或“解密后无有效结果”，导致搜索结果为空并触发降级。

本 PR 目标：
- 在不增加用户配置项的前提下提升稳定性。
- 仅对“确实与 UID 桶有关”的两类错误做 UID 轮换，避免无意义重试影响速度。
- 只针对因随机 UID 导致的偶发性解密失败的情况，无法解决vercel等国外平台s5接口受限制的情况

## 改动内容
- 新增进程内稳定 UID：`s5StableUid`（无外部存储依赖）。
- `searchWithS5Api` 增加单次受控重试：
  - 仅当错误为：
    - `s5 响应解密失败:*`
    - `s5 解密后无有效结果`
  - 才轮换一次 UID 并重试 1 次。
- 其他错误维持原逻辑（不轮换 UID，不额外放大请求）。
- 未新增任何 `.env` 配置项。

## 改动前后对比
测试环境：同一机器、同一代码库、同口径脚本。

### 1) 高频重复同关键词（`searchWithS5Api("来自星星的你")`）
- 改动前：50 轮，成功 20，失败 30（全部为 `s5 解密后无有效结果`）
- 改动后：50 轮，成功 50，失败 0

### 2) 模拟日常 20 个关键词单轮搜索（`search`）
- 改动前：20 个关键词，非空 17，空结果 3
- 改动后：20 个关键词，非空 18，空结果 2

说明：单轮 20 词会受上游波动影响；核心改善体现在高频重复场景的失败率明显下降。

## 兼容性与性能
- 无持久化依赖：仅进程内变量，适配 Vercel/Serverless。
- 重试边界清晰：最多额外 1 次请求，仅在两类解密相关错误触发。
- 其余流程与降级链路保持不变。
