### PR TITLE
修复 match 接口因为标题清理导致故障

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -187,14 +187,15 @@ function matchYear(anime, queryYear) {
 }
 
 export function matchSeason(anime, queryTitle, season) {
-  const normalizedAnimeTitle = normalizeSpaces(anime.animeTitle);
+  // 先从原始带括号的标题中分离出名称主体再对主体进行净化剥离非法字符
+  const match = anime.animeTitle.match(/^(.*?)\(\d{4}\)/);
+  const originalTitle = match ? match[1].trim() : anime.animeTitle.split("(")[0].trim();
+  const normalizedAnimeTitle = normalizeSpaces(originalTitle);
   const normalizedQueryTitle = normalizeSpaces(queryTitle);
 
   if (normalizedAnimeTitle.includes(normalizedQueryTitle)) {
-    const match = normalizedAnimeTitle.match(/^(.*?)\(\d{4}\)/);
-    const title = match ? match[1].trim() : normalizedAnimeTitle.split("(")[0].trim();
-    if (title.startsWith(normalizedQueryTitle)) {
-      const afterTitle = title.substring(normalizedQueryTitle.length).trim();
+    if (normalizedAnimeTitle.startsWith(normalizedQueryTitle)) {
+      const afterTitle = normalizedAnimeTitle.substring(normalizedQueryTitle.length).trim();
       if (afterTitle === '' && season === 1) {
         return true;
       }

--- a/danmu_api/configs/globals.js
+++ b/danmu_api/configs/globals.js
@@ -13,7 +13,7 @@ export const Globals = {
   accessedEnvVars: {},
 
   // 静态常量
-  VERSION: '1.18.6',
+  VERSION: '1.18.7',
   MAX_LOGS: 1000, // 日志存储，最多保存 1000 行
   MAX_RECORDS: 100, // 请求记录最大数量
 

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -320,10 +320,10 @@ export function validateType(value, expectedType) {
 // 从 animeTitle 中提取季数和纯剧名
 export function extractSeasonNumberFromAnimeTitle(animeTitle) {
   if (!animeTitle) return { season: null, baseTitle: null };
-
-  const normalizedAnimeTitle = normalizeSpaces(animeTitle);
-  const match = normalizedAnimeTitle.match(/^(.*?)\(\d{4}\)/);
-  const titleWithoutYear = match ? match[1].trim() : normalizedAnimeTitle.split("(")[0].trim();
+// 先在原始标题上做拆分切除年份后缀，再去除非法字符
+  const match = animeTitle.match(/^(.*?)\(\d{4}\)/);
+  const rawTitleWithoutYear = match ? match[1].trim() : animeTitle.split("(")[0].trim();
+  const titleWithoutYear = normalizeSpaces(rawTitleWithoutYear);
 
   // 1) 明确季数标识：第X季/期/部
   const explicitSeasonMatch = titleWithoutYear.match(/第\s*([0-9一二三四五六七八九十壹贰叁肆伍陆柒捌玖拾]+)\s*[季期部]/);
@@ -376,25 +376,25 @@ export function extractSeasonNumberFromAnimeTitle(animeTitle) {
 // 从集标题中提取集数（支持多种格式：第1集、第01集、EP01、E01等）
 export function extractEpisodeNumberFromTitle(episodeTitle) {
   if (!episodeTitle) return null;
-  
+
   // 匹配格式：第1集、第01集、第10集等
   const chineseMatch = episodeTitle.match(/第(\d+)集/);
   if (chineseMatch) {
     return parseInt(chineseMatch[1], 10);
   }
-  
+
   // 匹配格式：EP01、EP1、E01、E1等
   const epMatch = episodeTitle.match(/[Ee][Pp]?(\d+)/);
   if (epMatch) {
     return parseInt(epMatch[1], 10);
   }
-  
+
   // 匹配格式：01、1（纯数字，通常在标题开头或结尾）
   const numberMatch = episodeTitle.match(/(?:^|\s)(\d+)(?:\s|$)/);
   if (numberMatch) {
     return parseInt(numberMatch[1], 10);
   }
-  
+
   return null;
 }
 
@@ -402,6 +402,6 @@ export function extractEpisodeNumberFromTitle(episodeTitle) {
 export function extractAnimeInfo(animeTitle, episodeTitle) {
   let {season, baseTitle} = extractSeasonNumberFromAnimeTitle(animeTitle);
   let episode = extractEpisodeNumberFromTitle(episodeTitle);
-  
+
   return { baseTitle, season, episode };
 }

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -320,7 +320,7 @@ export function validateType(value, expectedType) {
 // 从 animeTitle 中提取季数和纯剧名
 export function extractSeasonNumberFromAnimeTitle(animeTitle) {
   if (!animeTitle) return { season: null, baseTitle: null };
-// 先在原始标题上做拆分切除年份后缀，再去除非法字符
+  // 先在原始标题上做拆分切除年份后缀，再去除非法字符
   const match = animeTitle.match(/^(.*?)\(\d{4}\)/);
   const rawTitleWithoutYear = match ? match[1].trim() : animeTitle.split("(")[0].trim();
   const titleWithoutYear = normalizeSpaces(rawTitleWithoutYear);


### PR DESCRIPTION
新的标题清理函数会清理掉代表年份的括号，导致相关函数无法分离年份，调整了相关函数执行顺序修复