### PR TITLE
健壮 Bangumi Data 匹配与合并工具，修复相关问题

### DIFF
--- a/danmu_api/sources/animeko.js
+++ b/danmu_api/sources/animeko.js
@@ -52,7 +52,7 @@ export default class AnimekoSource extends BaseSource {
             date: m.begin,
             score: 0,
             platform: m.typeStr, 
-            aliases: m.titles
+            aliases: [...m.titles]
           };
         }));
       }
@@ -284,12 +284,12 @@ export default class AnimekoSource extends BaseSource {
       const titleSuffix = item._relation_mark ? ` ${item._relation_mark}` : "";
 
       // 提取别名列表 (用于合并工具进行模糊匹配)
-      const aliases = [];
+      const aliases = Array.isArray(item.aliases) ? [...item.aliases] : [];
       if (item.infobox && Array.isArray(item.infobox)) {
           item.infobox.forEach(info => {
               if (info.key === '别名' && Array.isArray(info.value)) {
                   info.value.forEach(v => {
-                      if (v && v.v) aliases.push(v.v);
+                      if (v && v.v && !aliases.includes(v.v)) aliases.push(v.v);
                   });
               }
           });

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -166,6 +166,7 @@ export default class BahamutSource extends BaseSource {
           );
 
           if (matchedLocal) {
+              const originalBahamutTitle = item.title;
               const displayTitle = matchedLocal.titles.find(t => t && t.includes(keyword)) || matchedLocal.titles[1] || matchedLocal.title;
               const finalTitle = displayTitle + (matchedLocal.titleSuffix || '');
 
@@ -173,6 +174,12 @@ export default class BahamutSource extends BaseSource {
               item.title = finalTitle;
               item._displayTitle = finalTitle;
               item.aliases = [...matchedLocal.titles];
+              
+              // 将原始网络标题加入别名池，防止后续匹配时丢失源站的精确特征
+              if (originalBahamutTitle && !item.aliases.includes(originalBahamutTitle)) {
+                  item.aliases.push(originalBahamutTitle);
+              }
+              
               item._typeStr = matchedLocal.typeStr; 
 
               log("info", `[Bahamut] 网络结果 [${item.title}] 成功对齐本地 Bangumi-Data 数据`);
@@ -313,7 +320,9 @@ export default class BahamutSource extends BaseSource {
         return true;
       }
 
-      return bahamutTitleMatches(itemTitle, queryTitle, usedSearchTitle);
+      // 优先匹配主标题，若失败则继续在别名池中进行匹配兜底
+      return bahamutTitleMatches(itemTitle, queryTitle, usedSearchTitle) || 
+             (Array.isArray(item.aliases) && item.aliases.some(alias => bahamutTitleMatches(alias, queryTitle, usedSearchTitle)));
     });
 
     // 记录替换前的原始标题，作为别名传递给合并工具进行比对

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -174,12 +174,12 @@ export default class BahamutSource extends BaseSource {
               item.title = finalTitle;
               item._displayTitle = finalTitle;
               item.aliases = [...matchedLocal.titles];
-              
+
               // 将原始网络标题加入别名池，防止后续匹配时丢失源站的精确特征
               if (originalBahamutTitle && !item.aliases.includes(originalBahamutTitle)) {
                   item.aliases.push(originalBahamutTitle);
               }
-              
+
               item._typeStr = matchedLocal.typeStr; 
 
               log("info", `[Bahamut] 网络结果 [${item.title}] 成功对齐本地 Bangumi-Data 数据`);

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -47,6 +47,7 @@ export default class BahamutSource extends BaseSource {
               "Content-Type": "application/json",
               "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
             },
+			retries: 1,
           });
 
           // 如果原始搜索有结果，中断 TMDB 流程
@@ -110,7 +111,8 @@ export default class BahamutSource extends BaseSource {
               "Content-Type": "application/json",
               "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
             },
-            signal: tmdbAbortController.signal
+            signal: tmdbAbortController.signal,
+            retries: 1,
           });
 
           if (tmdbResp && tmdbResp.data && tmdbResp.data.anime && tmdbResp.data.anime.length > 0) {
@@ -209,6 +211,7 @@ export default class BahamutSource extends BaseSource {
           "Content-Type": "application/json",
           "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
         },
+		retries: 1,
       });
 
       // 判断 resp 和 resp.data 是否存在

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -71,6 +71,7 @@ export default class DandanSource extends BaseSource {
               "Content-Type": "application/json",
               "User-Agent": DandanUserAgent,
             },
+			retries: 1,
           });
 
           // 判断 resp 和 resp.data 是否存在
@@ -127,6 +128,7 @@ export default class DandanSource extends BaseSource {
               "User-Agent": DandanUserAgent,
             },
             signal: tmdbAbortController.signal,
+			retries: 1,
           });
 
           // 判断 resp 和 resp.data 是否存在

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -51,7 +51,8 @@ export default class DandanSource extends BaseSource {
             typeDescription: m.typeStr, 
             imageUrl: "", 
             startDate: m.begin,
-            rating: 0
+            rating: 0,
+			aliases: [...m.titles]
           };
         });
       }
@@ -352,7 +353,11 @@ export default class DandanSource extends BaseSource {
           }
 
           // 区分初始搜索结果与动态相关作品的结果过滤逻辑
