### PR TITLE
feat(util): 完善 Bangumi Data 缓存生命周期

### DIFF
--- a/danmu_api/apis/system-api.js
+++ b/danmu_api/apis/system-api.js
@@ -3,6 +3,7 @@ import { jsonResponse } from "../utils/http-util.js";
 import { HTML_TEMPLATE } from "../ui/template.js";
 import { formatLogMessage, log } from "../utils/log-util.js";
 import { HandlerFactory } from "../configs/handlers/handler-factory.js";
+import { clearBangumiDataCache, initBangumiData } from "../utils/bangumi-data-util.js";
 
 export function handleUI() {
   return new Response(HTML_TEMPLATE.replace("globals.currentToken", globals.currentToken), {
@@ -171,6 +172,20 @@ export async function handleClearCache() {
     globals.searchCache = new Map();
     globals.commentCache = new Map();
     globals.requestHistory = new Map();
+
+    try {
+      // 清理 Bangumi-Data 内存与磁盘缓存
+      clearBangumiDataCache(true);
+      
+      // 触发异步数据重载
+      if (globals.useBangumiData) {
+        initBangumiData(globals.deployPlatform, false).catch(e => {
+          log("warn", `[server] Bangumi-Data background reload failed: ${e.message}`);
+        });
+      }
+    } catch (e) {
+      log("error", `[server] Failed to clear Bangumi-Data cache: ${e.message}`);
+    }
     
     log("info", `[server] Memory cache cleared successfully`);
     

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -196,9 +196,9 @@ async function setupEnvWatcher() {
           console.log('[server] Environment variables reloaded successfully');
           console.log('[server] Updated keys:', Array.from(newEnvKeys).join(', '));
 
-          // 如果检测到关闭了 Bangumi Data 功能，主动释放 V8 内存
+          // 如果检测到关闭了 Bangumi Data 功能，主动释放内存与物理磁盘缓存
           if (process.env.USE_BANGUMI_DATA === 'false' || process.env.USE_BANGUMI_DATA === false) {
-              clearBangumiDataCache();
+              clearBangumiDataCache(true);
           }
 
         } catch (error) {

--- a/danmu_api/ui/template.js
+++ b/danmu_api/ui/template.js
@@ -226,6 +226,7 @@ export const HTML_TEMPLATE = /* html */ `
                                 <li>剧集ID缓存 (episodeIds)</li>
                                 <li>剧集编号缓存 (episodeNum)</li>
                                 <li>最后选择映射缓存 (lastSelectMap)</li>
+                                <li>动画元数据缓存 (Bangumi Data)</li>
                                 <li>搜索结果缓存</li>
                                 <li>弹幕内容缓存</li>
                                 <li>请求历史记录</li>

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -603,10 +603,11 @@ export async function searchBangumiData(keyword, siteKeys) {
 }
 
 /**
- * 释放本地数据内存缓存
- * 当动态关闭本地数据开关时调用，协助 V8 引擎进行垃圾回收
+ * 释放本地数据内存缓存与磁盘缓存
+ * 当动态关闭本地数据开关或主动清理缓存时调用，协助 V8 引擎进行垃圾回收并释放物理磁盘空间
+ * @param {boolean} clearDisk - 是否同步清理物理磁盘文件
  */
-export function clearBangumiDataCache() {
+export function clearBangumiDataCache(clearDisk = false) {
     if (memoryCache !== null) {
         const itemCount = memoryCache.items ? memoryCache.items.length : 0;
         memoryCache = null; // 切断引用，等待 GC 回收
@@ -617,5 +618,22 @@ export function clearBangumiDataCache() {
         log("info", `[Bangumi-Data] 内存缓存已主动释放 (原条目数: ${itemCount}，释放: ${memoryFootprintMB} MB，当前项目总占用: ${totalMemMB} MB)`);
         memoryFootprintMB = '0.00'; // 重置探针
         hasLoggedCacheWarning = false; // 重置警告标记
+    }
+
+    // 同步清理物理磁盘缓存文件及其并发临时文件
+    if (clearDisk && fs.existsSync(CACHE_DIR)) {
+        try {
+            const cachePath = path.join(CACHE_DIR, CACHE_FILENAME);
+            if (fs.existsSync(cachePath)) fs.unlinkSync(cachePath);
+            
+            // 清理可能存在的并发流临时文件
+            for (let i = 0; i < 5; i++) {
+                const tmpPath = `${cachePath}.tmp${i}`;
+                if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
+            }
+            log("info", `[Bangumi-Data] 磁盘缓存已同步清理`);
+        } catch (e) {
+            log("error", `[Bangumi-Data] 磁盘缓存清理失败: ${e.message}`);
+        }
     }
 }


### PR DESCRIPTION
- `/api/cache/clear`清理缓存时同步清理 Bangumi Data 内存与磁盘缓存
- 动态关闭 Bangumi Data 时，同步清理物理磁盘缓存