### PR TITLE
fix(netlify): 修复 FongMi 标题映射导致的函数打包失败

### DIFF
--- a/danmu_api/apis/clients/fongmi-api.js
+++ b/danmu_api/apis/clients/fongmi-api.js
@@ -359,7 +359,7 @@ function buildFongmiDanmakuItems(animes, detailStore, apiBase) {
  * @returns {Promise<Response>} 弹幕候选响应
  */
 export async function getFongmiDanmaku(url, req) {
-  const { name, episode } = await parseFongmiRequestParams(url, req);
+  let { name, episode } = await parseFongmiRequestParams(url, req);
 
   if (!name) {
     return jsonResponse([], 200);


### PR DESCRIPTION
修复 Netlify Functions 打包失败的问题。

`getFongmiDanmaku` 中 `name` 使用 `const` 声明，但在应用标题映射表后又会重新赋值，导致 esbuild 打包时报错，Netlify 可能回退为未打包函数，最终出现类似错误：

text
SyntaxError: Cannot use import statement outside a module

## 修改

- 将 `const { name, episode }` 改为 `let { name, episode }`

## 验证

- 已本地验证 Netlify Functions 打包通过

#322 