### PR TITLE
 fix(kan360): 修复360看源无法获取个别剧的最新一集

### DIFF
--- a/danmu_api/sources/kan360.js
+++ b/danmu_api/sources/kan360.js
@@ -276,9 +276,27 @@ export default class Kan360Source extends BaseSource {
               if (globals.vodAllowedPlatforms.includes(anime.seriesSite)) {
                 for (let i = 0; i < anime.seriesPlaylinks.length; i++) {
                   const item = anime.seriesPlaylinks[i];
+                  let epUrl = "";
+
+                  // 适配 seriesPlaylinks 列表中存在的异构数据节点
+                  // 1. 常规节点为包含 url 属性的对象结构
+                  if (item && typeof item === "object") {
+                    epUrl = item.url || "";
+                  } 
+                  // 2. 特殊节点为字符串形态的关联链接
+                  // 忽略该关联链接，并从顶层 playlinks 提取当前站点的主链接进行数据映射
+                  else if (typeof item === "string") {
+                    epUrl = (anime.playlinks && anime.playlinks[anime.seriesSite]) 
+                              ? anime.playlinks[anime.seriesSite] 
+                              : "";
+                  }
+
+                  // 过滤无有效 url 的空节点，避免生成非法格式的剧集对象
+                  if (!epUrl) continue;
+
                   links.push({
                     "name": (i + 1).toString(),
-                    "url": item.url,
+                    "url": epUrl,
                     "title": `【${anime.seriesSite}】 第${i + 1}集`
                   });
                 }


### PR DESCRIPTION
部分剧的最新一集链接在顶层 playlinks 中
如
[低智商犯罪 第24集](https://api.so.360kan.com/index?force_v=1&kw=%E4%BD%8E%E6%99%BA%E5%95%86%E7%8A%AF%E7%BD%AA&from=&pageno=1&v_ap=1&tab=all) 、[最浪漫的事 第8集](https://api.so.360kan.com/index?force_v=1&kw=%E6%9C%80%E6%B5%AA%E6%BC%AB%E7%9A%84%E4%BA%8B&from=&pageno=1&v_ap=1&tab=all) 、[神秘博士：神秘博士归来 第1集](https://api.so.360kan.com/index?force_v=1&kw=%E7%A5%9E%E7%A7%98%E5%8D%9A%E5%A3%AB%EF%BC%9A%E7%A5%9E%E7%A7%98%E5%8D%9A%E5%A3%AB%E5%BD%92%E6%9D%A5&from=&pageno=1&v_ap=1&tab=all)

Closes #316 