-          const allTitles = [anime.animeTitle, ...apiAliases];
+          const allTitles = [
+            anime.animeTitle, 
+            ...apiAliases, 
+            ...(anime.aliases || [])
+          ];
           let isMatch = false;
 
           if (anime.isRelated || anime.isTmdbSource) {
@@ -402,7 +407,7 @@ export default class DandanSource extends BaseSource {
             const displayTitle = anime._displayTitle || anime.animeTitle;
 
             // 合并别名池：API返回的别名 + 原始标题（供合并工具对齐使用）
-            const finalAliases = [...apiAliases];
+            const finalAliases = [...new Set([...apiAliases, ...(anime.aliases || [])])];
             if (anime.animeTitle && anime.animeTitle !== displayTitle && !finalAliases.includes(anime.animeTitle)) {
               finalAliases.push(anime.animeTitle);
             }

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -5,6 +5,7 @@ import fetch from 'node-fetch';
 import { globals } from '../configs/globals.js';
 import { log } from './log-util.js';
 import { titleMatches } from './common-util.js';
+import { simplized, traditionalized } from './zh-util.js';
 
 // =====================
 // Bangumi Data 管理工具（https://github.com/bangumi-data/bangumi-data）
@@ -261,6 +262,14 @@ export function searchBangumiData(keyword, siteKeys) {
 
     const validDubRegex = /(?:普通[话話]|[国國][语語]|中文配音|中配|中文|[粤粵][语語]配音|[粤粵]配|[粤粵][语語]|[台臺]配|[台臺][语語]|港配|港[语語]|字幕|助[听聽]|日[语語]|日配|原版|原[声聲])(?:版)?/;
     const results = [];
+
+    // 简繁转换搜索关键词
+    let searchTerms = [keyword];
+    try {
+        searchTerms = [...new Set([keyword, simplized(keyword), traditionalized(keyword)])];
+    } catch (e) {
+    }
+
     for (const item of memoryCache.items) {
         // 构建完整的搜索标题池
         const titles = [item.title];
@@ -270,7 +279,7 @@ export function searchBangumiData(keyword, siteKeys) {
             }
         }
 
-        const isMatch = titles.some(t => t && titleMatches(t, keyword));
+        const isMatch = titles.some(t => t && searchTerms.some(kw => titleMatches(t, kw)));
 
         if (isMatch && item.sites) {
             // 捕获所有符合条件的站点记录，支持同源多区域版本（如大陆版和港澳台版共存）

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -138,6 +138,52 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
     }
 }
 
+// 支持检索的有效站点标识集合
+const ALLOWED_SITES = new Set([
+    'anidb', 'bangumi', 'gamer', 'gamer_hk', 
+    'bilibili', 'bilibili_hk_mo_tw', 'bilibili_hk_mo', 'bilibili_tw', 'tmdb'
+]);
+
+/**
+ * 精简 Bangumi Data 数据结构
+ * 提取搜索逻辑必须的字段，并过滤掉不包含目标站点标识的动漫条目，控制常驻内存占用
+ * * @param {Object} rawData - 原始完整版 Bangumi Data JSON 对象
+ * @returns {Object} 包含精简后 items 数组的对象
+ */
+function pruneBangumiData(rawData) {
+    if (!rawData || !rawData.items) return { items: [] };
+
+    const prunedItems = [];
+    for (const item of rawData.items) {
+        // 筛选当前条目下属于允许列表的站点信息
+        const validSites = [];
+        if (item.sites) {
+            for (const s of item.sites) {
+                if (ALLOWED_SITES.has(s.site)) {
+                    const prunedSite = { site: s.site, id: s.id };
+                    if (s.comment) prunedSite.comment = s.comment;
+                    validSites.push(prunedSite);
+                }
+            }
+        }
+
+        // 丢弃不包含任何目标站点的条目，避免占用内存
+        if (validSites.length === 0) continue;
+
+        // 构建精简版条目，仅保留核心检索字段
+        const prunedItem = {
+            title: item.title,
+            type: item.type,
+            sites: validSites
+        };
+        if (item.begin) prunedItem.begin = item.begin;
+        if (item.titleTranslate) prunedItem.titleTranslate = item.titleTranslate;
+
+        prunedItems.push(prunedItem);
+    }
+    return { items: prunedItems };
+}
+
 /**
  * 下载并缓存最新版本的 Bangumi Data
  * 支持多节点并发竞速流式下载写入磁盘或直接解析到内存，并记录细粒度性能指标
@@ -145,12 +191,11 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
  * @returns {Promise<void>}
  */
 async function downloadAndCache(cachePath) {
-    log("info", "[Bangumi-Data] 开始优选节点下载最新数据 (约 7MB)...");
+    log("info", "[Bangumi-Data] 开始优选节点下载最新数据并执行精简...");
     try {
         const memBefore = process.memoryUsage().heapUsed;
         const startTime = Date.now(); 
 
-        let parseStartTime = 0;
         let parseTimeMs = 0;
 
         // 备选 CDN 节点列表
@@ -180,20 +225,25 @@ async function downloadAndCache(cachePath) {
             const response = await fetch(url, { ...fetchOptions, signal: controller.signal });
             if (!response.ok) throw new Error(`HTTP error ${response.status} from ${url}`);
 
-            let resultData = null;
+            // 获取并解析完整的 JSON 数据
+            const resultData = await response.json();
+            const originalCount = resultData.items ? resultData.items.length : 0;
+
+            // 立即执行数据裁剪以释放内存
+            const localParseStartTime = Date.now();
+            const prunedData = pruneBangumiData(resultData);
+            const pruneCost = Date.now() - localParseStartTime;
+
             let tempFilePath = null;
 
             if (cachePath) {
-                // 物理磁盘模式：为每个并发流生成独立的临时文件
+                // 物理磁盘模式：为每个并发流生成独立的临时文件，写入精简后的数据
                 tempFilePath = `${cachePath}.tmp${index}`;
-                await pipeline(response.body, fs.createWriteStream(tempFilePath));
-            } else {
-                // 纯内存模式：直接解析完整的 JSON
-                resultData = await response.json();
+                fs.writeFileSync(tempFilePath, JSON.stringify(prunedData), 'utf-8');
             }
 
             // 返回胜出者所需的所有上下文信息
-            return { index, url, tempFilePath, resultData };
+            return { index, url, tempFilePath, resultData: prunedData, pruneCost, originalCount };
         });
 
         // Promise.any 会等待第一个完全执行完毕的 Promise
@@ -216,24 +266,17 @@ async function downloadAndCache(cachePath) {
                     }
                 }
             });
+
+            // 将胜出者的临时文件正式重命名为缓存文件
+            fs.renameSync(winner.tempFilePath, cachePath); 
         }
 
         const downloadTime = ((Date.now() - startTime) / 1000).toFixed(2);
-        log("info", `[Bangumi-Data] 流式下载并写入磁盘成功(优选节点: ${new URL(winner.url).hostname} ,网络耗时: ${downloadTime} 秒)`);
+        log("info", `[Bangumi-Data] 精简数据已成功写入磁盘 (节点: ${new URL(winner.url).hostname} ,阶段耗时: ${downloadTime} 秒)`);
 
         // 数据处理流
