### PR TITLE
增加 HF README 元数据：新增 README.hf.md，sync_hf.yml 推送前自动替换

### DIFF
--- a/.github/workflows/sync_hf.yml
+++ b/.github/workflows/sync_hf.yml
@@ -17,6 +17,14 @@ jobs:
           fetch-depth: 0
           lfs: true
 
+      - name: Prepare Hugging Face README
+        run: |
+          cp README.hf.md README.md
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "准备 Hugging Face Space 元数据" --allow-empty
+
       - name: Push to Hugging Face Space
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/README.hf.md
+++ b/README.hf.md
@@ -1,0 +1,16 @@
+---
+title: Danmu API
+emoji: 🚀
+colorFrom: blue
+colorTo: purple
+sdk: docker
+app_port: 9321
+pinned: false
+---
+
+# Danmu API
+
+这是 danmu_api 的 Hugging Face Space 部署入口。
+
+完整文档请看 GitHub 仓库：
+https://github.com/huangxd-/danmu_api


### PR DESCRIPTION
参考适配 hf平台的其他项目的常见做法：
- README.md 保持干净文档，不放 HF YAML frontmatter
- README.hf.md 专门存放 HF metadata（title/emoji/sdk/port）
- GitHub Actions sync_hf.yml 在推送到 HF Space 前临时 cp 替换