### PR TITLE
修复最近bangumi-data继承导致fw插件不可用的问题

### DIFF
--- a/.github/workflows/sync_hf.yml
+++ b/.github/workflows/sync_hf.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   sync-to-huggingface:
     runs-on: ubuntu-latest
+    if: ${{ vars.ENABLE_HF_SYNC == 'true' }}
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ LogVar 弹幕 API 服务器
   - `GET /api/v2/comment?url=${videoUrl}&format=json`：通过视频URL直接获取弹幕（兼容第三方弹幕服务器格式）。
   - `POST /api/v2/segmentcomment?format=json`：通过comment接口返回体中的Segment类JSON数据获取单独一个分片的弹幕数据。
   - `GET /api/logs`：获取最近的日志（最多 500 行，格式为 `[时间戳] 级别: 消息`）。
+  - `GET /api/v2/fongmi/danmaku?name={name}&episode={episode}`：FengMi影视api。
+  - `GET /danmaku/api/v2/fongmi/danmaku?name={name}&episode={episode}`：兼容FengMi影视api短路径。
 - **弹幕格式输出**：支持 JSON 和 XML 两种格式输出，通过以下方式配置：
   - 环境变量：`DANMU_OUTPUT_FORMAT=json|xml`（默认：json）
   - 查询参数：`?format=xml` 或 `?format=json`（优先级最高）
@@ -328,7 +330,7 @@ LogVar 弹幕 API 服务器
   > 注意：TOKEN为默认87654321的情况下，可不带{TOKEN}请求，如`https://{account}-{space}.hf.space/api/v2/search/anime?keyword=子夜归`
 
 ## API食用指南
-支持 forward/senplayer/hills/小幻/yamby/eplayerx/afusekt/uz影视/dscloud/lenna/danmaku-anywhere/omnibox/ChaiChaiEmbyTV/moontv/capyplayer/kerkerker/LinPlayer/peekpili 等支持弹幕API的播放器。
+支持 forward/senplayer/hills/小幻/yamby/eplayerx/afusekt/uz影视/dscloud/lenna/danmaku-anywhere/omnibox/ChaiChaiEmbyTV/moontv/capyplayer/kerkerker/LinPlayer/peekpili/FengMi影视 等支持弹幕API的播放器。
 
 配合 dd-danmaku 扩展新增对 Emby Web 端弹幕的支持，具体使用方法参考 [PR #98](https://github.com/huangxd-/danmu_api/pull/98) 。
 

--- a/build-forward-widget.js
+++ b/build-forward-widget.js
@@ -75,7 +75,7 @@ let customPolyfillContent = fs.readFileSync('forward/custom-polyfill.js', 'utf8'
               if (result.errors.length === 0) {
                 let outputContent = fs.readFileSync('dist/logvar-danmu.js', 'utf8');
                 
-                // // 更通用的模式，匹配包含这四个函数名的导出语句
+                // 更通用的模式，匹配包含这四个函数名的导出语句
                 const genericExportPattern = /export\s*{\s*(?:\s*(?:getCommentsById|getDanmuWithSegmentTime|getDetailById|searchDanmu)\s*,?\s*){4}\s*};?/g;
                 outputContent = outputContent.replace(genericExportPattern, '');
 
@@ -86,6 +86,9 @@ let customPolyfillContent = fs.readFileSync('forward/custom-polyfill.js', 'utf8'
                 // 删除本地redis相关
                 outputContent = outputContent.replace(/.*setLocalRedisKey.*\n?/g, '\n');
                 outputContent = outputContent.replace(/.*updateLocalRedisCaches.*\n?/g, '\n');
+
+                // 删除包含 bangumi-data-util.js 关键字的行
+                outputContent = outputContent.replace(/.*bangumi-data-util\.js.*\n?/g, '');
                 
                 // 保存修改后的内容
                 fs.writeFileSync('dist/logvar-danmu.js', outputContent);

--- a/build-forward-widget.js
+++ b/build-forward-widget.js
@@ -20,6 +20,7 @@ const uiModules = [
   './ui/js/pushdanmu.js',
   './ui/js/systemsettings.js',
   './utils/local-redis-util.js',
+  './utils/bangumi-data-util.js',
   'danmu_api/ui/template.js',
   'danmu_api/ui/css/base.css.js',
   'danmu_api/ui/css/components.css.js',
@@ -31,7 +32,8 @@ const uiModules = [
   'danmu_api/ui/js/apitest.js',
   'danmu_api/ui/js/pushdanmu.js',
   'danmu_api/ui/js/systemsettings.js',
-  'danmu_api/utils/local-redis-util.js'
+  'danmu_api/utils/local-redis-util.js',
+  'danmu_api/utils/bangumi-data-util.js'
 ];
 
 let customPolyfillContent = fs.readFileSync('forward/custom-polyfill.js', 'utf8');
@@ -47,14 +49,18 @@ let customPolyfillContent = fs.readFileSync('forward/custom-polyfill.js', 'utf8'
       target: 'es2020',
       outfile: 'dist/logvar-danmu.js',
       format: 'esm', // 保持ES模块格式
-      external: ['redis'],
+      external: ['redis', 'fs', 'path', 'stream/promises', 'node-fetch'],
       plugins: [
         // 插件：排除UI相关模块
         {
           name: 'exclude-ui-modules',
           setup(build) {
             // 拦截对UI相关模块的导入
-            build.onResolve({ filter: /.*ui.*\.(css|js)$|.*template\.js$|.*local-redis-util\.js$/ }, (args) => {
+            build.onResolve({ filter: /.*ui.*\.(css|js)$|.*template\.js$|.*local-redis-util\.js$|.*bangumi-data-util\.js$/ }, (args) => {
+              // 直接匹配 bangumi-data-util.js 和 local-redis-util.js
+              if (args.path.includes('bangumi-data-util.js') || args.path.includes('local-redis-util.js')) {
+                return { path: args.path, external: true };
+              }
               if (uiModules.some(uiModule => args.path.includes(uiModule.replace('./', '').replace('../', '')))) {
                 return { path: args.path, external: true };
               }

--- a/danmu_api/configs/globals.js
+++ b/danmu_api/configs/globals.js
@@ -13,7 +13,7 @@ export const Globals = {
   accessedEnvVars: {},
 
   // 静态常量
-  VERSION: '1.19.1',
+  VERSION: '1.19.2',
   MAX_LOGS: 1000, // 日志存储，最多保存 1000 行
   MAX_RECORDS: 100, // 请求记录最大数量
 

--- a/forward/forward-widget.test.js
+++ b/forward/forward-widget.test.js
@@ -259,7 +259,7 @@ async function testNewFlow() {
       // title: "https://www.bilibili.com/bangumi/play/ep1231564",
       // title: "https://www.bilibili.com/video/av170001?p=2",
       // title: "https://www.bilibili.com/video/BV17x411w7KC?p=3",
-      title: '绿野仙踪',
+      title: '寻秦记',
       ...commonParams,
     });
     if (verbose) {


### PR DESCRIPTION
- 修复最近bangumi-data继承导致fw插件不可用的问题

- GitHub默认需配置ENABLE_HF_SYNC为true才开启sync_hf.yml