### PR TITLE
feat(bangumi-data): 集成新 Bangumi-Data 来源，应用后为 bahamut 支持节省搜索请求

### DIFF
--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -25,6 +25,30 @@ export default class BahamutSource extends BaseSource {
         log("info", `[Bahamut] Bangumi-Data 本地命中 ${localMatches.length} 条数据`);
       }
 
+      // 筛选出含有 video_sn 的本地匹配项
+      const localWithVideoSn = localMatches.filter(m => m.video_sn);
+
+      // 数据源直通模式：Bangumi-Data 本地数据完全覆盖时，跳过巴哈姆特搜索接口（零网络请求）
+      if (localMatches.length > 0 && localMatches.length === localWithVideoSn.length) {
+        log("info", `[Bahamut] Bangumi-Data 本地命中均含 video_sn，启用数据源直通模式（跳过搜索接口）`);
+        return localMatches.map(m => {
+          const displayTitle = m.titles.find(t => t && t.includes(keyword)) || m.titles[1] || m.title;
+          const finalTitle = displayTitle + (m.titleSuffix || '');
+          return {
+            video_sn: parseInt(m.video_sn),
+            title: finalTitle,
+            _displayTitle: finalTitle,
+            isLocalPriority: true,
+            aliases: [...m.titles],
+            _typeStr: m.typeStr,
+            _fromDataSourceDirectHit: true, // 标记来源于数据源直通模式
+            _originalQuery: keyword,
+            // 保留 begin 年份供 handleAnimes 使用
+            _bangumiBegin: m.begin || null
+          };
+        });
+      }
+
       // 在函数内部进行简转繁
       const traditionalizedKeyword = traditionalized(keyword);
       const tmdbSearchKeyword = keyword;
@@ -364,14 +388,19 @@ export default class BahamutSource extends BaseSource {
       }
     }
 