-        if (cachePath) {
-            // 将胜出者的临时文件正式重命名为缓存文件
-            fs.renameSync(winner.tempFilePath, cachePath); 
-
-            parseStartTime = Date.now();
-            memoryCache = JSON.parse(fs.readFileSync(cachePath, 'utf-8'));
-            parseTimeMs = Date.now() - parseStartTime;
-        } else {
-            parseStartTime = Date.now();
-            memoryCache = winner.resultData;
-            parseTimeMs = Date.now() - parseStartTime;
-        }
+        memoryCache = winner.resultData;
+        parseTimeMs = winner.pruneCost;
 
         const memAfter = process.memoryUsage().heapUsed;
         const totalTime = ((Date.now() - startTime) / 1000).toFixed(2); 
@@ -242,7 +285,7 @@ async function downloadAndCache(cachePath) {
         const totalMemMB = (process.memoryUsage().rss / 1024 / 1024).toFixed(2);
         memoryCacheTime = Date.now();
 
-        log("info", `[Bangumi-Data] 加载到内存成功，条目数: ${memoryCache.items.length}，解析耗时: ${parseTimeMs} ms，全链路总耗时: ${totalTime} 秒，约占内存: ${memoryFootprintMB} MB (当前项目总占用: ${totalMemMB} MB)`);
+        log("info", `[Bangumi-Data] 加载到内存成功，保留/原始条目数: ${memoryCache.items.length} / ${winner.originalCount}，处理耗时: ${parseTimeMs} ms，全链路总耗时: ${totalTime} 秒，净增内存: ${memoryFootprintMB} MB (当前项目总占用: ${totalMemMB} MB)`);
     } catch (e) {
         // 提取所有请求均失败时的具体错误信息
         const errorMessage = e instanceof AggregateError ? e.errors.map(err => err.message).join(' | ') : e.message;

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -1,5 +1,6 @@
 import { globals } from '../configs/globals.js';
 import { log } from './log-util.js'
+import { simplized, traditionalized } from './zh-util.js';
 
 // =====================
 // 通用工具方法
@@ -269,8 +270,15 @@ export function titleMatches(title, query) {
   const t = normalizeSpaces(title).toLowerCase();
   const q = normalizeSpaces(query).toLowerCase();
 
-  // 策略2：包含匹配优先 (性能最优且准确，只要完整包含即匹配)
-  if (t.includes(q)) return true;
+  // 预处理：构建搜索词变种池 (原词、简体、繁体)，利用 Set 去重
+  let qList = [q];
+  try {
+    qList = [...new Set([query, simplized(query), traditionalized(query)])]
+      .map(kw => normalizeSpaces(kw).toLowerCase()).filter(Boolean);
+  } catch (e) {}
+
+  // 策略2：包含匹配优先 (性能最优且准确，只要完整包含任意变种即匹配)
+  if (qList.some(kw => t.includes(kw))) return true;
 
   // 季度特征校验 (针对策略3的宽松相似度，防止字符集混淆导致季度错乱)
   const querySeason = getExplicitSeasonNumber(query);
@@ -287,16 +295,20 @@ export function titleMatches(title, query) {
   }
 
   // 策略3：相似度匹配 (阈值0.8)
-  // 长度差异过大，或纯英文/数字时，禁止使用字符打散策略阻断
-  if (Math.abs(t.length - q.length) > Math.max(t.length, q.length) * 0.7 || /^[a-zA-Z0-9]+$/.test(q)) {
-    return false; 
-  }
-  // 核心相似度计算：解决"和/与"等翻译差异
-  const qSet = new Set(q);
-  const tSet = new Set(t);
-  const matchCount = [...qSet].reduce((acc, char) => acc + (tSet.has(char) ? 1 : 0), 0);
+  const tSet = new Set(t); // 提取到循环外，避免重复创建
+  
+  // 使用 some 遍历变种池，包裹原版的相似度逻辑
+  return qList.some(kw => {
+    // 长度差异过大，或纯英文/数字时，禁止使用字符打散策略阻断
+    if (Math.abs(t.length - kw.length) > Math.max(t.length, kw.length) * 0.7 || /^[a-zA-Z0-9]+$/.test(kw)) {
+      return false; 
+    }
+    // 核心相似度计算：解决"和/与"等翻译差异
+    const qSet = new Set(kw);
+    const matchCount = [...qSet].reduce((acc, char) => acc + (tSet.has(char) ? 1 : 0), 0);
 
-  return (matchCount / qSet.size) > 0.8;
+    return (matchCount / qSet.size) > 0.8;
+  });
 }
 
 /**

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -296,10 +296,9 @@ export function titleMatches(title, query) {
 
   // 策略3：相似度匹配 (阈值0.8)
   const tSet = new Set(t); // 提取到循环外，避免重复创建
-  
-  // 使用 some 遍历变种池，包裹原版的相似度逻辑
+
   return qList.some(kw => {
-    // 长度差异过大，或纯英文/数字时，禁止使用字符打散策略阻断
+    // 长度差异过大，或纯英文/数字时，禁止使用字符打散策略
     if (Math.abs(t.length - kw.length) > Math.max(t.length, kw.length) * 0.7 || /^[a-zA-Z0-9]+$/.test(kw)) {
       return false; 
     }

--- a/danmu_api/utils/merge-util.js
+++ b/danmu_api/utils/merge-util.js
@@ -135,11 +135,11 @@ const RegexStore = {
     },
     Season: {
         PURE_PART: /^(?:(?:第|S(?:eason)?)\s*\d+(?:季|期|部)?|(?:Part|P|第)\s*\d+(?:部分)?)$/i,
-        PART_NORM: /第(\d+)部分/g,
+        PART_NORM: /第\s*(\d+)\s*部分/g,
         PART_NORM_2: /(?:Part|P)[\s.]*(\d+)/gi,
         FINAL: /(?:The\s+)?Final\s+Season/gi,
         NORM: /(?:Season|S)\s*(\d+)/gi,
-        CN: /第([一二三四五六七八九十])季/g,
+        CN: /第\s*([一二三四五六七八九十])\s*季/g,
         ROMAN: /(\s|^)(IV|III|II|I)(\s|$)/g,
         INFO_STRONG: /(?:season|s|第)\s*[0-9一二三四五六七八九十]+\s*(?:季|期|部(?!分))?/gi,
         PART_INFO_STRONG: /(?:part|p|第)\s*\d+\s*(?:部分)?/gi,
@@ -171,7 +171,7 @@ const RegexStore = {
     Episode: {
         SUFFIX_DIGIT: /_\d+(?=$|\s)/g,
         FILE_NOISE: /_(\d{2,4})(?=\.)/g,
-        SEASON_PREFIX: /(?:^|\s)(?:第[0-9一二三四五六七八九十]+季|S(?:eason)?\s*\d+)(?:\s+|_)/gi,
+        SEASON_PREFIX: /(?:^|\s)(?:第\s*[0-9一二三四五六七八九十]+\s*季|S(?:eason)?\s*\d+)(?:\s+|_)/gi,
         CLEAN_SMART: /(?:^|\s)(?:EP|E|Vol|Episode|No|Part|第)\s*\d+(?:\.\d+)?(?:\s*[话話集])?(?!\s*[季期部])/gi,
         PUNCTUATION: /[!！?？,，.。、~～:：\-–—]/g,
         DANDAN_TAG: /^【(dandan|animeko)】/i,
@@ -179,8 +179,8 @@ const RegexStore = {
         MOVIE_CHECK: /剧场版|劇場版|movie|film/i,
         PV_CHECK: /(pv|trailer|预告)/i,
         SPECIAL_CHECK: /^(s|o|sp|special)\d/i,
-        SEASON_MATCH: /(?:^|\s)(?:第|S)(\d+)[季S]/i,
-        NUM_STRATEGY_A: /(?:第|s)(\d+)[季s]\s*(?:第|ep|e)(\d+)/i,
+        SEASON_MATCH: /(?:^|\s)(?:第|S)\s*(\d+)\s*[季S]/i,
+        NUM_STRATEGY_A: /(?:第|s)\s*(\d+)\s*[季s]\s*(?:第|ep|e)\s*(\d+)/i,
         NUM_STRATEGY_B: /(?:ep|e|vol|episode|chapter|no|part|第)\s*(\d+(\.\d+)?)(?:\s*[话話集])?(?!\s*[季期部])/i,
         NUM_STRATEGY_C: /(?:^|\s)(?:第)?(\d+(\.\d+)?)(?:话|集|\s|$)/,
         DANDAN_IGNORE: /^[SC]\d+/i,
@@ -205,7 +205,7 @@ const SUFFIX_SPECIFIC_MAP = [
 ];
 
 const SEASON_PATTERNS = [
-  { regex: /(?:第)?(\d+)(?:季|期|部(?!分))/, prefix: 'S' },
+  { regex: /(?:第)?\s*(\d+)\s*(?:季|期|部(?!分))/, prefix: 'S' },
   { regex: /\bseason\s*(\d+)/i, prefix: 'S' },
   { regex: /\bs\s*(\d+)\b/i, prefix: 'S' },
   { regex: /\bpart\s*(\d+)/i, prefix: 'P' },
@@ -594,77 +594,88 @@ function checkTitleSubtitleConflict(titleA, titleB, isDateValid = true) {
 
 /**
  * 提取季数和类型标记
- * 核心逻辑：区分 S1, S2, MOVIE, SP 以及 AMBIGUOUS 标记
- * @param {string} title 
- * @param {string} [typeDesc=''] 
+ * 核心逻辑：从主标题及别名列表中识别 S1, S2, MOVIE, SP 等标记，并汇总去重
+ * @param {string} title - 主标题
+ * @param {string} [typeDesc=''] - 类型描述
+ * @param {Array<string>} [aliases=[]] - 别名列表
  * @returns {Set<string>}
  */
-function extractSeasonMarkers(title, typeDesc = '') {
-    title = normalizeTitleForEngine(title);
+function extractSeasonMarkers(title, typeDesc = '', aliases = []) {
   const markers = new Set();
-  const t = cleanText(title); 
   const type = cleanText(typeDesc || '');
-  const tWithoutParts = t.replace(RegexStore.Season.PART_ANY, '');
-  const structMatch = tWithoutParts.match(RegexStore.Season.CN_STRUCTURE);
-  if (structMatch) {
-      const char = structMatch[1];
-      if (char === '承') markers.add('S2');
-      else if (char === '转') markers.add('S3');
-      else if (char === '结') markers.add('S4');
-  }
-  SEASON_PATTERNS.forEach(p => {
-    const targetText = p.useCleaned ? tWithoutParts : t;
-    const match = targetText.match(p.regex);
-    if (match) {
-      if (p.prefix) markers.add(`${p.prefix}${parseInt(match[1])}`);
-      else markers.add(p.val);
+
+  const processSingleTitle = (rawTitle) => {
+    const t = cleanText(normalizeTitleForEngine(rawTitle));
+    const tWithoutParts = t.replace(RegexStore.Season.PART_ANY, '');
+    
+    // 1. 承转结字典映射
+    const structMatch = tWithoutParts.match(RegexStore.Season.CN_STRUCTURE);
+    if (structMatch) {
+      const charMap = { '承': 'S2', '转': 'S3', '结': 'S4' };
+      if (charMap[structMatch[1]]) markers.add(charMap[structMatch[1]]);
     }
-  });
-  let hitSpecific = false;
-  for (const item of SUFFIX_SPECIFIC_MAP) {
-      if (item.regex.test(tWithoutParts)) {
-          markers.add(item.val);
-          hitSpecific = true;
-          break; 
-      }
-  }
-  if (!hitSpecific) {
+
+    // 2. 正则模式匹配
+    SEASON_PATTERNS.forEach(p => {
+      const match = (p.useCleaned ? tWithoutParts : t).match(p.regex);
+      if (match) markers.add(p.prefix ? `${p.prefix}${parseInt(match[1])}` : p.val);
+    });
+
+    // 3. 特殊后缀硬映射
+    const hitSpecific = SUFFIX_SPECIFIC_MAP.some(item => {
+      if (item.regex.test(tWithoutParts)) { markers.add(item.val); return true; }
+    });
+
+    // 4. 罗马数字/字母歧义标记字典映射
+    if (!hitSpecific) {
       const ambMatch = tWithoutParts.match(RegexStore.Season.SUFFIX_AMBIGUOUS);
       if (ambMatch) {
-          markers.add('AMBIGUOUS');
-          const suffix = ambMatch[1].toUpperCase();
-          if (suffix === 'II') markers.add('S2');
-          if (suffix === 'III') markers.add('S3');
-          if (suffix === 'IV') markers.add('S4');
+        markers.add('AMBIGUOUS');
+        const sufMap = { 'II': 'S2', 'III': 'S3', 'IV': 'S4' };
+        const suffix = ambMatch[1].toUpperCase();
+        if (sufMap[suffix]) markers.add(sufMap[suffix]);
       }
-  }
-  if (RegexStore.Season.SUFFIX_SEQUEL.test(t) || type.includes('续篇')) markers.add('SEQUEL');
-  if (type.includes('剧场版') || type.includes('movie') || type.includes('film') || type.includes('电影')) markers.add('MOVIE');
+    }
+
+    // 5. 续篇与中文数字季度
+    if (RegexStore.Season.SUFFIX_SEQUEL.test(t)) markers.add('SEQUEL');
+
+    const cnNums = { '一': 1, '二': 2, '三': 3, '四': 4, '五': 5, 'final': 99 };
+    for (const [cn, num] of Object.entries(cnNums)) {
+      if (t.includes(`第${cn}季`)) markers.add(`S${num}`);
+    }
+  };
+
+  // 优雅合并主标题和别名并过滤空值，遍历处理
+  [title, ...(Array.isArray(aliases) ? aliases : [])].filter(Boolean).forEach(processSingleTitle);
+
+  // 利用正则统一处理剧场版等多个关键词判断
+  if (type.includes('续篇')) markers.add('SEQUEL');
+  if (/(剧场版|movie|film|电影)/i.test(type)) markers.add('MOVIE');
   if (/\b(ova|oad)\b/i.test(type)) markers.add('OVA');
   if (/\b(sp|special)\b/i.test(type)) markers.add('SP');
-  const cnNums = {'一':1, '二':2, '三':3, '四':4, '五':5, 'final': 99};
-  for (const [cn, num] of Object.entries(cnNums)) {
-    if (t.includes(`第${cn}季`)) markers.add(`S${num}`);
-  }
-  const hasSeason = Array.from(markers).some(m => m.startsWith('S'));
-  const hasPart = Array.from(markers).some(m => m.startsWith('P'));
-  const hasAmbiguous = markers.has('AMBIGUOUS');
-  const hasSequel = markers.has('SEQUEL');
-  const isTypeSpecial = markers.has('MOVIE') || markers.has('OVA') || markers.has('SP');
+
+  // 默认值判定逻辑简化
+  const mArr = Array.from(markers);
+  const hasSeason = mArr.some(m => m.startsWith('S'));
+  const hasPart = mArr.some(m => m.startsWith('P'));
+  const isSpecial = ['MOVIE', 'OVA', 'SP', 'SEQUEL', 'AMBIGUOUS'].some(key => markers.has(key));
+  
   if (hasPart && !hasSeason) markers.add('S1');
-  if (!hasSeason && !hasPart && !hasAmbiguous && !hasSequel && !isTypeSpecial) markers.add('S1');
+  if (!hasSeason && !hasPart && !isSpecial) markers.add('S1');
+  
   return markers;
 }
 
 /**
- * 辅助：从标题中提取明确的季度编号 (1, 2, 3...)
+ * 辅助：从标题及别名中提取明确的季度编号 (1, 2, 3...)
  * @param {string} title 
  * @param {string} [typeDesc=''] 
+ * @param {Array<string>} [aliases=[]]
  * @returns {number|null}
  */
-function getSeasonNumber(title, typeDesc = '') {
-    title = normalizeTitleForEngine(title);
-    const markers = extractSeasonMarkers(title, typeDesc);
+function getSeasonNumber(title, typeDesc = '', aliases = []) {
+    const markers = extractSeasonMarkers(title, typeDesc, aliases);
     let maxSeason = null;
     for (const m of markers) {
         if (m.startsWith('S')) {
@@ -788,9 +799,9 @@ function checkMediaTypeMismatch(titleA, titleB, typeDescA, typeDescB, countA, co
  * 校验季度/续作标记是否冲突
  * @returns {boolean} true=冲突, false=兼容
  */
-function checkSeasonMismatch(titleA, titleB, typeA, typeB) {
-  const markersA = extractSeasonMarkers(titleA, typeA);
-  const markersB = extractSeasonMarkers(titleB, typeB);
+function checkSeasonMismatch(titleA, titleB, typeA, typeB, aliasesA = [], aliasesB = []) {
+  const markersA = extractSeasonMarkers(titleA, typeA, aliasesA);
+  const markersB = extractSeasonMarkers(titleB, typeB, aliasesB);
   if (markersA.size === 0 && markersB.size === 0) return false;
   const hasS2OrMore = (set) => Array.from(set).some(m => m.startsWith('S') && parseInt(m.substring(1)) >= 2);
   const hasSequel = (set) => set.has('SEQUEL');
@@ -821,9 +832,9 @@ function checkSeasonMismatch(titleA, titleB, typeA, typeB) {
  * 检查是否包含相同的季度标记
  * @returns {boolean}
  */
-function hasSameSeasonMarker(titleA, titleB, typeA, typeB) {
-  const markersA = extractSeasonMarkers(titleA, typeA);
-  const markersB = extractSeasonMarkers(titleB, typeB);
+function hasSameSeasonMarker(titleA, titleB, typeA, typeB, aliasesA = [], aliasesB = []) {
+  const markersA = extractSeasonMarkers(titleA, typeA, aliasesA);
+  const markersB = extractSeasonMarkers(titleB, typeB, aliasesB);
   const seasonsA = Array.from(markersA).filter(m => m.startsWith('S'));
   const seasonsB = Array.from(markersB).filter(m => m.startsWith('S'));
   if (seasonsA.length > 0 && seasonsB.length > 0) return seasonsA.some(sa => seasonsB.includes(sa));
@@ -971,7 +982,7 @@ function probeContentMatch(primaryAnime, candidateAnime) {
 
 /**
  * 在副源列表中寻找最佳匹配的动画对象列表
- * 包含：上下文感知、集内容探测、中配优先、Tier筛选
+ * 包含：上下文感知、集内容探测、中配优先、Tier筛选、别名交叉比对
  * @param {Anime} primaryAnime 
  * @param {Array<Anime>} secondaryList 
  * @param {Set<string|number>} collectionAnimeIds 
@@ -992,7 +1003,7 @@ export function findSecondaryMatches(primaryAnime, secondaryList, collectionAnim
   const primaryCleanForZhi = cleanText(primaryTitleForSim);
   const cleanPrimarySim = cleanTitleForSimilarity(primaryTitleForSim);
   const baseA = removeParentheses(primaryTitleForSim);
-  const markersP = extractSeasonMarkers(rawPrimaryTitle, primaryAnime.typeDescription);
+  const markersP = extractSeasonMarkers(rawPrimaryTitle, primaryAnime.typeDescription, primaryAnime.aliases);
   const seasonsP = Array.from(markersP).filter(m => m.startsWith('S'));
 
   // 上下文感知准备
@@ -1066,7 +1077,7 @@ export function findSecondaryMatches(primaryAnime, secondaryList, collectionAnim
         continue;
     }
 
-    const isSeasonExactMatch = hasSameSeasonMarker(primaryTitleForSim, secTitleForSim, primaryAnime.typeDescription, secAnime.typeDescription);
+    const isSeasonExactMatch = hasSameSeasonMarker(primaryTitleForSim, secTitleForSim, primaryAnime.typeDescription, secAnime.typeDescription, primaryAnime.aliases, secAnime.aliases);
     const contentProbe = probeContentMatch(primaryAnime, secAnime);
 
     const hasMovieA = rawPrimaryTitle.search(RegexStore.Clean.MOVIE_KEYWORDS) !== -1;
@@ -1074,7 +1085,7 @@ export function findSecondaryMatches(primaryAnime, secondaryList, collectionAnim
 
     if (hasMovieA !== hasMovieB) {
         const markersA = markersP; // Reused
-        const markersB = extractSeasonMarkers(rawSecTitle, secAnime.typeDescription);
+        const markersB = extractSeasonMarkers(rawSecTitle, secAnime.typeDescription, secAnime.aliases);
         const stripMovie = (t) => cleanTitleForSimilarity(t.replace(RegexStore.Clean.MOVIE_KEYWORDS, ''));
         const cleanA = stripMovie(rawPrimaryTitle);
         const cleanB = stripMovie(rawSecTitle);
@@ -1102,7 +1113,7 @@ export function findSecondaryMatches(primaryAnime, secondaryList, collectionAnim
         }
     }
 
-    if (!isAnyCollection && checkSeasonMismatch(primaryTitleForSim, secTitleForSim, primaryAnime.typeDescription, secAnime.typeDescription)) {
+    if (!isAnyCollection && checkSeasonMismatch(primaryTitleForSim, secTitleForSim, primaryAnime.typeDescription, secAnime.typeDescription, primaryAnime.aliases, secAnime.aliases)) {
         if (contentProbe.isStrongMatch) {
             log("info", `[Merge-Check] 季度冲突豁免: [${rawPrimaryTitle}] vs [${rawSecTitle}] (Probe强匹配)`);
         } else {
@@ -1111,21 +1122,20 @@ export function findSecondaryMatches(primaryAnime, secondaryList, collectionAnim
         }
     }
 
-    const secCandidates = [secTitleForSim];
-    if (secAnime.aliases && Array.isArray(secAnime.aliases)) {
-        secAnime.aliases.forEach(alias => {
-            let cleanAlias = alias.replace(RegexStore.Clean.YEAR_TAG, '').replace(/【(电影|电视剧)】/g, '').trim();
-            if (cleanAlias) secCandidates.push(cleanAlias);
-        });
-    }
+    // 主副别名交叉比对 + Set去重
+    const cleanFn = t => t ? String(t).replace(RegexStore.Clean.YEAR_TAG, '').replace(/【(电影|电视剧)】/g, '').trim() : '';
+    const primaryCandidates = Array.from(new Set([primaryTitleForSim, ...(primaryAnime.aliases || [])].map(cleanFn).filter(Boolean)));
+    const secCandidates = Array.from(new Set([secTitleForSim, ...(secAnime.aliases || [])].map(cleanFn).filter(Boolean)));
 
     let bestScoreFull = 0, bestScoreBase = 0;
-    for (const candTitle of secCandidates) {
-        const sFull = calculateSimilarity(primaryTitleForSim, candTitle);
-        if (sFull > bestScoreFull) bestScoreFull = sFull;
-        const candBase = removeParentheses(candTitle);
-        const sBase = calculateSimilarity(baseA, candBase);
-        if (sBase > bestScoreBase) bestScoreBase = sBase;
+    
+    // 主源候选池与副源候选池进行交叉比对，取最高相似度
+    for (const pCand of primaryCandidates) {
+        const pBase = removeParentheses(pCand);
+        for (const sCand of secCandidates) {
+            bestScoreFull = Math.max(bestScoreFull, calculateSimilarity(pCand, sCand));
+            bestScoreBase = Math.max(bestScoreBase, calculateSimilarity(pBase, removeParentheses(sCand)));
+        }
     }
 
     let score = Math.max(bestScoreFull, bestScoreBase);
@@ -1162,7 +1172,7 @@ export function findSecondaryMatches(primaryAnime, secondaryList, collectionAnim
   const finalResults = validCandidates.filter(candidate => {
       if (candidate.score >= (maxScore - Thresholds.TIER_DEFAULT)) return true;
       if ((candidate.lang === 'CN') && (candidate.score >= (maxScore - Thresholds.TIER_CN))) return true;
-      const markersC = extractSeasonMarkers(candidate.debugTitle, candidate.anime.typeDescription);
+      const markersC = extractSeasonMarkers(candidate.debugTitle, candidate.anime.typeDescription, candidate.anime.aliases);
       const hasPart = Array.from(markersC).some(m => m.startsWith('P'));
       if (hasPart && (candidate.score >= (maxScore - Thresholds.TIER_PART))) {
           const seasonsC = Array.from(markersC).filter(m => m.startsWith('S'));
@@ -1662,7 +1672,7 @@ function buildSeasonLengthMap(allGroupAnimes, epFilter, collectionAnimeIds) {
             continue;
         }
 
-        const seasonNum = getSeasonNumber(realAnime.animeTitle, realAnime.typeDescription);
+        const seasonNum = getSeasonNumber(realAnime.animeTitle, realAnime.typeDescription, realAnime.aliases);
         if (seasonNum !== null && realAnime.links) {
             const validLinks = filterEpisodes(realAnime.links, epFilter, realAnime.source).filter(item => {
                 const title = item.link.title || item.link.name || "";
@@ -1843,8 +1853,8 @@ async function processMergeTask(params) {
         // 跨源合集时序接管：汇集所有有效匹配后，强制按季数升序排列全局匹配队列
         if (allMatches.length > 1 && (isPrimaryCollection || allMatches.some(m => collectionAnimeIds.has(m.animeId)))) {
             allMatches.sort((a, b) => {
-                const sA = getSeasonNumber(a.animeTitle, a.typeDescription) || 1;
-                const sB = getSeasonNumber(b.animeTitle, b.typeDescription) || 1;
+                const sA = getSeasonNumber(a.animeTitle, a.typeDescription, a.aliases) || 1;
+                const sB = getSeasonNumber(b.animeTitle, b.typeDescription, b.aliases) || 1;
                 if (sA !== sB) return sA - sB; // 季数优先
 
                 // 季数相同时，遵循用户配置的源优先级
@@ -1852,7 +1862,7 @@ async function processMergeTask(params) {
                 const idxB = availableSecondaries.indexOf(b.source);
                 return idxA - idxB;
             });
-            const seqLogs = allMatches.map(m => `[${m.source}]S${getSeasonNumber(m.animeTitle, m.typeDescription) || 1}`);
+            const seqLogs = allMatches.map(m => `[${m.source}]S${getSeasonNumber(m.animeTitle, m.typeDescription, m.aliases) || 1}`);
             log("info", `${logPrefix} [合集时序] 已将跨源匹配队列按季数升序排列，保障切片推断严格自举: ${seqLogs.join(' -> ')}`);
         }
 
@@ -1947,11 +1957,11 @@ async function processMergeTask(params) {
             };
 
             if (isPrimaryCollection && !isSecondaryCollection) {
-                const secSeason = getSeasonNumber(derivedMatch.animeTitle, derivedMatch.typeDescription);
+                const secSeason = getSeasonNumber(derivedMatch.animeTitle, derivedMatch.typeDescription, derivedMatch.aliases);
                 const res = performSlicing(true, filteredPLinksWithIndex, secSeason);
                 activePLinks = res.slicedList; sliceStartP = res.sliceStart;
             } else if (!isPrimaryCollection && isSecondaryCollection) {
-                const pSeason = getSeasonNumber(pAnime.animeTitle, pAnime.typeDescription);
+                const pSeason = getSeasonNumber(pAnime.animeTitle, pAnime.typeDescription, pAnime.aliases);
                 const res = performSlicing(false, filteredMLinksWithIndex, pSeason);
                 activeMLinks = res.slicedList; sliceStartS = res.sliceStart;
             }
@@ -2149,7 +2159,7 @@ async function processMergeTask(params) {
                                }
                           }
                           if (maxUsedIndex !== -1) {
-                              const sSeason = getSeasonNumber(derivedMatch.animeTitle, derivedMatch.typeDescription) || 1;
+                              const sSeason = getSeasonNumber(derivedMatch.animeTitle, derivedMatch.typeDescription, derivedMatch.aliases) || 1;
                               if (!collectionProgress.has(pAnime.animeId)) collectionProgress.set(pAnime.animeId, {});
                               const progress = collectionProgress.get(pAnime.animeId);
                               if (mergedCount >= 3) { 
@@ -2166,7 +2176,7 @@ async function processMergeTask(params) {
                                }
                           }
                           if (maxUsedIndex !== -1) {
-                              const pSeason = getSeasonNumber(pAnime.animeTitle, pAnime.typeDescription) || 1;
+                              const pSeason = getSeasonNumber(pAnime.animeTitle, pAnime.typeDescription, pAnime.aliases) || 1;
                               if (!collectionProgress.has(match.animeId)) collectionProgress.set(match.animeId, {});
                               const progress = collectionProgress.get(match.animeId);
                               if (mergedCount >= 3) { 
@@ -2239,7 +2249,7 @@ function detectCollectionCandidates(curAnimes) {
 
     curAnimes.forEach(anime => {
         const realAnime = globals.animes.find(a => String(a.animeId) === String(anime.animeId)) || anime;
-        const markers = extractSeasonMarkers(realAnime.animeTitle, realAnime.typeDescription);
+        const markers = extractSeasonMarkers(realAnime.animeTitle, realAnime.typeDescription, realAnime.aliases);
 
         if (markers.has('MOVIE') || markers.has('OVA') || markers.has('SP') || markers.has('SEQUEL')) return; 
 
@@ -2289,7 +2299,7 @@ function detectCollectionCandidates(curAnimes) {
 
         list.forEach(anime => {
             const realAnime = globals.animes.find(a => String(a.animeId) === String(anime.animeId)) || anime;
-            const markers = extractSeasonMarkers(realAnime.animeTitle, realAnime.typeDescription);
+            const markers = extractSeasonMarkers(realAnime.animeTitle, realAnime.typeDescription, realAnime.aliases);
 
             let seasonNum = 1; 
             for (const m of markers) {
@@ -2444,7 +2454,7 @@ export async function applyMergeLogic(curAnimes, detailStore = null) {
             // 优先级 2: 媒体类型 (确保同源内 TV 季度先于 电影/OVA/SP 处理)
             // 1 = High Priority (TV/Seasonal), 2 = Low Priority (Movie/Non-seasonal)
             const getMediaTypePriority = (anime) => {
-                const markers = extractSeasonMarkers(anime.animeTitle, anime.typeDescription);
+                const markers = extractSeasonMarkers(anime.animeTitle, anime.typeDescription, anime.aliases);
                 if (markers.has('MOVIE')) return 2;
                 if (markers.has('OVA') || markers.has('SP')) return 2;
 
@@ -2460,14 +2470,14 @@ export async function applyMergeLogic(curAnimes, detailStore = null) {
             if (typeA !== typeB) return typeA - typeB;
 
             // 优先级 3: 季度编号 ASC (确保同源、同类型内，按 S1, S2, S3 顺序执行)
-            const sA = getSeasonNumber(a.animeTitle, a.typeDescription) || 1;
-            const sB = getSeasonNumber(b.animeTitle, b.typeDescription) || 1;
+            const sA = getSeasonNumber(a.animeTitle, a.typeDescription, a.aliases) || 1;
+            const sB = getSeasonNumber(b.animeTitle, b.typeDescription, b.aliases) || 1;
             return sA - sB; 
         });
 
         const debugOrder = list.map(a => {
-            const sNum = getSeasonNumber(a.animeTitle, a.typeDescription) || 1;
-            const typeLabel = (extractSeasonMarkers(a.animeTitle, a.typeDescription).has('MOVIE') || getStrictMediaType(a.animeTitle, a.typeDescription) === 'MOVIE') ? 'Movie' : `S${sNum}`;
+            const sNum = getSeasonNumber(a.animeTitle, a.typeDescription, a.aliases) || 1;
+            const typeLabel = (extractSeasonMarkers(a.animeTitle, a.typeDescription, a.aliases).has('MOVIE') || getStrictMediaType(a.animeTitle, a.typeDescription) === 'MOVIE') ? 'Movie' : `S${sNum}`;
             const pLevel = sourcePriorityMap.get(a.source) ?? '?';
 
             return `[P${pLevel}] [${typeLabel}] [${a.source}] ${a.animeTitle}`;
@@ -2575,19 +2585,19 @@ export async function applyMergeLogic(curAnimes, detailStore = null) {
 
             // Part 复用逻辑检测
             // 如果主源是 Part 分部资源，尝试寻找已合并过的、同季度的全集资源进行复用
-            const markers = extractSeasonMarkers(pAnime.animeTitle, pAnime.typeDescription);
+            const markers = extractSeasonMarkers(pAnime.animeTitle, pAnime.typeDescription, pAnime.aliases);
             const hasPart = Array.from(markers).some(m => m.startsWith('P'));
             let allowReuseIds = null;
             if (hasPart) {
                 allowReuseIds = new Set();
-                const pSeasonNum = getSeasonNumber(pAnime.animeTitle, pAnime.typeDescription) || 1;
+                const pSeasonNum = getSeasonNumber(pAnime.animeTitle, pAnime.typeDescription, pAnime.aliases) || 1;
                 for (const consumedId of globalConsumedIds) {
                     const consumedAnime = globals.animes.find(a => String(a.animeId) === String(consumedId));
                     if (!consumedAnime) continue;
                     if (!availableSecondaries.includes(consumedAnime.source)) continue;
-                    const secMarkers = extractSeasonMarkers(consumedAnime.animeTitle, consumedAnime.typeDescription);
+                    const secMarkers = extractSeasonMarkers(consumedAnime.animeTitle, consumedAnime.typeDescription, consumedAnime.aliases);
                     if (Array.from(secMarkers).some(m => m.startsWith('P'))) continue;
-                    const sSeasonNum = getSeasonNumber(consumedAnime.animeTitle, consumedAnime.typeDescription) || 1;
+                    const sSeasonNum = getSeasonNumber(consumedAnime.animeTitle, consumedAnime.typeDescription, consumedAnime.aliases) || 1;
                     if (pSeasonNum === sSeasonNum) allowReuseIds.add(consumedAnime.animeId);
                 }
             }


### PR DESCRIPTION
## 📝 PR 描述

### 变更类型
🐛 Bug 修复 (bug)
🚀 优化/重构 (perf/refactor)

### 变更内容
本次 PR 主要修复了各源站（Bahamut、Dandan、Animeko）的标题匹配遗漏与别名传递丢失问题，优化了底层的全局匹配引擎，并进一步提升了网络请求的健壮性与本地数据的内存利用率。具体变更如下：

1. **修复 Bahamut 源的标题误杀问题 (`bahamut.js`)**
   - **问题**：在开启 `USE_BANGUMI_DATA` 时，网络结果成功对齐本地数据后，主标题会被本地优选标题覆盖，导致后续基于用户搜索词的标题匹配规则校验失败，进而错杀有效搜索结果。
   - **修复**：在标题被覆盖前，将巴哈姆特的原始标题备份至别名池（`aliases`）中；同时重构过滤阶段的匹配逻辑，利用短路求值特性，在主标题匹配失败时自动降级验证别名池，确保源站特征不丢失。

2. **优化 Bangumi Data 检索精度与性能 (`bangumi-data-util.js`)**
   - **优化**：为 `searchBangumiData` 函数新增了搜索词的简繁体转换兜底支持，以实现更高精度的精确匹配。
   - **实现细节**：为了应对庞大的本地缓存数据，采用 `Set` 对原词、简体词和繁体词进行提前聚合与去重。在遍历数据源时，通过双重 `some` 逻辑进行极简的短路碰撞，在提升匹配准确率的同时，保证了遍历操作的性能。

3. **优化全局标题匹配引擎，引入简繁双向容错 (`common-util.js`)**
   - **问题**：原有的全站通用标题匹配逻辑（`titleMatches`）不具备简繁体转换能力。当遇到如“终末起点 第二季”与“終末起點 第二季”这种仅存在简繁字形差异的情况时，无论是包含匹配还是相似度匹配都会因为字符不一致导致评分骤降，引发跨源误杀。
   - **优化**：在底层工具中引入简繁转换依赖。在函数顶层将单搜索词扩展为“原词、简体、繁体”的去重变种池（`qList`），让包含匹配与相似度匹配兜底策略共享该词池。在维持原有代码层级与防错逻辑不变的前提下，消除了简繁体匹配的死角。

4. **修复 Dandan 与 Animeko 源的别名传递丢失与内存污染隐患 (`dandan.js`, `animeko.js`)**
   - **问题**：在触发本地 Bangumi-Data 拦截时，伪造返回的数据对象中漏传了 `aliases` 字段，导致下游 `handleAnimes` 构建比对池时缺少关键线索。此外，`animeko.js` 中存在直接覆盖别名数组的隐患。
   - **修复**：在本地拦截返回时，通过展开语法（`[...m.titles]`）将多国译名浅拷贝注入到 `aliases` 中；修复了 `animeko` 的继承丢失问题。此举保证了本地别名能送达匹配校验层，并阻断了下游逻辑操作对全局缓存库的内存污染风险。

5. **重构 Bangumi Data 缓存与加载机制，降低常驻内存与磁盘占用 (`bangumi-data-util.js`)**
   - **问题**：原逻辑将约 7MB 的全量数据文件直接进行流式磁盘缓存或整体内存解析。完整 JSON 经 V8 引擎解析为对象树后，会产生较高的常驻内存占用，增加了 Serverless 环境下的 OOM 风险；同时，全量文件读取也增加了进程冷启动时的 `JSON.parse()` 耗时。
   - **优化**：改变原有直接写盘的流式处理逻辑，在下载完成后引入同步数据精简步骤（`pruneBangumiData`）。针对原始 JSON 结构执行精确剔除，仅保留项目中实际调用的 9 个目标站点（如 `bilibili`、`tmdb`、`anidb` 等），并丢弃不包含这些站点的无用条目及冗余字段（如 `broadcast`、`officialSite` 等）。
   - **实现细节**：并发获取数据的同时，独立的 Promise 节点记录各自的解析与精简耗时。竞速胜出后，将精简后的轻量级对象结构写入磁盘并挂载至内存变量。此举在不影响数据完整性的前提下，大幅减少了本地缓存文件的体积与运行时的内存堆积。

### 相关 Issue
无

## 📋 提交前检查清单
无需