### PR TITLE
fix(util): 修复搜索叠词会产生大量无关结果的问题，修复 TMDB 日语原名检索特殊场景下匹配到无关结果的问题

### DIFF
--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -304,10 +304,19 @@ export function titleMatches(title, query, parsedSeason = null) {
       return false; 
     }
     // 核心相似度计算：解决"和/与"等翻译差异
-    const qSet = new Set(kw);
-    const matchCount = [...qSet].reduce((acc, char) => acc + (tSet.has(char) ? 1 : 0), 0);
+    let matchCount = 0;
+    // 将标题转为数组以实现字符消耗逻辑，避免同一字符被重复匹配
+    const tChars = Array.from(t); 
 
-    return (matchCount / qSet.size) > 0.8;
+    for (const char of kw) {
+      const idx = tChars.indexOf(char);
+      if (idx !== -1) {
+        matchCount++;
+        tChars[idx] = null; 
+      }
+    }
+
+    return (matchCount / kw.length) > 0.8;
   });
 }
 

--- a/danmu_api/utils/tmdb-util.js
+++ b/danmu_api/utils/tmdb-util.js
@@ -266,39 +266,6 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
           };
         };
 
-        // 内部函数：批量验证搜索结果
-        const validateResults = (results) => {
-          if (!results || results.length === 0) {
-            return { 
-              hasValid: false, 
-              validCount: 0, 
-              totalCount: 0, 
-              details: "搜索结果为空" 
-            };
-          }
-
-          let validCount = 0;
-          const validItems = [];
-
-          for (const item of results) {
-            const validation = isValidContent(item);
-            if (validation.isValid) {
-              validCount++;
-              const itemTitle = item.name || item.title || "未知";
-              validItems.push(`${itemTitle}(${validation.reason})`);
-            }
-          }
-
-          return {
-            hasValid: validCount > 0,
-            validCount: validCount,
-            totalCount: results.length,
-            details: validCount > 0 
-              ? `找到${validCount}个符合条件的内容: ${validItems.slice(0, 3).join(', ')}${validCount > 3 ? '...' : ''}`
-              : `所有${results.length}个结果均不符合条件(非动画且非日语)`
-          };
-        };
-
         // 相似度计算函数
         const similarity = (s1, s2) => {
           // 标准化处理
@@ -376,17 +343,29 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
           return null;
         }
 
-        // 第二步：类型验证（宽松策略：只要有一个符合就继续）
-        const validationResult = validateResults(dataZh.results);
+        // 第二步：数据清洗与类型严格过滤
+        // 拦截所有非目标类型条目，确保只有动画或日文条目能进入核心匹配池
+        const validResults = [];
+        const invalidItems = [];
 
-        if (!validationResult.hasValid) {
-          log("info", `[TMDB] 类型判断未通过,跳过后续搜索: ${validationResult.details}`);
+        for (const item of dataZh.results) {
+          const validation = isValidContent(item);
+          if (validation.isValid) {
+            validResults.push(item);
+          } else {
+            const itemTitle = item.name || item.title || "未知";
+            invalidItems.push(`${itemTitle}(${validation.reason})`);
+          }
+        }
+
+        if (validResults.length === 0) {
+          log("info", `[TMDB] 数据清洗拦截: 搜索结果中没有任何目标类型(动画/日文)的内容`);
           return null;
         }
 
-        log("info", `[TMDB] 类型判断通过: ${validationResult.details}`);
+        log("info", `[TMDB] 数据清洗完成: 保留 ${validResults.length} 个有效条目参与匹配，过滤 ${invalidItems.length} 个无关条目${invalidItems.length > 0 ? '，过滤详情: ' + invalidItems.join(', ') : ''}`);
 
-        // 第三步：找到最相似的结果
+        // 第三步：在干净的结果池中找到最相似的结果
         let bestMatch = null;
         let bestScore = -1;
         let bestMatchChineseTitle = null;
@@ -394,7 +373,8 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
         const MAX_ALTERNATIVE_FETCHES = 5; // 最多获取5个别名
         let skipAlternativeFetch = false; // 是否跳过后续别名获取
 
-        for (const result of dataZh.results) {
+        // 遍历经过严格过滤清洗后的干净结果池
+        for (const result of validResults) {
           const resultTitle = result.name || result.title || "";
           if (!resultTitle) continue;
 
@@ -746,9 +726,13 @@ export function smartTitleReplace(animes, cnAlias) {
           log("info", `[TMDB] [分隔符模式] "${originalTitle}" -> "${anime._displayTitle}"`);
         }
       } else {
-        // 策略 C: 全替模式
-        anime._displayTitle = cnAlias;
-        log("info", `[TMDB] [全替模式] "${originalTitle}" -> "${anime._displayTitle}"`);
+        // 策略 C: 安全兜底模式
+        if (isNonChinese(originalTitle)) {
+          anime._displayTitle = cnAlias;
+          log("info", `[TMDB] [纯外文全替模式] "${originalTitle}" -> "${anime._displayTitle}"`);
+        } else {
+          log("info", `[TMDB] [跳过替换] "${originalTitle}" 含有中文且特征不符，拒绝强制全替以防误杀`);
+        }
       }
     }
   }