-    // 使用 map 和 async 时需要返回 Promise 数组，并等待所有 Promise 完成
+    // 同一调用内对相同 video_sn 去重（缓存 Promise 避免并发竞态）
+    const episodeCache = new Map();
     const processBahamutAnimes = await Promise.all(matchedAnimes.map(async (anime) => {
       try {
-        const epData = await this.getEpisodes(anime.video_sn);
+        // 复用同一 video_sn 的在途 Promise 避免重复请求
+        const cacheKey = String(anime.video_sn);
+        if (!episodeCache.has(cacheKey)) {
+          episodeCache.set(cacheKey, this.getEpisodes(anime.video_sn));
+        }
+        const epData = await episodeCache.get(cacheKey);
         const detail = epData.video;
 
-        // 处理 episodes 对象中的多个键（"0", "1", "2" 等）
-        // 某些内容（如电影）可能在不同的键中
+        // episodes 可能在不同键中（如 "0"、"1"），电影类内容尤其常见
         let eps = null;
         if (epData.anime.episodes) {
           // 优先使用 "0" 键，如果不存在则使用第一个可用的键
@@ -391,7 +420,27 @@ export default class BahamutSource extends BaseSource {
         }
 
         if (links.length > 0) {
-          let yearMatch = (anime.info || "").match(/(\d{4})/);
+          // 年份优先级：bangumi-data begin > 详情接口 seasonStart/upTime > 搜索接口 info
+          let resolvedYear = null;
+          if (anime._bangumiBegin) {
+            resolvedYear = parseInt(anime._bangumiBegin.substring(0, 4));
+          }
+          if (!resolvedYear && epData.anime && epData.anime.seasonStart) {
+            resolvedYear = new Date(epData.anime.seasonStart).getFullYear();
+          }
+          if (!resolvedYear && detail && detail.upTime) {
+            const upTimeStr = String(detail.upTime);
+            const upTimeMatch = upTimeStr.match(/(\d{4})/);
+            if (upTimeMatch) resolvedYear = parseInt(upTimeMatch[1]);
+          }
+          if (!resolvedYear) {
+            // 最后降级到搜索接口的 info 字段
+            const yearMatch = (anime.info || "").match(/(\d{4})/);
+            if (yearMatch) resolvedYear = parseInt(yearMatch[1]);
+          }
+
+          // 封面优先级：动漫主封面(anime) > 搜索接口 cover > 单集封面(video)
+          const resolvedCover = (epData.anime && epData.anime.cover) || anime.cover || (detail && detail.cover) || "";
 
           // 优先使用tmdb智能标题替换的标题，否则简转繁处理原标题
           const displayTitle = anime._displayTitle || simplized(anime.title);
@@ -403,7 +452,7 @@ export default class BahamutSource extends BaseSource {
           }
 
           // 优先使用本地数据标注的精准类型，如果不存在则使用原版默认类型兜底
-          let itemType = anime._typeStr || "动漫"; 
+          let itemType = anime._typeStr || "动漫";
           const fullTitle = (epData.anime && epData.anime.title) || (detail && detail.title) || "";
 
           if (fullTitle.includes("[電影]")) {
@@ -415,12 +464,12 @@ export default class BahamutSource extends BaseSource {
           let transformedAnime = {
             animeId: anime.video_sn,
             bangumiId: String(anime.video_sn),
-            animeTitle: `${displayTitle}(${(anime.info.match(/(\d{4})/) || [null])[0]})【${itemType}】from bahamut`,
+            animeTitle: `${displayTitle}(${resolvedYear || 'N/A'})【${itemType}】from bahamut`,
             aliases: aliases,
             type: "动漫",
             typeDescription: "动漫",
-            imageUrl: anime.cover,
-            startDate: generateValidStartDate(new Date(epData.anime.seasonStart).getFullYear()),
+            imageUrl: resolvedCover,
+            startDate: resolvedYear ? generateValidStartDate(resolvedYear) : generateValidStartDate(epData.anime.seasonStart ? new Date(epData.anime.seasonStart).getFullYear() : null),
             episodeCount: links.length,
             rating: detail.rating,
             isFavorited: true,

--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -355,37 +355,73 @@ export default class BilibiliSource extends BaseSource {
       // 处理本地遗珠：补全网络搜索未覆盖的本地条目
       const missingLocalMatches = localMatches.filter(m => !consumedLocalMdIds.has(`md${m.siteId}`));
       if (missingLocalMatches.length > 0) {
-          log("info", `[Bilibili] 从本地 Bangumi-Data 补充 ${missingLocalMatches.length} 条缺漏记录并请求详情...`);
+          // 按是否携带 season_id 分流：本地已有时直接用 season_id 构建，无需请求 md→season_id 转换接口
+          const missingWithSeason = missingLocalMatches.filter(m => m.season_id);
+          const missingWithoutSeason = missingLocalMatches.filter(m => !m.season_id);
 
-          const missingPromises = missingLocalMatches.map(async (m) => {
-              const mediaInfo = await this._resolveMediaInfo(m.siteId);
-              const displayTitle = m.titles.find(t => t && t.includes(keyword)) || m.titles[1] || m.title;
-              const finalTitle = displayTitle + (m.titleSuffix || '');
+          if (missingWithSeason.length > 0) {
+              log("info", `[Bilibili] 从本地 Bangumi-Data 补充 ${missingWithSeason.length} 条缺漏记录并请求详情....（包含 season_id ）`);
 
-              return {
-                provider: "bilibili",
-                mediaId: mediaInfo.seasonId || `md${m.siteId}`,
-                mdId: `md${m.siteId}`,
-                title: finalTitle,
-                org_title: m.title,
-                aliases: [...m.titles],
-                _displayTitle: finalTitle,
-                type: m.typeStr,
-                year: m.begin ? parseInt(m.begin.substring(0, 4)) : null,
-                imageUrl: mediaInfo.cover,
-                episodeCount: 0,
-                isOversea: ['bilibili_hk_mo_tw', 'bilibili_hk_mo', 'bilibili_tw'].includes(m.matchedSiteKey),
-                isLocalPriority: true
-              };
-          });
+              for (const m of missingWithSeason) {
+                  const displayTitle = m.titles.find(t => t && t.includes(keyword)) || m.titles[1] || m.title;
+                  const finalTitle = displayTitle + (m.titleSuffix || '');
+                  const item = {
+                    provider: "bilibili",
+                    mediaId: `ss${m.season_id}`,
+                    mdId: `md${m.siteId}`,
+                    title: finalTitle,
+                    org_title: m.title,
+                    aliases: [...m.titles],
+                    _displayTitle: finalTitle,
+                    type: m.typeStr,
+                    year: m.begin ? parseInt(m.begin.substring(0, 4)) : null,
+                    imageUrl: "",
+                    episodeCount: 0,
+                    isOversea: ['bilibili_hk_mo_tw', 'bilibili_hk_mo', 'bilibili_tw'].includes(m.matchedSiteKey),
+                    isLocalPriority: true
+                  };
+                  const idKey = item.mediaId;
+                  if (idKey && !seenIds.has(idKey)) {
+                      seenIds.add(idKey);
+                      finalResults.unshift(item);
+                  }
+              }
+          }
 
-          const missingResults = await Promise.all(missingPromises);
-          for (const item of missingResults) {
-              const idKey = item.mediaId;
-              if (idKey && seenIds.has(idKey)) continue;
-              if (idKey) {
-                seenIds.add(idKey);
-                finalResults.unshift(item);
+          // 无 season_id 的条目回退到原流程：请求详情接口完成 md → season_id 转换
+          if (missingWithoutSeason.length > 0) {
+              log("info", `[Bilibili] 从本地 Bangumi-Data 补充 ${missingWithoutSeason.length} 条缺漏记录并请求详情...`);
+
+              const missingPromises = missingWithoutSeason.map(async (m) => {
+                  const mediaInfo = await this._resolveMediaInfo(m.siteId);
+                  const displayTitle = m.titles.find(t => t && t.includes(keyword)) || m.titles[1] || m.title;
+                  const finalTitle = displayTitle + (m.titleSuffix || '');
+
+                  return {
+                    provider: "bilibili",
+                    mediaId: mediaInfo.seasonId || `md${m.siteId}`,
+                    mdId: `md${m.siteId}`,
+                    title: finalTitle,
+                    org_title: m.title,
+                    aliases: [...m.titles],
+                    _displayTitle: finalTitle,
+                    type: m.typeStr,
+                    year: m.begin ? parseInt(m.begin.substring(0, 4)) : null,
+                    imageUrl: mediaInfo.cover,
+                    episodeCount: 0,
+                    isOversea: ['bilibili_hk_mo_tw', 'bilibili_hk_mo', 'bilibili_tw'].includes(m.matchedSiteKey),
+                    isLocalPriority: true
+                  };
+              });
+
+              const missingResults = await Promise.all(missingPromises);
+              for (const item of missingResults) {
+                  const idKey = item.mediaId;
+                  if (idKey && seenIds.has(idKey)) continue;
+                  if (idKey) {
+                    seenIds.add(idKey);
+                    finalResults.unshift(item);
+                  }
               }
           }
       }
@@ -447,6 +483,8 @@ export default class BilibiliSource extends BaseSource {
             if (data.code === 0 && data.result) {
                 // 优先从 main_section 获取分集，兼容 view 和 section 接口
                 rawEpisodes = data.result.main_section?.episodes || data.result.episodes || [];
+                // 从详情接口提取番剧主封面，供搜索结果未提供 imageUrl 时使用
+                if (data.result.cover) rawEpisodes._cover = data.result.cover;
                 if (rawEpisodes.length > 0) break;
             }
         } catch(e) {
@@ -480,6 +518,9 @@ export default class BilibiliSource extends BaseSource {
             link: `https://www.bilibili.com/bangumi/play/ep${ep.id}`
         };
     });
+
+    // 将详情接口封面转移到返回数组（.map() 产生新数组，不会继承原数组属性）
+    if (rawEpisodes._cover) episodes._cover = rawEpisodes._cover;
 
     log("info", `[Bilibili] 获取到 ${episodes.length} 个番剧分集`);
     return episodes;
@@ -662,6 +703,8 @@ export default class BilibiliSource extends BaseSource {
                log("info", `[Bilibili] ${anime.title} 无分集，跳过`);
                return;
              }
+             // 使用详情接口返回的番剧主封面填充搜索结果未提供的 imageUrl
+             if (eps._cover) anime.imageUrl = eps._cover;
              links = eps.map((ep, index) => {
                 let linkUrl = ep.link + `?season_id=${anime.mediaId.substring(2)}`;
                 // 传递区域标记

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -19,11 +19,32 @@ let memoryFootprintMB = '0.00';
 let hasLoggedCacheWarning = false;
 let charInvertedIndex = new Map();
 
+// 当前生效的数据源标识 ('custom' | 'official')
+let activeDataSource = 'custom';
+// 缓存已解析的版本号（进程内有效）
+let cachedCustomVersion = null;
+let cachedOfficialVersion = null;
+
 // 定义缓存目录/文件名
 const CACHE_DIR = path.join(process.cwd(), '.cache');
 const CACHE_FILENAME = 'bangumi-data-cache.json';
 const DOWNLOAD_TIMEOUT_MS = 20000;
 const queryCache = new Map();
+
+// CDN 节点配置：自定义优先，官方备用
+const CDN_SOURCES = {
+  custom: [
+    "https://cdn.jsdelivr.net/npm/@wan0ge/bangumi-data@0.3/dist/data.json",
+    "https://unpkg.com/@wan0ge/bangumi-data@0.3/dist/data.json"
+  ],
+  official: [
+    "https://cdn.jsdelivr.net/npm/bangumi-data@0.3/dist/data.json",
+    "https://unpkg.com/bangumi-data@0.3/dist/data.json"
+  ]
+};
+
+const CUSTOM_PACKAGE = '@wan0ge/bangumi-data';
+const OFFICIAL_PACKAGE = 'bangumi-data';
 
 // 预编译全局正则表达式
 const VALID_DUB_REGEX = /(?:普通[话話]|[国國][语語]|中文配音|中配|中文|[粤粵][语語]配音|[粤粵]配|[粤粵][语語]|[台臺]配|[台臺][语語]|港配|港[语語]|字幕|助[听聽]|日[语語]|日配|原版|原[声聲])(?:版)?/;
@@ -59,6 +80,103 @@ function buildInvertedIndex(items) {
     }
 
     charInvertedIndex = newCharIndex;
+}
+
+/**
+ * 解析语义化版本号
+ * 支持标准 semver 格式 (major.minor.patch)
+ * @param {string} versionStr 版本字符串（如 "0.3.208", "0.3.209"）
+ * @returns {{major:number, minor:number, patch:number}|null} 解析结果
+ */
+function parseSemanticVersion(versionStr) {
+    if (!versionStr || typeof versionStr !== 'string') return null;
+
+    const match = versionStr.match(/^(\d+)\.(\d+)\.(\d+)$/);
+    if (!match) return null;
+
+    return {
+        major: parseInt(match[1], 10),
+        minor: parseInt(match[2], 10),
+        patch: parseInt(match[3], 10)
+    };
+}
+
+/**
+ * 比较两个语义化版本号
+ * 标准-semver 逐段数值比较
+ * @param {string} verA 版本A
+ * @param {string} verB 版本B
+ * @returns {number} 正数表示 A>B, 负数表示 A<B, 0 表示相等
+ */
+function compareVersions(verA, verB) {
+    const a = parseSemanticVersion(verA);
+    const b = parseSemanticVersion(verB);
+    if (!a || !b) return 0;
+
+    if (a.major !== b.major) return a.major - b.major;
+    if (a.minor !== b.minor) return a.minor - b.minor;
+    if (a.patch !== b.patch) return a.patch - b.patch;
+
+    return 0;
+}
+
+/**
+ * 从 npm registry 查询包的最新版本号
+ * @param {string} packageName npm 包名
+ * @returns {Promise<string|null>} 版本号或 null
+ */
+async function fetchNpmLatestVersion(packageName) {
+    try {
+        const url = `https://registry.npmjs.org/${encodeURIComponent(packageName)}/latest`;
+        log("info", `[请求模拟] HTTP GET: ${url}`);
+        const response = await fetch(url, {
+            headers: { 'Accept': 'application/json' },
+            signal: AbortSignal.timeout(8000)
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        return data?.version || null;
+    } catch (e) {
+        log("warn", `[Bangumi-Data] 查询 ${packageName} 版本号失败: ${e.message}`);
+        return null;
+    }
+}
+
+/**
+ * 智能选择数据源：比较自定义构建与官方版本的版本号决定使用哪个
+ *
+ * 切换规则：
+ * - 自定义版本 >= 官方版本 → 使用自定义源（正常维护状态）
+ * - 官方版本 > 自定义版本 → 切换到官方源（自定义已停止维护）
+ * - 版本查询失败 → 默认使用自定义源
+ *
+ * @returns {Promise<'custom'|'official'>} 应使用的数据源标识
+ */
+async function selectBestDataSource() {
+    try {
+        const [customVer, officialVer] = await Promise.all([
+            cachedCustomVersion || fetchNpmLatestVersion(CUSTOM_PACKAGE),
+            cachedOfficialVersion || fetchNpmLatestVersion(OFFICIAL_PACKAGE)
+        ]);
+
+        if (customVer) cachedCustomVersion = customVer;
+        if (officialVer) cachedOfficialVersion = officialVer;
+
+        if (!customVer || !officialVer) {
+            log("info", `[Bangumi-Data] 版本检测不完整 (custom=${customVer}, official=${officialVer})，默认使用自定义源`);
+            return 'custom';
+        }
+
+        const cmp = compareVersions(customVer, officialVer);
+        const selected = cmp >= 0 ? 'custom' : 'official';
+
+        log("info", `[Bangumi-Data] 版本对比: @wan0ge/bangumi-data@${customVer} vs bangumi-data@${officialVer} => 使用${selected === 'custom' ? '自定义' : '官方'}源`);
+
+        return selected;
+    } catch (e) {
+        log("warn", `[Bangumi-Data] 数据源选择异常，回退到自定义源: ${e.message}`);
+        return 'custom';
+    }
 }
 
 /**
@@ -211,7 +329,12 @@ function pruneBangumiData(rawData) {
             for (const s of item.sites) {
                 if (ALLOWED_SITES.has(s.site)) {
                     const prunedSite = { site: s.site, id: s.id };
+                    // 提取 bilibili 系列站点的 season_id 字段
+                    if (s.season_id) prunedSite.season_id = String(s.season_id);
+                    // 提取 gamer/gamer_hk 站点的 video_sn 字段
+                    if (s.video_sn) prunedSite.video_sn = String(s.video_sn);
                     if (s.comment) prunedSite.comment = s.comment;
+                    if (s.related) prunedSite.related = s.related;
                     validSites.push(prunedSite);
                 }
             }
@@ -258,24 +381,20 @@ async function downloadAndCache(cachePath) {
     log("info", "[Bangumi-Data] 开始优选节点下载最新数据并执行精简...");
     try {
         const memBefore = process.memoryUsage().heapUsed;
-        const startTime = Date.now(); 
+        const startTime = Date.now();
 
         let parseTimeMs = 0;
 
-        // 备选 CDN 节点列表
-        const CDNS = [
-            "https://cdn.jsdelivr.net/npm/bangumi-data@0.3/dist/data.json",
-            "https://unpkg.com/bangumi-data@0.3/dist/data.json"
-        ];
+        // 每次重新下载时检测版本号以选择数据源
+        activeDataSource = await selectBestDataSource();
+        const CDNS = CDN_SOURCES[activeDataSource] || CDN_SOURCES.custom;
 
-        // 声明压缩头，提升传输效率
         const fetchOptions = {
             headers: {
                 'Accept-Encoding': 'br, gzip, deflate'
             }
         };
 
-        // 为每个请求分配独立的终止控制器
         const controllers = CDNS.map(() => new AbortController());
 
         CDNS.forEach(url => {
@@ -564,6 +683,13 @@ export async function searchBangumiData(keyword, siteKeys) {
 
             if (matchedSite.comment) {
                 const dubs = matchedSite.comment.split(COMMA_SPLIT_REGEX);
+                // 从 related 数组建立 id → season_id 查找表，供衍生配音条目使用
+                const relatedMap = new Map();
+                if (matchedSite.related && Array.isArray(matchedSite.related)) {
+                    for (const r of matchedSite.related) {
+                        if (r.id) relatedMap.set(String(r.id), r.season_id || null);
+                    }
+                }
                 for (const dub of dubs) {
                     const parts = dub.split(COLON_SPLIT_REGEX);
                     if (parts.length >= 2) {
@@ -572,7 +698,8 @@ export async function searchBangumiData(keyword, siteKeys) {
                             additionalDubs.push({
                                 title: item.title, titles: [...titles], begin: item.begin,
                                 siteId: dubId, matchedSiteKey: matchedSite.site,
-                                type: item.type, typeStr: typeStr, typeId: typeId, titleSuffix: ` ${dubName}${baseSuffix}`
+                                type: item.type, typeStr: typeStr, typeId: typeId, titleSuffix: ` ${dubName}${baseSuffix}`,
+                                season_id: relatedMap.get(dubId) || null
                             });
                         }
                     } else if (parts.length === 1 && parts[0].trim()) {
@@ -592,7 +719,11 @@ export async function searchBangumiData(keyword, siteKeys) {
             results.push({
                 title: item.title, titles: [...titles], begin: item.begin,
                 siteId: matchedSite.id, matchedSiteKey: matchedSite.site,
-                type: item.type, typeStr: typeStr, typeId: typeId, titleSuffix: currentItemSuffix 
+                type: item.type, typeStr: typeStr, typeId: typeId, titleSuffix: currentItemSuffix,
+                // 传递 bilibili 系列站点的 season_id 供直接构建分集请求
+                season_id: matchedSite.season_id || null,
+                // 传递 gamer/gamer_hk 站点的 video_sn 供直接获取详情
+                video_sn: matchedSite.video_sn || null
             });
 
             // 推送提取出的衍生条目


### PR DESCRIPTION
https://github.com/wan0ge/bangumi-data
自己构建了一个bangumi-data并跟随上游更新，补上了我们项目 bahamut 需要的 video_sn 字段以及 bilibili 衍生配音条目的 season_id / related 字段。应用后 bahamut 源在本地数据命中时可完全跳过搜索接口（零网络请求），bilibili 源的遗珠补全流程在本地已有 season_id 时可省去 md→season_id 转换请求。

变更：

bangumi-data-util.js：

- 新增版本智能切换：通过 npm registry 查询 @wan0ge/bangumi-data 与官方 bangumi-data 的版本号，标准 semver 比较，官方更新大于自我构建时自动切换到官方源
- CDN 节点按数据源分离（custom/official），支持独立优先级配置
- pruneBangumiData 新增 season_id（bilibili 站点）、video_sn（gamer/gamer_hk 站点）和 related（衍生配音关联条目）字段提取与传递
- searchBangumiData 返回结果新增 season_id / video_sn 字段；衍生配音条目通过 related 数组自动关联对应 season_id

bilibili.js：

- 遗珠补全 season_id 分流：本地缺漏记录中已携带 season_id 的条目直接构建结果对象（零网络请求），未携带的回退到 _resolveMediaInfo 请求 md→season_id 转换接口
- _getPgcEpisodes 从详情接口提取番剧主封面（result.cover），通过 _cover 属性沿调用链传递至最终 imageUrl
- handleAnimes else 分支（getEpisodes 路径）补充 _cover 读取，填充搜索结果未提供的 imageUrl

bahamut.js：

- 数据源直通模式：当 Bangumi-Data 本地命中条目均含 video_sn 时，跳过巴哈姆特搜索接口（零网络请求返回）
- 同一调用内相同 video_sn 的 in-flight Promise 去重，避免并发重复请求
- 封面优先级链：anime.cover（动漫主封面） > 详情 cover/video.cover
- 年份优先级链：bangumi-data begin > 详情 seasonStart/upTime > 搜索接口 info