--- a/danmu_api/utils/tmdb-util.js
+++ b/danmu_api/utils/tmdb-util.js
@@ -453,7 +453,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
           }
         }
 
-        const MIN_SIMILARITY = 0.2;
+        const MIN_SIMILARITY = 0.4;
         if (!bestMatch || bestScore < MIN_SIMILARITY) {
           log("info", `[TMDB] 最佳匹配相似度过低或未找到匹配 (${bestMatch ? (bestScore * 100).toFixed(2) + '%' : 'N/A'}),跳过`);
           return null;
@@ -512,7 +512,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
   // 增加引用计数
   task.refCount++;
 
-  // 定义退出任务的逻辑
+  // 定义退出任务及释放计数的处理函数
   const leaveTask = () => {
     // 再次获取任务确认其仍存在
     const currentTask = TMDB_PENDING.get(cleanTitle);
@@ -525,21 +525,25 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
     }
   };
 
-  // 处理用户中断监听
+  // 声明局部变量以供全局释放
+  let abortHandler;
+
+  // 处理调用者主动中断的监听
   if (signal) {
     if (signal.aborted) {
         leaveTask();
         log("info", `[TMDB] 搜索已被中断 (Source: ${sourceLabel})`);
         return null;
     }
-    signal.addEventListener('abort', leaveTask, { once: true });
+    signal.addEventListener('abort', leaveTask);
   }
 
   // 使用 Race 机制等待结果或用户中断
   try {
     const userAbortPromise = new Promise((_, reject) => {
         if (signal) {
-            signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+            abortHandler = () => reject(new DOMException('Aborted', 'AbortError'));
+            signal.addEventListener('abort', abortHandler);
         }
     });
 
@@ -552,6 +556,14 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
     }
     log("error", `[TMDB] 搜索异常: ${error.message}`);
     return null;
+  } finally {
+    // 释放并移除终止信号监听器，防止发生内存泄漏
+    if (signal) {
+      signal.removeEventListener('abort', leaveTask);
+      if (abortHandler) {
+        signal.removeEventListener('abort', abortHandler);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
#### 通用工具:
- 去掉标题相似度匹配算法中的 Set 字符去重，将标题转为数组以实现字符消耗逻辑，避免同一字符被重复匹配

修复搜索`哈哈哈哈哈`时使用 Set 进行字符去重导致大量无关结果被通过

#### TMDB 工具:
- 给日语原名检索新增结果类型校验
- 提高日语原名搜索的相似度阈值，并安全释放计数事件监听器

之前的逻辑只要结果中有一个满足类型就扔给相似度对比返回原名太宽松了，造成了搜索`老友记`时返回了`Friends`这种通用英语词汇给源搜索，导致返回了大量无关结果