### PR TITLE
feat: 前端新增覆盖全项目的日志筛选分类系统

### DIFF
--- a/danmu_api/apis/clients/fongmi-api.js
+++ b/danmu_api/apis/clients/fongmi-api.js
@@ -268,7 +268,7 @@ async function parseFongmiRequestParams(url, req) {
       }
     }
   } catch (e) {
-    log("warn", `[Fongmi] 解析请求参数失败: ${e.message}`);
+    log("warn", `[system] [Fongmi] 解析请求参数失败: ${e.message}`);
   }
 
   return { name: "", episode: "" };
@@ -368,7 +368,7 @@ export async function getFongmiDanmaku(url, req) {
   if (globals.titleMappingTable && globals.titleMappingTable.size > 0) {
     const mappedTitle = globals.titleMappingTable.get(name);
     if (mappedTitle) {
-      log("info", `[Fongmi] Title mapped from original: ${name} to: ${mappedTitle}`);
+      log("info", `[system] [Fongmi] Title mapped from original: ${name} to: ${mappedTitle}`);
       name = mappedTitle;
     }
   }
@@ -384,14 +384,14 @@ export async function getFongmiDanmaku(url, req) {
     animes = Array.isArray(searchData?.animes) ? searchData.animes : [];
     if (animes.length) {
       if (keyword !== name) {
-        log("info", `[Fongmi] Search fallback hit: raw=${name}, keyword=${keyword}, episode=${episode}`);
+        log("info", `[system] [Fongmi] Search fallback hit: raw=${name}, keyword=${keyword}, episode=${episode}`);
       }
       break;
     }
   }
 
   if (!animes.length) {
-    log("info", `[Fongmi] No danmaku candidates for name=${name}, episode=${episode}`);
+    log("info", `[system] [Fongmi] No danmaku candidates for name=${name}, episode=${episode}`);
     return jsonResponse([], 200);
   }
 
@@ -415,6 +415,6 @@ export async function getFongmiDanmaku(url, req) {
     if (items.length >= 1000) break;
   }
 
-  log("info", `[Fongmi] name=${name}, episode=${episode}, candidates=${items.length}`);
+  log("info", `[system] [Fongmi] name=${name}, episode=${episode}, candidates=${items.length}`);
   return jsonResponse(items, 200);
 }

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1,5 +1,5 @@
 import { globals } from '../configs/globals.js';
-import { getPageTitle, jsonResponse, httpGet } from '../utils/http-util.js';
+import { getPageTitle, jsonResponse, httpGet, sourceLogContext, toLogSourceName } from '../utils/http-util.js';
 import { log } from '../utils/log-util.js'
 import { simplized } from '../utils/zh-util.js';
 import { setRedisKey, updateRedisCaches } from "../utils/redis-util.js";
@@ -115,35 +115,35 @@ async function resolveUrlDuration(url) {
     let segmentResult = null;
 
     if (targetUrl.includes('.qq.com')) {
-      segmentResult = await tencentSource.getComments(targetUrl, 'qq', true);
+      segmentResult = await sourceLogContext.run('tencent', () => tencentSource.getComments(targetUrl, 'qq', true));
     } else if (targetUrl.includes('.iqiyi.com')) {
-      segmentResult = await iqiyiSource.getComments(targetUrl, 'qiyi', true);
+      segmentResult = await sourceLogContext.run('iqiyi', () => iqiyiSource.getComments(targetUrl, 'qiyi', true));
     } else if (targetUrl.includes('.mgtv.com')) {
-      segmentResult = await mangoSource.getComments(targetUrl, 'imgo', true);
+      segmentResult = await sourceLogContext.run('mango', () => mangoSource.getComments(targetUrl, 'imgo', true));
     } else if (targetUrl.includes('.bilibili.com') || targetUrl.includes('b23.tv')) {
       if (targetUrl.includes('b23.tv')) {
-        targetUrl = await bilibiliSource.resolveB23Link(targetUrl);
+        targetUrl = await sourceLogContext.run('bilibili', () => bilibiliSource.resolveB23Link(targetUrl));
       }
-      segmentResult = await bilibiliSource.getComments(targetUrl, 'bilibili1', true);
+      segmentResult = await sourceLogContext.run('bilibili', () => bilibiliSource.getComments(targetUrl, 'bilibili1', true));
     } else if (targetUrl.includes('.youku.com')) {
-      segmentResult = await youkuSource.getComments(targetUrl, 'youku', true);
+      segmentResult = await sourceLogContext.run('youku', () => youkuSource.getComments(targetUrl, 'youku', true));
     } else if (targetUrl.includes('.miguvideo.com')) {
-      segmentResult = await miguSource.getComments(targetUrl, 'migu', true);
+      segmentResult = await sourceLogContext.run('migu', () => miguSource.getComments(targetUrl, 'migu', true));
     } else if (targetUrl.includes('.sohu.com')) {
-      segmentResult = await sohuSource.getComments(targetUrl, 'sohu', true);
+      segmentResult = await sourceLogContext.run('sohu', () => sohuSource.getComments(targetUrl, 'sohu', true));
     } else if (targetUrl.includes('.le.com')) {
-      segmentResult = await leshiSource.getComments(targetUrl, 'leshi', true);
+      segmentResult = await sourceLogContext.run('leshi', () => leshiSource.getComments(targetUrl, 'leshi', true));
     } else if (targetUrl.includes('.douyin.com') || targetUrl.includes('.ixigua.com')) {
-      segmentResult = await xiguaSource.getComments(targetUrl, 'xigua', true);
+      segmentResult = await sourceLogContext.run('xigua', () => xiguaSource.getComments(targetUrl, 'xigua', true));
     } else if (targetUrl.includes('.mddcloud.com.cn')) {
-      segmentResult = await maiduiduiSource.getComments(targetUrl, 'maiduidui', true);
+      segmentResult = await sourceLogContext.run('maiduidui', () => maiduiduiSource.getComments(targetUrl, 'maiduidui', true));
     } else if (targetUrl.includes('.yfsp.tv')) {
-      segmentResult = await aiyifanSource.getComments(targetUrl, 'aiyifan', true);
+      segmentResult = await sourceLogContext.run('aiyifan', () => aiyifanSource.getComments(targetUrl, 'aiyifan', true));
     }
 
     return extractDurationFromSegments(segmentResult);
   } catch (error) {
-    log('warn', `[Duration] 获取时长失败: ${error.message}`);
+    log('warn', `[system] [Duration] 获取时长失败: ${error.message}`);
     return 0;
   }
 }
@@ -167,7 +167,7 @@ async function resolveMergedDuration(url) {
     const durations = await Promise.all(targetUrls.map(resolveUrlDuration));
     return durations.reduce((maxValue, currentValue) => Math.max(maxValue, currentValue || 0), 0);
   } catch (error) {
-    log('warn', `[Duration] 获取时长失败: ${error.message}`);
+    log('warn', `[system] [Duration] 获取时长失败: ${error.message}`);
     return 0;
   }
 }
@@ -331,76 +331,76 @@ async function executeSourceHandlers(resultData, queryTitle, targetAnimesList, r
 
     if (key === '360') {
       // 处理360来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: kan360Source.handleAnimes(animes360, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(toLogSourceName(key), () => kan360Source.handleAnimes(animes360, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'vod') {
       // 处理Vod来源（遍历所有VOD服务器的结果，依次在同一隔离容器中处理）
       if (animesVodResults && Array.isArray(animesVodResults)) {
-        const vodPromise = (async () => {
+        const vodPromise = sourceLogContext.run(key, () => (async () => {
           for (const vodResult of animesVodResults) {
             if (vodResult && vodResult.list && vodResult.list.length > 0) {
               await vodSource.handleAnimes(vodResult.list, queryTitle, isolatedAnimes, vodResult.serverName, isolatedDetailStore, targetSeason);
             }
           }
-        })();
+        })());
         sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: vodPromise });
       }
     } else if (key === 'tmdb') {
       // 处理TMDB来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: tmdbSource.handleAnimes(animesTmdb, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => tmdbSource.handleAnimes(animesTmdb, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'douban') {
       // 处理Douban来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: doubanSource.handleAnimes(animesDouban, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => doubanSource.handleAnimes(animesDouban, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'renren') {
       // 处理Renren来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: renrenSource.handleAnimes(animesRenren, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => renrenSource.handleAnimes(animesRenren, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'hanjutv') {
       // 处理Hanjutv来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: hanjutvSource.handleAnimes(animesHanjutv, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => hanjutvSource.handleAnimes(animesHanjutv, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'bahamut') {
       // 处理Bahamut来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: bahamutSource.handleAnimes(animesBahamut, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => bahamutSource.handleAnimes(animesBahamut, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'dandan') {
       // 处理弹弹play来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: dandanSource.handleAnimes(animesDandan, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => dandanSource.handleAnimes(animesDandan, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'custom') {
       // 处理自定义弹幕源来源（handleAnimes签名不含detailStore和querySeason）
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: customSource.handleAnimes(animesCustom, queryTitle, isolatedAnimes) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => customSource.handleAnimes(animesCustom, queryTitle, isolatedAnimes)) });
     } else if (key === 'tencent') {
       // 处理Tencent来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: tencentSource.handleAnimes(animesTencent, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => tencentSource.handleAnimes(animesTencent, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'youku') {
       // 处理Youku来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: youkuSource.handleAnimes(animesYouku, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => youkuSource.handleAnimes(animesYouku, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'iqiyi') {
       // 处理iQiyi来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: iqiyiSource.handleAnimes(animesIqiyi, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => iqiyiSource.handleAnimes(animesIqiyi, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'imgo') {
       // 处理Mango来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: mangoSource.handleAnimes(animesImgo, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(toLogSourceName(key), () => mangoSource.handleAnimes(animesImgo, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'bilibili') {
       // 处理Bilibili来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: bilibiliSource.handleAnimes(animesBilibili, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => bilibiliSource.handleAnimes(animesBilibili, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'migu') {
       // 处理Migu来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: miguSource.handleAnimes(animesMigu, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => miguSource.handleAnimes(animesMigu, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'sohu') {
       // 处理Sohu来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sohuSource.handleAnimes(animesSohu, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => sohuSource.handleAnimes(animesSohu, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'leshi') {
       // 处理Leshi来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: leshiSource.handleAnimes(animesLeshi, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => leshiSource.handleAnimes(animesLeshi, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'xigua') {
       // 处理Xigua来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: xiguaSource.handleAnimes(animesXigua, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => xiguaSource.handleAnimes(animesXigua, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'maiduidui') {
       // 处理Maiduidui来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: maiduiduiSource.handleAnimes(animesMaiduidui, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => maiduiduiSource.handleAnimes(animesMaiduidui, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'aiyifan') {
       // 处理Aiyifan来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: aiyifanSource.handleAnimes(animesAiyifan, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => aiyifanSource.handleAnimes(animesAiyifan, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     } else if (key === 'animeko') {
       // 处理Animeko来源
-      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: animekoSource.handleAnimes(animesAnimeko, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason) });
+      sourceTasks.push({ key, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: sourceLogContext.run(key, () => animekoSource.handleAnimes(animesAnimeko, queryTitle, isolatedAnimes, isolatedDetailStore, targetSeason)) });
     }
   }
 
@@ -413,7 +413,7 @@ async function executeSourceHandlers(resultData, queryTitle, targetAnimesList, r
 
   for (let i = 0; i < sourceTasks.length; i++) {
     if (results[i].status === 'rejected') {
-      log("error", `[executeSourceHandlers] 源 ${sourceTasks[i].key} 处理失败: ${results[i].reason}`);
+      log("error", `[system] [executeSourceHandlers] 源 ${sourceTasks[i].key} 处理失败: ${results[i].reason}`);
       continue;
     }
 
@@ -443,7 +443,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
   querySeason = querySeason ? parseInt(querySeason, 10) : null;
   let queryEpisode = url.searchParams.get("episode");
   queryEpisode = queryEpisode ? parseInt(queryEpisode, 10) : null;
-  log("info", `Search anime with keyword: ${queryTitle}, target season: ${querySeason}, target episode: ${queryEpisode}`);
+  log("info", `[system] [searchAnime] Search anime with keyword: ${queryTitle}, target season: ${querySeason}, target episode: ${queryEpisode}`);
 
   // 关键字为空直接返回，不用多余查询
   if (queryTitle === "") {
@@ -458,7 +458,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
   // 如果启用了搜索关键字繁转简，则进行转换
   if (globals.animeTitleSimplified) {
     const simplifiedTitle = simplized(queryTitle);
-    log("info", `searchAnime converted traditional to simplified: ${queryTitle} -> ${simplifiedTitle}`);
+    log("info", `[system] [searchAnime] searchAnime converted traditional to simplified: ${queryTitle} -> ${simplifiedTitle}`);
     queryTitle = simplifiedTitle;
   }
 
@@ -495,7 +495,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       }
       
       if (satisfied) {
-        log("info", `Episode ${queryEpisode} satisfied by combining cached seasons S${querySeason} to S${currentS - 1}`);
+        log("info", `[system] [LogVar-API] Episode ${queryEpisode} satisfied by combining cached seasons S${querySeason} to S${currentS - 1}`);
         return jsonResponse({
           errorCode: 0,
           success: true,
@@ -503,7 +503,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
           animes: combinedCachedResults,
         });
       }
-      log("info", `Episode ${queryEpisode} not satisfied in cache. Proceeding to network search.`);
+      log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in cache. Proceeding to network search.`);
     }
   }
 
@@ -550,7 +550,8 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       platform = "aiyifan";
     }
 
-    const pageTitle = await getPageTitle(queryTitle);
+    // 将源标识符统一映射到日志标签规范名称
+    const pageTitle = await sourceLogContext.run(toLogSourceName(platform), () => getPageTitle(queryTitle));
 
     const links = [{
       "name": "手动解析链接弹幕",
@@ -586,8 +587,9 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
 
   try {
     // 根据 sourceOrderArr 动态构建请求数组
-    log("info", `Search sourceOrderArr: ${globals.sourceOrderArr}`);
+    log("info", `[system] [LogVar-API] Search sourceOrderArr: ${globals.sourceOrderArr}`);
     const requestPromises = globals.sourceOrderArr.map(source => {
+      return sourceLogContext.run(toLogSourceName(source), () => {
       if (source === "360") return kan360Source.search(queryTitle);
       if (source === "vod") return vodSource.search(queryTitle, preferAnimeId, preferSource);
       if (source === "tmdb") return tmdbSource.search(queryTitle);
@@ -609,7 +611,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       if (source === "maiduidui") return maiduiduiSource.search(queryTitle);
       if (source === "aiyifan") return aiyifanSource.search(queryTitle);
       if (source === "animeko") return animekoSource.search(queryTitle);
-    });
+    }); });
 
     // 执行所有请求并等待结果
     const results = await Promise.all(requestPromises);
@@ -651,7 +653,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       }
 
       if (maxSeason > querySeason) {
-        log("info", `Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${maxSeason}...`);
+        log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${maxSeason}...`);
         const expandPromises = [];
         for (let s = querySeason + 1; s <= maxSeason; s++) {
           expandPromises.push((async () => {
@@ -671,7 +673,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       }
     }
   } catch (error) {
-    log("error", "发生错误:", error);
+    log("error", "[system] [LogVar-API] 发生错误:", error);
   }
 
   // 执行源合并逻辑（支持常规配对组和自定义规则表触发）
@@ -1289,7 +1291,7 @@ async function fallbackMatchAniAndEp(searchData, req, season, episode, year, tit
       // 过滤集标题一致的 episode，且保留首次出现的集标题的 episode
       const filteredEpisodes = filterSameEpisodeTitle(filteredTmpEpisodes);
 
-      log("info", "过滤后的集标题", filteredEpisodes.map(episode => episode.episodeTitle));
+      log("info", "[system] [LogVar-API] 过滤后的集标题", filteredEpisodes.map(episode => episode.episodeTitle));
 
       let targetEpisode = episode;
       if (offsets && offsets[String(season)] !== undefined) {
@@ -1396,7 +1398,7 @@ export async function extractTitleSeasonEpisode(cleanFileName) {
     title = await getTMDBChineseTitle(title.replace('.', ' '), season, episode);
   }
 
-  log("info", "Parsed title, season, episode, year", {title, season, episode, year});
+  log("info", "[system] [Match] Parsed title, season, episode, year", {title, season, episode, year});
   return {title, season, episode, year};
 }
 
@@ -1408,7 +1410,7 @@ export async function matchAnime(url, req, clientIp) {
 
     // 验证请求体是否有效
     if (!body) {
-      log("error", "Request body is empty");
+      log("error", "[system] [Match] Request body is empty");
       return jsonResponse(
         { errorCode: 400, success: false, errorMessage: "Empty request body" },
         400
@@ -1419,7 +1421,7 @@ export async function matchAnime(url, req, clientIp) {
     // 假设请求体包含一个字段，比如 { query: "anime name" }
     const { fileName } = body;
     if (!fileName) {
-      log("error", "Missing fileName parameter in request body");
+      log("error", "[system] [Match] Missing fileName parameter in request body");
       return jsonResponse(
         { errorCode: 400, success: false, errorMessage: "Missing fileName parameter" },
         400
@@ -1428,8 +1430,8 @@ export async function matchAnime(url, req, clientIp) {
 
     // 解析fileName，提取平台偏好
     const { cleanFileName, preferredPlatform } = parseFileName(fileName);
-    log("info", `Processing anime match for query: ${fileName}`);
-    log("info", `Parsed cleanFileName: ${cleanFileName}, preferredPlatform: ${preferredPlatform}`);
+    log("info", `[system] [Match] Processing anime match for query: ${fileName}`);
+    log("info", `[system] [Match] Parsed cleanFileName: ${cleanFileName}, preferredPlatform: ${preferredPlatform}`);
 
     let {title, season, episode, year} = await extractTitleSeasonEpisode(cleanFileName);
 
@@ -1438,20 +1440,20 @@ export async function matchAnime(url, req, clientIp) {
       const mappedTitle = globals.titleMappingTable.get(title);
       if (mappedTitle) {
         title = mappedTitle;
-        log("info", `Title mapped from original: ${url.searchParams.get("keyword")} to: ${title}`);
+        log("info", `[system] [Match] Title mapped from original: ${url.searchParams.get("keyword")} to: ${title}`);
       }
     }
 
     // 如果启用了搜索关键字繁转简，则进行转换
     if (globals.animeTitleSimplified) {
       const simplifiedTitle = simplized(title);
-      log("info", `matchAnime converted traditional to simplified: ${title} -> ${simplifiedTitle}`);
+      log("info", `[system] [Match] matchAnime converted traditional to simplified: ${title} -> ${simplifiedTitle}`);
       title = simplifiedTitle;
     }
 
     // 获取 prefer animeId（按 season 维度）
     const [preferAnimeId, preferSource, offsets] = getPreferAnimeId(title, season);
-    log("info", `prefer animeId: ${preferAnimeId} from ${preferSource}`);
+    log("info", `[system] [Match] prefer animeId: ${preferAnimeId} from ${preferSource}`);
 
     // 根据指定平台创建动态平台顺序
     const dynamicPlatformOrder = createDynamicPlatformOrder(preferredPlatform);
@@ -1461,7 +1463,7 @@ export async function matchAnime(url, req, clientIp) {
     let originSearchUrl = new URL(req.url.replace("/match", `/search/anime?keyword=${title}&season=${season || ''}&episode=${episode || ''}`));
     const searchRes = await searchAnime(originSearchUrl, preferAnimeId, preferSource, requestAnimeDetailsMap, targetPlatform);
     const searchData = await searchRes.json();
-    log("info", `searchData: ${searchData.animes}`);
+    log("info", `[system] [Match] searchData: ${searchData.animes}`);
 
     let resAnime;
     let resEpisode;
@@ -1474,9 +1476,9 @@ export async function matchAnime(url, req, clientIp) {
       "matches": []
     };
 
-    log("info", `Original platformOrderArr: ${globals.platformOrderArr}`);
-    log("info", `Dynamic platformOrder: ${dynamicPlatformOrder}`);
-    log("info", `Preferred platform: ${preferredPlatform || 'none'}`);
+    log("info", `[system] [Match] Original platformOrderArr: ${globals.platformOrderArr}`);
+    log("info", `[system] [Match] Dynamic platformOrder: ${dynamicPlatformOrder}`);
+    log("info", `[system] [Match] Preferred platform: ${preferredPlatform || 'none'}`);
 
     // 尝试使用AI进行匹配
     const aiMatchResult = await matchAniAndEpByAi(season, episode, year, searchData, title, req, dynamicPlatformOrder, preferAnimeId, requestAnimeDetailsMap);
@@ -1484,7 +1486,7 @@ export async function matchAnime(url, req, clientIp) {
       resAnime = aiMatchResult.resAnime;
       resEpisode = aiMatchResult.resEpisode;
       resData["isMatched"] = true;
-      log("info", `AI match found: ${resAnime.animeTitle}; episode: ${resEpisode.episodeTitle}`);
+      log("info", `[system] [Match] AI match found: ${resAnime.animeTitle}; episode: ${resEpisode.episodeTitle}`);
     } else {
       // AI匹配失败或未配置，使用传统匹配方式
       for (const platform of dynamicPlatformOrder) {
@@ -1494,7 +1496,7 @@ export async function matchAnime(url, req, clientIp) {
 
         if (resAnime) {
           resData["isMatched"] = true;
-          log("info", `Found match with platform: ${platform || 'default'}`);
+          log("info", `[system] [Match] Found match with platform: ${platform || 'default'}`);
           break;
         }
       }
@@ -1525,13 +1527,13 @@ export async function matchAnime(url, req, clientIp) {
       ]
     }
 
-    log("info", `resMatchData: ${resData}`);
+    log("info", `[system] [Match] resMatchData: ${resData}`);
 
     // 示例返回
     return jsonResponse(resData);
   } catch (error) {
     // 处理 JSON 解析错误或其他异常
-    log("error", `Failed to parse request body: ${error.message}`);
+    log("error", `[system] [Match] Failed to parse request body: ${error.message}`);
     return jsonResponse(
       { errorCode: 400, success: false, errorMessage: "Invalid JSON body" },
       400
@@ -1547,14 +1549,14 @@ export async function searchEpisodes(url) {
   // 如果启用了搜索关键字繁转简，则进行转换
   if (globals.animeTitleSimplified) {
     const simplifiedTitle = simplized(anime);
-    log("info", `searchEpisodes converted traditional to simplified: ${anime} -> ${simplifiedTitle}`);
+    log("info", `[system] [Episodes] searchEpisodes converted traditional to simplified: ${anime} -> ${simplifiedTitle}`);
     anime = simplifiedTitle;
   }
 
-  log("info", `Search episodes with anime: ${anime}, episode: ${episode}`);
+  log("info", `[system] [Episodes] Search episodes with anime: ${anime}, episode: ${episode}`);
 
   if (!anime) {
-    log("error", "Missing anime parameter");
+    log("error", "[system] [Episodes] Missing anime parameter");
     return jsonResponse(
       { errorCode: 400, success: false, errorMessage: "Missing anime parameter" },
       400
@@ -1569,7 +1571,7 @@ export async function searchEpisodes(url) {
   const searchData = await searchRes.json();
 
   if (!searchData.success || !searchData.animes || searchData.animes.length === 0) {
-    log("info", "No anime found for the given title");
+    log("info", "[system] [Episodes] No anime found for the given title");
     return jsonResponse({
       errorCode: 0,
       success: true,
@@ -1636,7 +1638,7 @@ export async function searchEpisodes(url) {
     }
   }
 
-  log("info", `Found ${resultAnimes.length} animes with filtered episodes`);
+  log("info", `[system] [Episodes] Found ${resultAnimes.length} animes with filtered episodes`);
 
   return jsonResponse({
     errorCode: 0,
@@ -1654,7 +1656,7 @@ export async function getBangumi(path, detailStore = null, source = null) {
     resolveAnimeById(idParam);
 
   if (!anime) {
-    log("error", `Anime with ID ${idParam} not found`);
+    log("error", `[system] [Bangumi] Anime with ID ${idParam} not found`);
     return jsonResponse(
       { errorCode: 404, success: false, errorMessage: "Anime not found", bangumi: null },
       404
@@ -1664,7 +1666,7 @@ export async function getBangumi(path, detailStore = null, source = null) {
 }
 
 function buildBangumiData(anime, idParam = "") {
-  log("info", `Fetched details for anime ID: ${idParam || anime.bangumiId}`);
+  log("info", `[system] [Bangumi] Fetched details for anime ID: ${idParam || anime.bangumiId}`);
 
   // 构建 episodes 列表
   let episodesList = [];
@@ -1684,11 +1686,11 @@ function buildBangumiData(anime, idParam = "") {
     episodesList = episodesList.filter(episode => {
       return !globals.episodeTitleFilter.test(episode.episodeTitle);
     });
-    log("info", `[getBangumi] Episode filter enabled. Filtered episodes: ${episodesList.length}/${anime.links.length}`);
+    log("info", `[system] [getBangumi] Episode filter enabled. Filtered episodes: ${episodesList.length}/${anime.links.length}`);
 
     // 如果过滤后没有有效剧集，返回错误
     if (episodesList.length === 0) {
-      log("warn", `[getBangumi] No valid episodes after filtering for anime ID ${idParam || anime.bangumiId}`);
+      log("warn", `[system] [getBangumi] No valid episodes after filtering for anime ID ${idParam || anime.bangumiId}`);
       return {
         errorCode: 404,
         success: false,
@@ -1806,7 +1808,7 @@ async function fetchMergedComments(url, animeTitle, commentId) {
     }
 
     // 定义请求任务
-    const fetchTask = (async () => {
+    const fetchTask = sourceLogContext.run(toLogSourceName(sourceName), async () => {
         let sourceInstance = null;
 
         if (sourceName === 'renren') sourceInstance = renrenSource;
@@ -1832,6 +1834,7 @@ async function fetchMergedComments(url, animeTitle, commentId) {
             // 获取原始数据 -> 格式化
             const raw = await sourceInstance.getEpisodeDanmu(realId, parts);
             const formatted = sourceInstance.formatComments(raw);
+            log("info", `[${sourceLabel}] 获取弹幕 ${formatted.length} 条`);
             
             // 给合并工具里的每一条弹幕打上独立的原始源标签
             if (formatted && Array.isArray(formatted)) {
@@ -1849,7 +1852,7 @@ async function fetchMergedComments(url, animeTitle, commentId) {
           }
         }
         return [];
-    })();
+    });
 
     // 将任务加入队列
     PENDING_DANMAKU_REQUESTS.set(pendingKey, fetchTask);
@@ -1921,14 +1924,14 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
   let title = findTitleById(commentId);
   let plat = title ? (title.match(/【(.*?)】/) || [null])[0]?.replace(/[【】]/g, '') : null;
   const shouldAttachDuration = shouldIncludeVideoDuration(queryFormat, includeDuration);
-  log("info", "comment url...", url);
-  log("info", "comment title...", title);
-  log("info", "comment platform...", plat);
+  log("info", "[system] [LogVar-API] comment url...", url);
+  log("info", "[system] [LogVar-API] comment title...", title);
+  log("info", "[system] [LogVar-API] comment platform...", plat);
   if (!url) {
-    log("error", `Comment with ID ${commentId} not found`);
+    log("error", `[system] [LogVar-API] Comment with ID ${commentId} not found`);
     return jsonResponse({ count: 0, comments: [] }, 404);
   }
-  log("info", `Fetched comment ID: ${commentId}`);
+  log("info", `[system] [LogVar-API] Fetched comment ID: ${commentId}`);
 
   // 检查弹幕缓存
   const cachedComments = getCommentCache(url);
@@ -1940,7 +1943,7 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
     return formatDanmuResponse(responseData, queryFormat);
   }
 
-  log("info", "开始从本地请求弹幕...", url);
+  log("info", "[system] [LogVar-API] 开始从本地请求弹幕...", url);
   let danmus = [];
   const durationPromise = shouldAttachDuration ? resolveMergedDuration(url) : null;
 
@@ -1948,54 +1951,54 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
     danmus = await fetchMergedComments(url, animeTitle, commentId);
   } else {
     if (url.includes('.qq.com')) {
-      danmus = await tencentSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('tencent', () => tencentSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.iqiyi.com')) {
-      danmus = await iqiyiSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('iqiyi', () => iqiyiSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.mgtv.com')) {
-      danmus = await mangoSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('mango', () => mangoSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.bilibili.com') || url.includes('b23.tv')) {
       // 如果是 b23.tv 短链接，先解析为完整 URL
       if (url.includes('b23.tv')) {
-        url = await bilibiliSource.resolveB23Link(url);
+        url = await sourceLogContext.run('bilibili', () => bilibiliSource.resolveB23Link(url));
       }
-      danmus = await bilibiliSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('bilibili', () => bilibiliSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.youku.com')) {
-      danmus = await youkuSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('youku', () => youkuSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.miguvideo.com')) {
-      danmus = await miguSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('migu', () => miguSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.sohu.com')) {
-      danmus = await sohuSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('sohu', () => sohuSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.le.com')) {
-      danmus = await leshiSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('leshi', () => leshiSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.douyin.com') || url.includes('.ixigua.com')) {
-      danmus = await xiguaSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('xigua', () => xiguaSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.mddcloud.com.cn')) {
-      danmus = await maiduiduiSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('maiduidui', () => maiduiduiSource.getComments(url, plat, segmentFlag));
     } else if (url.includes('.yfsp.tv')) {
-      danmus = await aiyifanSource.getComments(url, plat, segmentFlag);
+      danmus = await sourceLogContext.run('aiyifan', () => aiyifanSource.getComments(url, plat, segmentFlag));
     }
 
     // 请求其他平台弹幕
     const urlPattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(\/.*)?$/i;
     if (!urlPattern.test(url)) {
       if (plat === "renren") {
-        danmus = await renrenSource.getComments(url, plat, segmentFlag);
+        danmus = await sourceLogContext.run('renren', () => renrenSource.getComments(url, plat, segmentFlag));
       } else if (plat === "hanjutv") {
-        danmus = await hanjutvSource.getComments(url, plat, segmentFlag);
+        danmus = await sourceLogContext.run('hanjutv', () => hanjutvSource.getComments(url, plat, segmentFlag));
       } else if (plat === "bahamut") {
-        danmus = await bahamutSource.getComments(url, plat, segmentFlag);
+        danmus = await sourceLogContext.run('bahamut', () => bahamutSource.getComments(url, plat, segmentFlag));
       } else if (plat === "dandan") {
-        danmus = await dandanSource.getComments(url, plat, segmentFlag);
+        danmus = await sourceLogContext.run('dandan', () => dandanSource.getComments(url, plat, segmentFlag));
       } else if (plat === "custom") {
-        danmus = await customSource.getComments(url, plat, segmentFlag);
+        danmus = await sourceLogContext.run('custom', () => customSource.getComments(url, plat, segmentFlag));
       } else if (plat === "animeko") {
-        danmus = await animekoSource.getComments(url, plat, segmentFlag);
+        danmus = await sourceLogContext.run('animeko', () => animekoSource.getComments(url, plat, segmentFlag));
       }
     }
 
     // 如果弹幕为空，则请求第三方弹幕服务器作为兜底
     if ((!danmus || danmus.length === 0) && urlPattern.test(url)) {
-      danmus = await otherSource.getComments(url, "other_server", segmentFlag);
+      danmus = await sourceLogContext.run('other', () => otherSource.getComments(url, "other_server", segmentFlag));
     }
   }
 
@@ -2011,14 +2014,14 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
         lastTitle = lastSearch.title;
         lastSeason = lastSearch.season;
         offset = `${lastSearch.episode}:${episodeTitle}`;
-        log("info", `Calculated episode offset for IP ${clientIp}: Query E${lastSearch.episode}, Selected ${episodeTitle} -> Offset ${offset} (Season ${lastSeason})`);
+        log("info", `[system] [LogVar-API] Calculated episode offset for IP ${clientIp}: Query E${lastSearch.episode}, Selected ${episodeTitle} -> Offset ${offset} (Season ${lastSeason})`);
       }
     }
 
-    log("info", `animeTitle：${animeTitle}; lastTitle：${lastTitle}; titleMatches：${titleMatches(animeTitle, lastTitle)}`)
+    log("info", `[system] [LogVar-API] animeTitle：${animeTitle}; lastTitle：${lastTitle}; titleMatches：${titleMatches(animeTitle, lastTitle)}`);
 
     if (titleMatches(animeTitle, lastTitle)) {
-      log("info", `excute setPreferByAnimeId`)
+      log("info", `[system] [LogVar-API] excute setPreferByAnimeId`);
       setPreferByAnimeId(animeId, source, lastSeason, offset);
     }
 
@@ -2026,7 +2029,7 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
         writeCacheToFile('lastSelectMap', JSON.stringify(Object.fromEntries(globals.lastSelectMap)));
     }
     if (globals.redisValid && animeId) {
-        setRedisKey('lastSelectMap', globals.lastSelectMap).catch(e => log("error", "Redis set error", e));
+        setRedisKey('lastSelectMap', globals.lastSelectMap).catch(e => log("error", "[system] [LogVar-API] Redis set error", e));
     }
     if (globals.localRedisValid && animeId) {
         setLocalRedisKey('lastSelectMap', globals.lastSelectMap);
@@ -2046,7 +2049,7 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
     const offset = offsetRule?.offset || 0;
     if (offset !== 0) {
       const videoDuration = offsetRule?.usePercent ? await resolveUrlDuration(url) : 0;
-      log("info", `Applying danmu offset: ${offset}${offsetRule?.usePercent ? '%' : 's'} for ${baseTitle}/${seasonStr}/${episodeStr}${offsetRule?.usePercent ? `, duration=${videoDuration}s` : ''}`);
+      log("info", `[system] [LogVar-API] Applying danmu offset: ${offset}${offsetRule?.usePercent ? '%' : 's'} for ${baseTitle}/${seasonStr}/${episodeStr}${offsetRule?.usePercent ? `, duration=${videoDuration}s` : ''}`);
       danmus = applyOffset(danmus, offset, {
         usePercent: offsetRule?.usePercent,
         videoDuration
@@ -2075,7 +2078,7 @@ export async function getCommentByUrl(videoUrl, queryFormat, segmentFlag, includ
   try {
     // 验证URL参数
     if (!videoUrl || typeof videoUrl !== 'string') {
-      log("error", "Missing or invalid url parameter");
+      log("error", "[system] [LogVar-API] Missing or invalid url parameter");
       return jsonResponse(
         { errorCode: 400, success: false, errorMessage: "Missing or invalid url parameter", count: 0, comments: [] },
         400
@@ -2086,14 +2089,14 @@ export async function getCommentByUrl(videoUrl, queryFormat, segmentFlag, includ
 
     // 验证URL格式
     if (!videoUrl.startsWith('http')) {
-      log("error", "Invalid url format, must start with http or https");
+      log("error", "[system] [LogVar-API] Invalid url format, must start with http or https");
       return jsonResponse(
         { errorCode: 400, success: false, errorMessage: "Invalid url format, must start with http or https", count: 0, comments: [] },
         400
       );
     }
 
-    log("info", `Processing comment request for URL: ${videoUrl}`);
+    log("info", `[system] [LogVar-API] Processing comment request for URL: ${videoUrl}`);
 
     let url = videoUrl;
     const shouldAttachDuration = shouldIncludeVideoDuration(queryFormat, includeDuration);
@@ -2110,46 +2113,46 @@ export async function getCommentByUrl(videoUrl, queryFormat, segmentFlag, includ
       return formatDanmuResponse(responseData, queryFormat);
     }
 
-    log("info", "开始从本地请求弹幕...", url);
+    log("info", "[system] [LogVar-API] 开始从本地请求弹幕...", url);
     let danmus = [];
     const durationPromise = shouldAttachDuration ? resolveMergedDuration(url) : null;
 
     // 根据URL域名判断平台并获取弹幕
     if (url.includes('.qq.com')) {
-      danmus = await tencentSource.getComments(url, "qq", segmentFlag);
+      danmus = await sourceLogContext.run('tencent', () => tencentSource.getComments(url, "qq", segmentFlag));
     } else if (url.includes('.iqiyi.com')) {
-      danmus = await iqiyiSource.getComments(url, "qiyi", segmentFlag);
+      danmus = await sourceLogContext.run('iqiyi', () => iqiyiSource.getComments(url, "qiyi", segmentFlag));
     } else if (url.includes('.mgtv.com')) {
-      danmus = await mangoSource.getComments(url, "imgo", segmentFlag);
+      danmus = await sourceLogContext.run('mango', () => mangoSource.getComments(url, "imgo", segmentFlag));
     } else if (url.includes('.bilibili.com') || url.includes('b23.tv')) {
       // 如果是 b23.tv 短链接，先解析为完整 URL
       if (url.includes('b23.tv')) {
-        url = await bilibiliSource.resolveB23Link(url);
+        url = await sourceLogContext.run('bilibili', () => bilibiliSource.resolveB23Link(url));
       }
-      danmus = await bilibiliSource.getComments(url, "bilibili1", segmentFlag);
+      danmus = await sourceLogContext.run('bilibili', () => bilibiliSource.getComments(url, "bilibili1", segmentFlag));
     } else if (url.includes('.youku.com')) {
-      danmus = await youkuSource.getComments(url, "youku", segmentFlag);
+      danmus = await sourceLogContext.run('youku', () => youkuSource.getComments(url, "youku", segmentFlag));
     } else if (url.includes('.miguvideo.com')) {
-      danmus = await miguSource.getComments(url, "migu", segmentFlag);
+      danmus = await sourceLogContext.run('migu', () => miguSource.getComments(url, "migu", segmentFlag));
     } else if (url.includes('.sohu.com')) {
-      danmus = await sohuSource.getComments(url, "sohu", segmentFlag);
+      danmus = await sourceLogContext.run('sohu', () => sohuSource.getComments(url, "sohu", segmentFlag));
     } else if (url.includes('.le.com')) {
-      danmus = await leshiSource.getComments(url, "leshi", segmentFlag);
+      danmus = await sourceLogContext.run('leshi', () => leshiSource.getComments(url, "leshi", segmentFlag));
     } else if (url.includes('.douyin.com') || url.includes('.ixigua.com')) {
-      danmus = await xiguaSource.getComments(url, "xigua", segmentFlag);
+      danmus = await sourceLogContext.run('xigua', () => xiguaSource.getComments(url, "xigua", segmentFlag));
     } else if (url.includes('.mddcloud.com.cn')) {
-      danmus = await maiduiduiSource.getComments(url, "maiduidui", segmentFlag);
+      danmus = await sourceLogContext.run('maiduidui', () => maiduiduiSource.getComments(url, "maiduidui", segmentFlag));
     } else if (url.includes('.yfsp.tv')) {
-      danmus = await aiyifanSource.getComments(url, "aiyifan", segmentFlag);
+      danmus = await sourceLogContext.run('aiyifan', () => aiyifanSource.getComments(url, "aiyifan", segmentFlag));
     } else {
       // 如果不是已知平台，尝试第三方弹幕服务器
       const urlPattern = /^(https?:\/\/)?([\w.-]+)\.([a-z]{2,})(\/.*)?$/i;
       if (urlPattern.test(url)) {
-        danmus = await otherSource.getComments(url, "other_server", segmentFlag);
+        danmus = await sourceLogContext.run('other', () => otherSource.getComments(url, "other_server", segmentFlag));
       }
     }
 
-    log("info", `Successfully fetched ${danmus.length} comments from URL`);
+    log("info", `[system] [LogVar-API] Successfully fetched ${danmus.length} comments from URL`);
 
     // 缓存弹幕结果
     if (danmus.length > 0) {
@@ -2166,7 +2169,7 @@ export async function getCommentByUrl(videoUrl, queryFormat, segmentFlag, includ
     return formatDanmuResponse(responseData, queryFormat);
   } catch (error) {
     // 处理异常
-    log("error", `Failed to process comment by URL request: ${error.message}`);
+    log("error", `[system] [LogVar-API] Failed to process comment by URL request: ${error.message}`);
     return jsonResponse(
       { errorCode: 500, success: false, errorMessage: "Internal server error", count: 0, comments: [] },
       500
@@ -2182,7 +2185,7 @@ export async function getSegmentComment(segment, queryFormat) {
 
     // 验证URL参数
     if (!url || typeof url !== 'string') {
-      log("error", "Missing or invalid url parameter");
+      log("error", "[system] [SegmentComment] Missing or invalid url parameter");
       return jsonResponse(
         { errorCode: 400, success: false, errorMessage: "Missing or invalid url parameter", count: 0, comments: [] },
         400
@@ -2191,7 +2194,7 @@ export async function getSegmentComment(segment, queryFormat) {
 
     url = url.trim();
 
-    log("info", `Processing segment comment request for URL: ${url}`);
+    log("info", `[system] [SegmentComment] Processing segment comment request for URL: ${url}`);
 
     // 检查弹幕缓存
     const cachedComments = getCommentCache(url);
@@ -2206,49 +2209,49 @@ export async function getSegmentComment(segment, queryFormat) {
       return formatDanmuResponse(responseData, queryFormat);
     }
 
-    log("info", `开始从本地请求分段弹幕... URL: ${url}`);
+    log("info", `[system] [SegmentComment] 开始从本地请求分段弹幕... URL: ${url}`);
     let danmus = [];
 
     // 根据平台调用相应的分段弹幕获取方法
     if (platform === "qq") {
-      danmus = await tencentSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('tencent', () => tencentSource.getSegmentComments(segment));
     } else if (platform === "qiyi") {
-      danmus = await iqiyiSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('iqiyi', () => iqiyiSource.getSegmentComments(segment));
     } else if (platform === "imgo") {
-      danmus = await mangoSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('mango', () => mangoSource.getSegmentComments(segment));
     } else if (platform === "bilibili1") {
-      danmus = await bilibiliSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('bilibili', () => bilibiliSource.getSegmentComments(segment));
     } else if (platform === "youku") {
-      danmus = await youkuSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('youku', () => youkuSource.getSegmentComments(segment));
     } else if (platform === "migu") {
-      danmus = await miguSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('migu', () => miguSource.getSegmentComments(segment));
     } else if (platform === "sohu") {
-      danmus = await sohuSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('sohu', () => sohuSource.getSegmentComments(segment));
     } else if (platform === "leshi") {
-      danmus = await leshiSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('leshi', () => leshiSource.getSegmentComments(segment));
     } else if (platform === "xigua") {
-      danmus = await xiguaSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('xigua', () => xiguaSource.getSegmentComments(segment));
     } else if (platform === "maiduidui") {
-      danmus = await maiduiduiSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('maiduidui', () => maiduiduiSource.getSegmentComments(segment));
     } else if (platform === "aiyifan") {
-      danmus = await aiyifanSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('aiyifan', () => aiyifanSource.getSegmentComments(segment));
     } else if (platform === "hanjutv") {
-      danmus = await hanjutvSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('hanjutv', () => hanjutvSource.getSegmentComments(segment));
     } else if (platform === "bahamut") {
-      danmus = await bahamutSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('bahamut', () => bahamutSource.getSegmentComments(segment));
     } else if (platform === "renren") {
-      danmus = await renrenSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('renren', () => renrenSource.getSegmentComments(segment));
     } else if (platform === "dandan") {
-      danmus = await dandanSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('dandan', () => dandanSource.getSegmentComments(segment));
     } else if (platform === "animeko") {
-      danmus = await animekoSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('animeko', () => animekoSource.getSegmentComments(segment));
     } else if (platform === "custom") {
-      danmus = await customSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('custom', () => customSource.getSegmentComments(segment));
     } else if (platform === "other_server") {
-      danmus = await otherSource.getSegmentComments(segment);
+      danmus = await sourceLogContext.run('other', () => otherSource.getSegmentComments(segment));
     }
 
-    log("info", `Successfully fetched ${danmus.length} segment comments from URL`);
+    log("info", `[system] [SegmentComment] Successfully fetched ${danmus.length} segment comments from URL`);
 
     // 缓存弹幕结果
     if (danmus.length > 0) {
@@ -2265,7 +2268,7 @@ export async function getSegmentComment(segment, queryFormat) {
     return formatDanmuResponse(responseData, queryFormat);
   } catch (error) {
     // 处理异常
-    log("error", `Failed to process segment comment request: ${error.message}`);
+    log("error", `[system] [SegmentComment] Failed to process segment comment request: ${error.message}`);
     return jsonResponse(
       { errorCode: 500, success: false, errorMessage: "Internal server error", count: 0, comments: [] },
       500

--- a/danmu_api/apis/env-api.js
+++ b/danmu_api/apis/env-api.js
@@ -1,4 +1,5 @@
 import { jsonResponse } from '../utils/http-util.js';
+import { log } from '../utils/log-util.js';
 import { HandlerFactory } from '../configs/handlers/handler-factory.js';
 import { globals } from '../configs/globals.js';
 import AIClient from '../utils/ai-util.js';
@@ -29,7 +30,7 @@ export async function handleSetEnv(request) {
       return jsonResponse({ success: false, message: `环境变量 ${key} 设置失败` }, 500);
     }
   } catch (error) {
-    console.error('设置环境变量失败:', error);
+    log("error", "[system] [Server] 设置环境变量失败:", error);
     return jsonResponse({ success: false, message: `设置环境变量失败: ${error.message}` }, 500);
   }
 }
@@ -60,7 +61,7 @@ export async function handleAddEnv(request) {
       return jsonResponse({ success: false, message: `环境变量 ${key} 添加失败` }, 500);
     }
   } catch (error) {
-    console.error('添加环境变量失败:', error);
+    log("error", "[system] [Server] 添加环境变量失败:", error);
     return jsonResponse({ success: false, message: `添加环境变量失败: ${error.message}` }, 500);
   }
 }
@@ -91,7 +92,7 @@ export async function handleDelEnv(request) {
       return jsonResponse({ success: false, message: `环境变量 ${key} 删除失败` }, 500);
     }
   } catch (error) {
-    console.error('删除环境变量失败:', error);
+    log("error", "[system] [Server] 删除环境变量失败:", error);
     return jsonResponse({ success: false, message: `删除环境变量失败: ${error.message}` }, 500);
   }
 }
@@ -141,7 +142,7 @@ export async function handleAiVerify(request) {
       }, 200);
     }
   } catch (error) {
-    console.error('AI 连通性验证失败:', error);
+    log("error", "[system] [Server] AI 连通性验证失败:", error);
     return jsonResponse({ 
       success: false, 
       ok: false,

--- a/danmu_api/apis/system-api.js
+++ b/danmu_api/apis/system-api.js
@@ -89,32 +89,32 @@ export function handleConfig(hasPermission = false) {
 export async function handleDeploy() {
   try {
     const deployPlatform = globals.deployPlatform;
-    log("info", `[server] Deployment request received for platform: ${deployPlatform}`);
+    log("info", `[system] [Server] Deployment request received for platform: ${deployPlatform}`);
     
     // 如果是 Node 部署，直接返回成功，因为 Node 环境不需要重新部署
     if (deployPlatform.toLowerCase() === 'node') {
-      log("info", `[server] Node/Docker deployment - no redeployment needed, config changes take effect automatically`);
+      log("info", `[system] [Server] Node/Docker deployment - no redeployment needed, config changes take effect automatically`);
       return jsonResponse({ success: true, message: "Node/Docker deployment - configuration changes take effect automatically" }, 200);
     }
     
     // 对于其他平台（如 Cloudflare、Vercel、Netlify 等），使用相应的 Handler 触发部署
     const handler = await HandlerFactory.getHandler(deployPlatform);
     if (!handler) {
-      log("error", `[server] No handler found for platform: ${deployPlatform}`);
+      log("error", `[system] [Server] No handler found for platform: ${deployPlatform}`);
       return jsonResponse({ success: false, message: `No handler found for platform: ${deployPlatform}` }, 400);
     }
     
     // 调用 handler 的 deploy 方法
     const deployResult = await handler.deploy();
     if (deployResult) {
-      log("info", `[server] Deployment triggered successfully for platform: ${deployPlatform}`);
+      log("info", `[system] [Server] Deployment triggered successfully for platform: ${deployPlatform}`);
       return jsonResponse({ success: true, message: "Deployment triggered successfully" }, 200);
     } else {
-      log("error", `[server] Failed to trigger deployment for platform: ${deployPlatform}`);
+      log("error", `[system] [Server] Failed to trigger deployment for platform: ${deployPlatform}`);
       return jsonResponse({ success: false, message: "Failed to trigger deployment" }, 500);
     }
   } catch (error) {
-    log("error", `[server] Deployment error: ${error.message}`);
+    log("error", `[system] [Server] Deployment error: ${error.message}`);
     return jsonResponse({ success: false, message: `Deployment failed: ${error.message}` }, 500);
   }
 }
@@ -180,14 +180,14 @@ export async function handleClearCache() {
       // 触发异步数据重载
       if (globals.useBangumiData) {
         initBangumiData(globals.deployPlatform, false).catch(e => {
-          log("warn", `[server] Bangumi-Data background reload failed: ${e.message}`);
+          log("warn", `[system] [Server] Bangumi-Data background reload failed: ${e.message}`);
         });
       }
     } catch (e) {
-      log("error", `[server] Failed to clear Bangumi-Data cache: ${e.message}`);
+      log("error", `[system] [Server] Failed to clear Bangumi-Data cache: ${e.message}`);
     }
     
-    log("info", `[server] Memory cache cleared successfully`);
+    log("info", `[system] [Server] Memory cache cleared successfully`);
     
     // 同步清理本地缓存和Redis缓存
     try {
@@ -195,10 +195,10 @@ export async function handleClearCache() {
       if (globals.localCacheValid) {
         const { updateLocalCaches } = await import("../utils/cache-util.js");
         await updateLocalCaches();
-        log("info", `[server] Local cache cleared successfully`);
+        log("info", `[system] [Server] Local cache cleared successfully`);
       }
     } catch (localError) {
-      log("warn", `[server] Local cache may not be available: ${localError.message}`);
+      log("warn", `[system] [Server] Local cache may not be available: ${localError.message}`);
     }
     
     try {
@@ -206,10 +206,10 @@ export async function handleClearCache() {
       if (globals.redisValid) {
         const { updateRedisCaches } = await import("../utils/redis-util.js");
         await updateRedisCaches();
-        log("info", `[server] Redis cache cleared successfully`);
+        log("info", `[system] [Server] Redis cache cleared successfully`);
       }
     } catch (redisError) {
-      log("warn", `[server] Redis may not be available: ${redisError.message}`);
+      log("warn", `[system] [Server] Redis may not be available: ${redisError.message}`);
     }
 
     try {
@@ -217,13 +217,13 @@ export async function handleClearCache() {
       if (globals.localRedisValid) {
         const { updateLocalRedisCaches } = await import("../utils/local-redis-util.js");
         await updateLocalRedisCaches();
-        log("info", `[server] LocalRedis cache cleared successfully`);
+        log("info", `[system] [Server] LocalRedis cache cleared successfully`);
       }
     } catch (redisError) {
-      log("warn", `[server] LocalRedis may not be available: ${redisError.message}`);
+      log("warn", `[system] [Server] LocalRedis may not be available: ${redisError.message}`);
     }
     
-    log("info", `[server] All caches cleared successfully`);
+    log("info", `[system] [Server] All caches cleared successfully`);
     return jsonResponse({ success: true, message: "Cache cleared successfully", clearedItems: {
       animes: 0,
       episodeIds: 0,
@@ -236,7 +236,7 @@ export async function handleClearCache() {
       todayReqNum: 0
     }}, 200);
   } catch (error) {
-    log("error", `[server] Cache clear failed: ${error.message}`);
+    log("error", `[system] [Server] Cache clear failed: ${error.message}`);
     return jsonResponse({ success: false, message: `Cache clear failed: ${error.message}` }, 500);
   }
 }
@@ -310,7 +310,7 @@ export function handleCacheAnimes() {
 
     return jsonResponse({ success: true, data: formattedData }, 200);
   } catch (error) {
-    log("error", `[server] Fetch cache animes failed: ${error.message}`);
+    log("error", `[system] [Server] Fetch cache animes failed: ${error.message}`);
     return jsonResponse({ success: false, message: `获取缓存失败: ${error.message}` }, 500);
   }
 }

--- a/danmu_api/configs/handlers/base-handler.js
+++ b/danmu_api/configs/handlers/base-handler.js
@@ -22,7 +22,7 @@ export default class BaseHandler {
     // 重新初始化全局配置
     globals.reInit();
 
-    log("info", `[server] ✓ Environment variable updated successfully: ${key}`);
+    log("info", `[system] [Server] ✓ Environment variable updated successfully: ${key}`);
     return true;
   }
 
@@ -38,7 +38,7 @@ export default class BaseHandler {
     // 重新初始化全局配置
     globals.reInit();
 
-    log("info", `[server] ✓ Environment variable deleted successfully: ${key}`);
+    log("info", `[system] [Server] ✓ Environment variable deleted successfully: ${key}`);
     return true;
   }
 

--- a/danmu_api/configs/handlers/cloudflare-handler.js
+++ b/danmu_api/configs/handlers/cloudflare-handler.js
@@ -60,7 +60,7 @@ export class CloudflareHandler extends BaseHandler {
       // 获取所有环境变量
       const envs = await this._getAllEnvs(globals.deployPlatformAccount, globals.deployPlatformProject, globals.deployPlatformToken);
       if (envs === null) {
-        log("error", '[server] ✗ Failed to set environment variable: envs is null');
+        log("error", '[system] [Server] ✗ Failed to set environment variable: envs is null');
         return;
       }
 
@@ -82,7 +82,7 @@ export class CloudflareHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to set environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to set environment variable:', error.message);
     }
   }
 
@@ -102,13 +102,13 @@ export class CloudflareHandler extends BaseHandler {
       await this._getAllEnvs(accountId, projectId, token);
       return true;
     } catch (error) {
-      log("error", 'checkParams failed! accountId, projectId or token is not valid:', error.message);
+      log("error", '[system] [Server] checkParams failed! accountId, projectId or token is not valid:', error.message);
       return false;
     }
   }
 
   async deploy() {
-    log("log", 'After modifying the environment variables on the cloudflare platform, it will be automatically deployed.');
+    log("info", '[system] [Server] After modifying the environment variables on the cloudflare platform, it will be automatically deployed.');
     return true;
   }
 }

--- a/danmu_api/configs/handlers/edgeone-handler.js
+++ b/danmu_api/configs/handlers/edgeone-handler.js
@@ -50,7 +50,7 @@ export class EdgeoneHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to set environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to set environment variable:', error.message);
     }
   }
 
@@ -72,7 +72,7 @@ export class EdgeoneHandler extends BaseHandler {
 
       return this.delLocalEnv(key);
     } catch (error) {
-      log("error", '[server] ✗ Failed to del environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to del environment variable:', error.message);
     }
   }
 
@@ -81,7 +81,7 @@ export class EdgeoneHandler extends BaseHandler {
       await this._getAllEnvs(projectId, token);
       return true;
     } catch (error) {
-      log("error", 'checkParams failed! accountId, projectId or token is not valid:', error.message);
+      log("error", '[system] [Server] checkParams failed! accountId, projectId or token is not valid:', error.message);
       return false;
     }
   }
@@ -99,12 +99,12 @@ export class EdgeoneHandler extends BaseHandler {
 
       const res = await this._httpPost(globals.deployPlatformToken, data);
       if (res?.data?.Code !== 0) {
-        log("error", '[server] ✗ Failed to deploy:', JSON.stringify(res?.data));
+        log("error", '[system] [Server] ✗ Failed to deploy:', JSON.stringify(res?.data));
         return false;
       }
       return true;
     } catch (error) {
-      log("error", '[server] ✗ Failed to deploy:', error.message);
+      log("error", '[system] [Server] ✗ Failed to deploy:', error.message);
       return false;
     }
   }

--- a/danmu_api/configs/handlers/huggingface-handler.js
+++ b/danmu_api/configs/handlers/huggingface-handler.js
@@ -45,7 +45,7 @@ export class HuggingfaceHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to set environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to set environment variable:', error.message);
     }
   }
 
@@ -63,7 +63,7 @@ export class HuggingfaceHandler extends BaseHandler {
 
       return this.delLocalEnv(key);
     } catch (error) {
-      log("error", '[server] ✗ Failed to del environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to del environment variable:', error.message);
     }
   }
 
@@ -72,7 +72,7 @@ export class HuggingfaceHandler extends BaseHandler {
       await this._getAllEnvs(accountId, projectId, token);
       return true;
     } catch (error) {
-      log("error", 'checkParams failed! accountId, projectId or token is not valid:', error.message);
+      log("error", '[system] [Server] checkParams failed! accountId, projectId or token is not valid:', error.message);
       return false;
     }
   }
@@ -83,7 +83,7 @@ export class HuggingfaceHandler extends BaseHandler {
       await httpPost(url, undefined, this._getOptions());
       return true;
     } catch (error) {
-      log("error", '[server] ✗ Failed to deploy:', error.message);
+      log("error", '[system] [Server] ✗ Failed to deploy:', error.message);
       return false;
     }
   }

--- a/danmu_api/configs/handlers/netlify-handler.js
+++ b/danmu_api/configs/handlers/netlify-handler.js
@@ -35,7 +35,7 @@ export class NetlifyHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to set environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to set environment variable:', error.message);
     }
   }
 
@@ -56,7 +56,7 @@ export class NetlifyHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to add environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to add environment variable:', error.message);
     }
   }
 
@@ -71,7 +71,7 @@ export class NetlifyHandler extends BaseHandler {
 
       return this.delLocalEnv(key);
     } catch (error) {
-      log("error", '[server] ✗ Failed to add environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to add environment variable:', error.message);
     }
   }
 
@@ -80,7 +80,7 @@ export class NetlifyHandler extends BaseHandler {
       await this._getAllEnvs(accountId, projectId, token);
       return true;
     } catch (error) {
-      log("error", 'checkParams failed! accountId, projectId or token is not valid:', error.message);
+      log("error", '[system] [Server] checkParams failed! accountId, projectId or token is not valid:', error.message);
       return false;
     }
   }
@@ -97,12 +97,12 @@ export class NetlifyHandler extends BaseHandler {
       const res = await httpPost(url, JSON.stringify(data), options);
 
       if (!res?.data?.id) {
-        log("error", '[server] ✗ Failed to deploy:', JSON.stringify(res?.data));
+        log("error", '[system] [Server] ✗ Failed to deploy:', JSON.stringify(res?.data));
         return false;
       }
       return true;
     } catch (error) {
-      log("error", '[server] ✗ Failed to deploy:', error.message);
+      log("error", '[system] [Server] ✗ Failed to deploy:', error.message);
       return false;
     }
   }

--- a/danmu_api/configs/handlers/node-handler.js
+++ b/danmu_api/configs/handlers/node-handler.js
@@ -64,13 +64,13 @@ export class NodeHandler extends BaseHandler {
         }
 
         fs.writeFileSync(envPath, lines.join('\n'), 'utf8');
-        log("info", `[server] Updated ${key} in .env`);
+        log("info", `[system] [Server] Updated ${key} in .env`);
         updated = true;
       }
 
       return updated;
     } catch (error) {
-      log("error", '[server] Error updating configuration:', error.message);
+      log("error", '[system] [Server] Error updating configuration:', error.message);
       throw error;
     }
   }
@@ -79,7 +79,7 @@ export class NodeHandler extends BaseHandler {
    * 设置环境变量并重新初始化全局配置
    */
   async setEnv(key, value) {
-    log("info", '[server] Setting environment variable:', key, '=', value);
+    log("info", '[system] [Server] Setting environment variable:', key, '=', value);
 
     try {
       // 更新配置文件
@@ -91,7 +91,7 @@ export class NodeHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to set environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to set environment variable:', error.message);
     }
   }
 
@@ -127,7 +127,7 @@ export class NodeHandler extends BaseHandler {
         });
 
         fs.writeFileSync(envPath, filteredLines.join('\n'), 'utf8');
-        log("info", `[server] Deleted ${key} from .env`);
+        log("info", `[system] [Server] Deleted ${key} from .env`);
         deleted = true;
       }
 
@@ -137,7 +137,7 @@ export class NodeHandler extends BaseHandler {
 
       return false;
     } catch (error) {
-      log("error", '[server] ✗ Failed to delete environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to delete environment variable:', error.message);
     }
   }
 }

--- a/danmu_api/configs/handlers/vercel-handler.js
+++ b/danmu_api/configs/handlers/vercel-handler.js
@@ -35,7 +35,7 @@ export class VercelHandler extends BaseHandler {
         return null;
       }
     } catch (error) {
-      log("error", '[server] ✗ Failed to _getEevId:', error.message);
+      log("error", '[system] [Server] ✗ Failed to _getEevId:', error.message);
     }
   }
 
@@ -43,7 +43,7 @@ export class VercelHandler extends BaseHandler {
     // 首先获取云端环境变量
     const envItem = await this._getEevId(key);
     if (!envItem) {
-      log("error", '[server] Error setEnv: 没有找到对应的环境变量！');
+      log("error", '[system] [Server] Error setEnv: 没有找到对应的环境变量！');
       return;
     }
 
@@ -63,7 +63,7 @@ export class VercelHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to set environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to set environment variable:', error.message);
     }
   }
 
@@ -88,7 +88,7 @@ export class VercelHandler extends BaseHandler {
 
       return this.updateLocalEnv(key, value);
     } catch (error) {
-      log("error", '[server] ✗ Failed to add environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to add environment variable:', error.message);
     }
   }
 
@@ -96,7 +96,7 @@ export class VercelHandler extends BaseHandler {
     // 首先获取云端环境变量
     const envItem = await this._getEevId(key);
     if (!envItem) {
-      log("error", '[server] Error setEnv: 没有找到对应的环境变量！');
+      log("error", '[system] [Server] Error setEnv: 没有找到对应的环境变量！');
       return;
     }
 
@@ -110,7 +110,7 @@ export class VercelHandler extends BaseHandler {
 
       return this.delLocalEnv(key);
     } catch (error) {
-      log("error", '[server] ✗ Failed to add environment variable:', error.message);
+      log("error", '[system] [Server] ✗ Failed to add environment variable:', error.message);
     }
   }
 
@@ -119,7 +119,7 @@ export class VercelHandler extends BaseHandler {
       await this._getAllEnvs(projectId, token);
       return true;
     } catch (error) {
-      log("error", 'checkParams failed! projectId or token is not valid:', error.message);
+      log("error", '[system] [Server] checkParams failed! projectId or token is not valid:', error.message);
       return false;
     }
   }
@@ -137,7 +137,7 @@ export class VercelHandler extends BaseHandler {
       if (resList?.data && resList?.data?.deployments && resList?.data?.deployments.length > 0) {
         lastestDeployId = resList.data.deployments[0].uid;
       } else {
-        log("error", '[server] ✗ Failed to deploy:', JSON.stringify(resList?.data));
+        log("error", '[system] [Server] ✗ Failed to deploy:', JSON.stringify(resList?.data));
         return false;
       }
 
@@ -155,12 +155,12 @@ export class VercelHandler extends BaseHandler {
       const res = await httpPost(url, JSON.stringify(data), options);
 
       if (!res?.data?.id) {
-        log("error", '[server] ✗ Failed to deploy:', JSON.stringify(res?.data));
+        log("error", '[system] [Server] ✗ Failed to deploy:', JSON.stringify(res?.data));
         return false;
       }
       return true;
     } catch (error) {
-      log("error", '[server] ✗ Failed to deploy:', error.message);
+      log("error", '[system] [Server] ✗ Failed to deploy:', error.message);
       return false;
     }
   }

--- a/danmu_api/sources/aiyifan.js
+++ b/danmu_api/sources/aiyifan.js
@@ -66,7 +66,7 @@ export default class AiyifanSource extends BaseSource {
       "Accept": "application/json"
     };
 
-    log("info", `[搜索] 关键词: ${keyword}, 页码: ${page}`);
+    log("info", `[Aiyifan] [搜索] 关键词: ${keyword}, 页码: ${page}`);
     
     try {
       const urlWithParams = updateQueryString(this.SEARCH_API, params);
@@ -75,7 +75,7 @@ export default class AiyifanSource extends BaseSource {
       const data = typeof response.data === "string" ? JSON.parse(response.data) : response.data;
       return data;
     } catch (error) {
-      log("error", `[搜索失败] 错误: ${error.message}`);
+      log("error", `[Aiyifan] [搜索失败] 错误: ${error.message}`);
       return null;
     }
   }
@@ -90,7 +90,7 @@ export default class AiyifanSource extends BaseSource {
     const infoList = searchResult?.data?.info || [];
 
     if (!infoList.length) {
-      log("warn", "[警告] 搜索结果为空");
+      log("warn", "[Aiyifan] [警告] 搜索结果为空");
       return dramas;
     }
 
@@ -111,7 +111,7 @@ export default class AiyifanSource extends BaseSource {
           title: title,
           ...dramaInfo
         });
-        log("info", `[发现剧目] ${title}  vid=${vid}`);
+        log("info", `[Aiyifan] [发现剧目] ${title}  vid=${vid}`);
       }
     }
 
@@ -137,7 +137,7 @@ export default class AiyifanSource extends BaseSource {
       "Accept": "application/json"
     };
 
-    log("info", `[播放列表] 请求 vid: ${vid}`);
+    log("info", `[Aiyifan] [播放列表] 请求 vid: ${vid}`);
     
     try {
       const { data } = await this.signingProvider.signedGetJson(this.PLAYLIST_API, baseParams, headers, "播放列表");
@@ -150,10 +150,10 @@ export default class AiyifanSource extends BaseSource {
         }
       }
 
-      log("info", `[播放列表] 共获取到 ${episodes.length} 集`);
+      log("info", `[Aiyifan] [播放列表] 共获取到 ${episodes.length} 集`);
       return episodes;
     } catch (error) {
-      log("error", `[播放列表失败] 错误: ${error.message}`);
+      log("error", `[Aiyifan] [播放列表失败] 错误: ${error.message}`);
       return [];
     }
   }
@@ -182,14 +182,14 @@ export default class AiyifanSource extends BaseSource {
     };
 
     const epInfo = epId ? `(ID:${epId})` : "";
-    log("info", `[视频信息] 请求 key: ${epKey} ${epInfo}`);
+    log("info", `[Aiyifan] [视频信息] 请求 key: ${epKey} ${epInfo}`);
 
     try {
       const { data, vv } = await this.signingProvider.signedGetJson(this.VIDEO_API, baseParams, headers, "视频信息");
-      log("info", `[视频信息] vv签名: ${vv.substring(0, 16)}...`);
+      log("info", `[Aiyifan] [视频信息] vv签名: ${vv.substring(0, 16)}...`);
       return data.data || {};
     } catch (error) {
-      log("error", `[视频信息失败] 错误: ${error.message}`);
+      log("error", `[Aiyifan] [视频信息失败] 错误: ${error.message}`);
       return null;
     }
   }
@@ -203,7 +203,7 @@ export default class AiyifanSource extends BaseSource {
     const info = videoInfo.info?.[0] || {};
     const uniqueKey = info.uniqueKey;
     if (uniqueKey) {
-      log("info", `[视频信息] 获取到 uniqueKey: ${uniqueKey}`);
+      log("info", `[Aiyifan] [视频信息] 获取到 uniqueKey: ${uniqueKey}`);
     }
     return uniqueKey;
   }
@@ -227,17 +227,17 @@ export default class AiyifanSource extends BaseSource {
       "User-Agent": this.USER_AGENT,
     };
 
-    log("info", `[弹幕] 请求 uniqueKey: ${uniqueKey}`);
+    log("info", `[Aiyifan] [弹幕] 请求 uniqueKey: ${uniqueKey}`);
 
     try {
       const { data, vv } = await this.signingProvider.signedGetJson(this.DANMU_API, baseParams, headers, "弹幕");
-      log("info", `[弹幕] vv签名: ${vv.substring(0, 16)}...`);
+      log("info", `[Aiyifan] [弹幕] vv签名: ${vv.substring(0, 16)}...`);
 
       const danmuList = data.data?.info || [];
-      log("info", `[弹幕] 获取到 ${danmuList.length} 条弹幕`);
+      log("info", `[Aiyifan] [弹幕] 获取到 ${danmuList.length} 条弹幕`);
       return danmuList;
     } catch (error) {
-      log("error", `[弹幕失败] 错误: ${error.message}`);
+      log("error", `[Aiyifan] [弹幕失败] 错误: ${error.message}`);
       return [];
     }
   }
@@ -253,13 +253,13 @@ export default class AiyifanSource extends BaseSource {
     // Step 1: 搜索，拿到剧目列表
     const searchResult = await this.searchDrama(keyword);
     if (!searchResult) {
-      log("error", "搜索失败，退出");
+      log("error", "[Aiyifan] 搜索失败，退出");
       return [];
     }
 
     const dramas = this.extractDramaList(searchResult);
     if (!dramas.length) {
-      log("warn", "未找到剧目信息，退出");
+      log("warn", "[Aiyifan] 未找到剧目信息，退出");
       return [];
     }
 
@@ -291,7 +291,7 @@ export default class AiyifanSource extends BaseSource {
     // 获取播放列表
     const episodes = await this.getPlaylist(id);
     if (!episodes.length) {
-      log("error", "获取播放列表失败");
+      log("error", "[Aiyifan] 获取播放列表失败");
       return [];
     }
 
@@ -418,21 +418,21 @@ export default class AiyifanSource extends BaseSource {
       // 获取视频信息
       const videoInfo = await this.getVideoInfo(videoId);
       if (!videoInfo) {
-        log("error", "获取视频信息失败");
+        log("error", "[Aiyifan] 获取视频信息失败");
         return [];
       }
 
       // 提取uniqueKey
       const uniqueKey = this.extractUniqueKey(videoInfo);
       if (!uniqueKey) {
-        log("error", "未获取到uniqueKey");
+        log("error", "[Aiyifan] 未获取到uniqueKey");
         return [];
       }
 
       // 获取弹幕
       const danmuList = await this.fetchBarrage(uniqueKey);
       if (danmuList.length === 0) {
-        log("info", "未获取到弹幕");
+        log("info", "[Aiyifan] 未获取到弹幕");
         return [];
       }
 

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -89,7 +89,7 @@ export default class BahamutSource extends BaseSource {
                 a._searchUsedTitle = traditionalizedKeyword;
               } catch (e) {}
             }
-            log("info", `bahamutSearchresp (original): ${JSON.stringify(anime)}`);
+            log("info", `[Bahamut] bahamutSearchresp (original): ${JSON.stringify(anime)}`);
             log("info", `[Bahamut] 返回 ${anime.length} 条结果 (source: original)`);
             return { success: true, data: anime, source: 'original' };
           }
@@ -148,7 +148,7 @@ export default class BahamutSource extends BaseSource {
                 a._tmdbCnAlias = cnAlias;
               } catch (e) {}
             }
-            log("info", `bahamutSearchresp (TMDB): ${JSON.stringify(anime)}`);
+            log("info", `[Bahamut] bahamutSearchresp (TMDB): ${JSON.stringify(anime)}`);
             log("info", `[Bahamut] 返回 ${anime.length} 条结果 (source: tmdb)`);
             return { success: true, data: anime, source: 'tmdb' };
           }
@@ -216,7 +216,7 @@ export default class BahamutSource extends BaseSource {
       return finalResults;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getBahamutAnimes error:", {
+      log("error", "[Bahamut] getBahamutAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -240,23 +240,23 @@ export default class BahamutSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!resp || !resp.data) {
-        log("info", "getBahamutEposides: 请求失败或无数据返回");
+        log("info", "[Bahamut] getBahamutEposides: 请求失败或无数据返回");
         return [];
       }
 
       // 判断 seriesData 是否存在
       if (!resp.data.data || !resp.data.data.video || !resp.data.data.anime) {
-        log("info", "getBahamutEposides: video 或 anime 不存在");
+        log("info", "[Bahamut] getBahamutEposides: video 或 anime 不存在");
         return [];
       }
 
       // 正常情况下输出 JSON 字符串
-      log("info", `getBahamutEposides: ${JSON.stringify(resp.data.data)}`);
+      log("info", `[Bahamut] getBahamutEposides: ${JSON.stringify(resp.data.data)}`);
 
       return resp.data.data;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getBahamutEposides error:", {
+      log("error", "[Bahamut] getBahamutEposides error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -515,7 +515,7 @@ export default class BahamutSource extends BaseSource {
       return danmus;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "fetchBahamutEpisodeDanmu error:", {
+      log("error", "[Bahamut] fetchBahamutEpisodeDanmu error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -525,7 +525,7 @@ export default class BahamutSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取巴哈姆特弹幕分段列表...", id);
+    log("info", "[Bahamut] 获取巴哈姆特弹幕分段列表...", id);
 
     return new SegmentListResponse({
       "type": "bahamut",

--- a/danmu_api/sources/base.js
+++ b/danmu_api/sources/base.js
@@ -7,6 +7,7 @@ import { extractAnimeTitle, extractYear } from "../utils/common-util.js";
 // =====================
 
 export default class BaseSource {
+
   constructor() {
     // 构造函数，初始化通用配置
   }
@@ -50,30 +51,30 @@ export default class BaseSource {
   async getComments(id, sourceName, segmentFlag=false, progressCallback=null) {
     if (segmentFlag) {
       if(progressCallback) await progressCallback(5, `开始获取弹幕${sourceName}弹幕分片列表`);
-      log("info", `开始获取弹幕${sourceName}弹幕分片列表`);
+      log("info", `[system] [Base] 开始获取弹幕${sourceName}弹幕分片列表`);
       return await this.getEpisodeDanmuSegments(id);
     }
     if(progressCallback) await progressCallback(5, `开始获取弹幕${sourceName}弹幕`);
-    log("info", `开始获取弹幕${sourceName}弹幕`);
+    log("info", `[system] [Base] 开始获取弹幕${sourceName}弹幕`);
     const raw = await this.getEpisodeDanmu(id);
     if(progressCallback) await progressCallback(85,`原始弹幕 ${raw.length} 条，正在规范化`);
-    log("info", `原始弹幕 ${raw.length} 条，正在规范化`);
+    log("info", `[system] [Base] 原始弹幕 ${raw.length} 条，正在规范化`);
     const formatted = this.formatComments(raw);
     if(progressCallback) await progressCallback(100,`弹幕处理完成，共 ${formatted.length} 条`);
-    log("info", `弹幕处理完成，共 ${formatted.length} 条`);
+    log("info", `[system] [Base] 弹幕处理完成，共 ${formatted.length} 条`);
     return convertToDanmakuJson(formatted, sourceName);
   }
 
   // 获取分片弹幕流水线方法(获取某集分片弹幕 -> 格式化弹幕 -> 弹幕处理，如去重/屏蔽字等)
   async getSegmentComments(segment, progressCallback=null) {
     if(progressCallback) await progressCallback(5, `开始获取分片弹幕${segment.type}弹幕`);
-    log("info", `开始获取分片弹幕${segment.type}弹幕`);
+    log("info", `[system] [Base] 开始获取分片弹幕${segment.type}弹幕`);
     const raw = await this.getEpisodeSegmentDanmu(segment);
     if(progressCallback) await progressCallback(85,`原始分片弹幕 ${raw.length} 条，正在规范化`);
-    log("info", `原始分片弹幕 ${raw.length} 条，正在规范化`);
+    log("info", `[system] [Base] 原始分片弹幕 ${raw.length} 条，正在规范化`);
     const formatted = this.formatComments(raw);
     if(progressCallback) await progressCallback(100,`分片弹幕处理完成，共 ${formatted.length} 条`);
-    log("info", `分片弹幕处理完成，共 ${formatted.length} 条`);
+    log("info", `[system] [Base] 分片弹幕处理完成，共 ${formatted.length} 条`);
     return convertToDanmakuJson(formatted, segment.type);
   }
 

--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -33,7 +33,7 @@ export default class BilibiliSource extends BaseSource {
   async resolveB23Link(shortUrl) {
     let timeoutId;
     try {
-      log("info", `正在解析 b23.tv 短链接: ${shortUrl}`);
+      log("info", `[Bilibili] 正在解析 b23.tv 短链接: ${shortUrl}`);
 
       // b23.tv 第一跳会在 Location 中给出真实 B 站地址。
       // 只读取第一跳，避免继续访问最终页面时被 B 站页面风控返回 412。
@@ -53,14 +53,14 @@ export default class BilibiliSource extends BaseSource {
       const location = response.headers?.get?.('location') || response.headers?.get?.('Location');
       const finalUrl = location ? new URL(location, shortUrl).toString() : response.url;
       if (finalUrl && finalUrl !== shortUrl) {
-        log("info", `b23.tv 短链接已解析为: ${finalUrl}`);
+        log("info", `[Bilibili] b23.tv 短链接已解析为: ${finalUrl}`);
         return finalUrl;
       }
 
-      log("error", "无法解析 b23.tv 短链接");
+      log("error", "[Bilibili] 无法解析 b23.tv 短链接");
       return shortUrl; // 如果解析失败，返回原 URL
     } catch (error) {
-      log("error", "解析 b23.tv 短链接失败:", error);
+      log("error", "[Bilibili] 解析 b23.tv 短链接失败:", error);
       return shortUrl; // 如果出错，返回原 URL
     } finally {
       if (timeoutId) clearTimeout(timeoutId);
@@ -758,7 +758,7 @@ export default class BilibiliSource extends BaseSource {
 
   // 提取视频信息的公共方法
   async _extractVideoInfo(id) {
-    log("info", "提取B站视频信息...", id);
+    log("info", "[Bilibili] 提取B站视频信息...", id);
 
     const api_video_info = "https://api.bilibili.com/x/web-interface/view";
     const api_epid_cid = "https://api.bilibili.com/pgc/view/web/season";
@@ -771,9 +771,9 @@ export default class BilibiliSource extends BaseSource {
     if (match) {
       path = match[2].split('/').filter(Boolean);  // 分割路径并去掉空字符串
       path.unshift("");
-      log("info", path);
+      log("info", "[Bilibili] ", path);
     } else {
-      log("error", 'Invalid URL');
+      log("error", '[Bilibili] Invalid URL');
       return null;
     }
 
@@ -796,7 +796,7 @@ export default class BilibiliSource extends BaseSource {
               }
             }
         }
-        log("info", `p: ${p}`);
+        log("info", `[Bilibili] p: ${p}`);
 
         let videoInfoUrl;
         if (id.includes("BV")) {
@@ -815,14 +815,14 @@ export default class BilibiliSource extends BaseSource {
 
         const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
         if (data.code !== 0) {
-          log("error", "获取普通投稿视频信息失败:", data.message);
+          log("error", "[Bilibili] 获取普通投稿视频信息失败:", data.message);
           return null;
         }
 
         duration = data.data.duration;
         cid = data.data.pages[p - 1].cid;
       } catch (error) {
-        log("error", "请求普通投稿视频信息失败:", error);
+        log("error", "[Bilibili] 请求普通投稿视频信息失败:", error);
         return null;
       }
 
@@ -881,7 +881,7 @@ export default class BilibiliSource extends BaseSource {
         }
 
         if (!cid) {
-          log("error", "未找到匹配的番剧集信息");
+          log("error", "[Bilibili] 未找到匹配的番剧集信息");
           return null;
         }
 
@@ -889,7 +889,7 @@ export default class BilibiliSource extends BaseSource {
         if (!duration && duration !== 0) duration = 0;
 
       } catch (error) {
-        log("error", "请求番剧视频信息失败:", error);
+        log("error", "[Bilibili] 请求番剧视频信息失败:", error);
         return null;
       }
 
@@ -899,7 +899,7 @@ export default class BilibiliSource extends BaseSource {
         const ssid = path.slice(-1)[0].slice(2).split('?')[0]; // 移除可能的查询参数
         const ssInfoUrl = `${api_epid_cid}?season_id=${ssid}`;
 
-        log("info", `获取番剧信息: season_id=${ssid}`);
+        log("info", `[Bilibili] 获取番剧信息: season_id=${ssid}`);
 
         const res = await httpGet(ssInfoUrl, {
           headers: {
@@ -910,13 +910,13 @@ export default class BilibiliSource extends BaseSource {
 
         const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
         if (data.code !== 0) {
-          log("error", "获取番剧视频信息失败:", data.message);
+          log("error", "[Bilibili] 获取番剧视频信息失败:", data.message);
           return null;
         }
 
         // 检查是否有episodes数据
         if (!data.result.episodes || data.result.episodes.length === 0) {
-          log("error", "番剧没有可用的集数");
+          log("error", "[Bilibili] 番剧没有可用的集数");
           return null;
         }
 
@@ -926,25 +926,25 @@ export default class BilibiliSource extends BaseSource {
         duration = firstEpisode.duration / 1000;
         title = firstEpisode.share_copy;
 
-        log("info", `使用第一集: ${title}, cid=${cid}`);
+        log("info", `[Bilibili] 使用第一集: ${title}, cid=${cid}`);
 
       } catch (error) {
-        log("error", "请求番剧视频信息失败:", error);
+        log("error", "[Bilibili] 请求番剧视频信息失败:", error);
         return null;
       }
 
     } else {
-      log("error", "不支持的B站视频网址，仅支持普通视频(av,bv)、剧集视频(ep,ss)");
+      log("error", "[Bilibili] 不支持的B站视频网址，仅支持普通视频(av,bv)、剧集视频(ep,ss)");
       return null;
     }
 
-    log("info", `提取视频信息完成: cid=${cid}, aid=${aid}, duration=${duration}`);
+    log("info", `[Bilibili] 提取视频信息完成: cid=${cid}, aid=${aid}, duration=${duration}`);
 
     return { cid, aid, duration, title };
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求B站弹幕...", id);
+    log("info", "[Bilibili] 开始从本地请求B站弹幕...", id);
 
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -953,7 +953,7 @@ export default class BilibiliSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Bilibili] 弹幕分段数量: ${segmentList.length}`);
 
     // 分批并发请求，防止请求过多
     const BATCH_SIZE = 6;
@@ -986,7 +986,7 @@ export default class BilibiliSource extends BaseSource {
    * 对于合并分P，将其拆解为标准分段任务队列并注入时间轴平移元数据
    */
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取B站弹幕分段列表...", id);
+    log("info", "[Bilibili] 获取B站弹幕分段列表...", id);
 
     // 解析合并分P请求，直接转化为标准分段列表返回，由后续并发池统一处理
     if (typeof id === 'string' && id.includes('/combine?')) {
@@ -1040,7 +1040,7 @@ export default class BilibiliSource extends BaseSource {
     }
 
     const { cid, aid, duration } = videoInfo;
-    log("info", `视频信息: cid=${cid}, aid=${aid}, duration=${duration}`);
+    log("info", `[Bilibili] 视频信息: cid=${cid}, aid=${aid}, duration=${duration}`);
 
     // [提示] 无时长时的默认分段策略提示
     if (duration <= 0) {
@@ -1049,7 +1049,7 @@ export default class BilibiliSource extends BaseSource {
 
     // 计算视频的分片数量
     const maxLen = (duration > 0) ? Math.ceil(duration / 360) : 36;
-    log("info", `maxLen: ${maxLen}`);
+    log("info", `[Bilibili] maxLen: ${maxLen}`);
 
     const segmentList = [];
     for (let i = 0; i < maxLen; i += 1) {

--- a/danmu_api/sources/custom.js
+++ b/danmu_api/sources/custom.js
@@ -21,13 +21,13 @@ export default class CustomSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!resp || !resp.data) {
-        log("info", "customSourceSearchresp: 请求失败或无数据返回");
+        log("info", "[Custom] customSourceSearchresp: 请求失败或无数据返回");
         return [];
       }
 
       // 判断 seriesData 是否存在
       if (!resp.data.animes) {
-        log("info", "customSourceSearchresp: seriesData 或 seriesList 不存在");
+        log("info", "[Custom] customSourceSearchresp: seriesData 或 seriesList 不存在");
         return [];
       }
 
@@ -37,7 +37,7 @@ export default class CustomSource extends BaseSource {
       return resp.data.animes;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getCustomSourceAnimes error:", {
+      log("error", "[Custom] getCustomSourceAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -57,23 +57,23 @@ export default class CustomSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!resp || !resp.data) {
-        log("info", "getCustomSourceEposides: 请求失败或无数据返回");
+        log("info", "[Custom] getCustomSourceEposides: 请求失败或无数据返回");
         return [];
       }
 
       // 判断 seriesData 是否存在
       if (!resp.data.bangumi || !resp.data.bangumi.episodes) {
-        log("info", `getCustomSourceEposides: episodes 不存在. Response: ${JSON.stringify(resp.data)}`);
+        log("info", `[Custom] getCustomSourceEposides: episodes 不存在. Response: ${JSON.stringify(resp.data)}`);
         return [];
       }
 
       // 正常情况下输出 JSON 字符串
-      log("info", `getCustomSourceEposides: ${JSON.stringify(resp.data.bangumi.episodes)}`);
+      log("info", `[Custom] getCustomSourceEposides: ${JSON.stringify(resp.data.bangumi.episodes)}`);
 
       return resp.data.bangumi.episodes;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getCustomSourceEposides error:", {
+      log("error", "[Custom] getCustomSourceEposides error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -87,7 +87,7 @@ export default class CustomSource extends BaseSource {
 
     // 添加错误处理，确保sourceAnimes是数组
     if (!sourceAnimes || !Array.isArray(sourceAnimes)) {
-      log("error", "[Custom Source] sourceAnimes is not a valid array");
+      log("error", "[Custom] sourceAnimes is not a valid array");
       return [];
     }
 
@@ -128,7 +128,7 @@ export default class CustomSource extends BaseSource {
             if (globals.animes.length > globals.MAX_ANIMES) removeEarliestAnime();
           }
         } catch (error) {
-          log("error", `[Custom Source] Error processing anime: ${error.message}`);
+          log("error", `[Custom] Error processing anime: ${error.message}`);
         }
       })
     );
@@ -158,7 +158,7 @@ export default class CustomSource extends BaseSource {
       return allDanmus;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "fetchCustomSourceEpisodeDanmu error:", {
+      log("error", "[Custom] fetchCustomSourceEpisodeDanmu error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -168,7 +168,7 @@ export default class CustomSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取Custom Source弹幕分段列表...", id);
+    log("info", "[Custom] 获取Custom Source弹幕分段列表...", id);
 
     return new SegmentListResponse({
       "type": "custom",

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -90,12 +90,12 @@ export default class DandanSource extends BaseSource {
           // 原始搜索有结果，中断 TMDB 流程
           tmdbAbortController.abort();
           const animes = resp.data.animes;
-          log("info", `dandanSearchresp (original): ${JSON.stringify(animes)}`);
+          log("info", `[Dandan] dandanSearchresp (original): ${JSON.stringify(animes)}`);
           log("info", `[Dandan] 返回 ${animes.length} 条结果 (source: original)`);
           return { success: true, data: animes, source: 'original' };
         } catch (error) {
           // 捕获原始搜索错误，但不阻塞 TMDB 搜索
-          log("error", "getDandanAnimes error:", {
+          log("error", "[Dandan] getDandanAnimes error:", {
             message: error.message,
             name: error.name,
             stack: error.stack,
@@ -152,7 +152,7 @@ export default class DandanSource extends BaseSource {
             anime._tmdbCnAlias = cnAlias;
           }
 
-          log("info", `dandanSearchresp (tmdb): ${JSON.stringify(animes)}`);
+          log("info", `[Dandan] dandanSearchresp (tmdb): ${JSON.stringify(animes)}`);
           log("info", `[Dandan] 返回 ${animes.length} 条结果 (source: tmdb)`);
           return { success: true, data: animes, source: 'tmdb' };
         } catch (error) {
@@ -197,7 +197,7 @@ export default class DandanSource extends BaseSource {
       return [];
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getDandanAnimes error:", {
+      log("error", "[Dandan] getDandanAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -219,13 +219,13 @@ export default class DandanSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!resp || !resp.data) {
-        log("info", "getDandanEposides: 请求失败或无数据返回");
+        log("info", "[Dandan] getDandanEposides: 请求失败或无数据返回");
         return { episodes: [], titles: [], relateds: [], type: null, typeDescription: null };
       }
 
       // 判断 bangumi 数据是否存在
       if (!resp.data.bangumi) {
-        log("info", "getDandanEposides: bangumi 数据不存在");
+        log("info", "[Dandan] getDandanEposides: bangumi 数据不存在");
         return { episodes: [], titles: [], relateds: [], type: null, typeDescription: null };
       }
 
@@ -264,14 +264,14 @@ export default class DandanSource extends BaseSource {
       const imageUrl = bangumiData.imageUrl || null;
 
       // 正常情况下输出 JSON 字符串
-      log("info", `getDandanEposides: ${JSON.stringify(resp.data.bangumi.episodes)}`);
+      log("info", `[Dandan] getDandanEposides: ${JSON.stringify(resp.data.bangumi.episodes)}`);
 
       // 返回包含剧集、别名、相关作品、类型及封面信息的完整对象
       return { episodes, titles, relateds, type, typeDescription, imageUrl };
 
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getDandanEposides error:", {
+      log("error", "[Dandan] getDandanEposides error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -498,7 +498,7 @@ export default class DandanSource extends BaseSource {
           "User-Agent": DandanUserAgent,
         },
         retries: 1,
-      }).catch(e => { log('error', `dandan base comments error: ${e.message}`); return null; });
+      }).catch(e => { log('error', `[Dandan] dandan base comments error: ${e.message}`); return null; });
 
       const resp = await dandanPromise;
 
@@ -510,7 +510,7 @@ export default class DandanSource extends BaseSource {
       }
 
     } catch (error) {
-      log("error", "getEpisodeDanmu error:", {
+      log("error", "[Dandan] getEpisodeDanmu error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -521,7 +521,7 @@ export default class DandanSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取弹弹play弹幕分段列表...", id);
+    log("info", "[Dandan] 获取弹弹play弹幕分段列表...", id);
 
     return new SegmentListResponse({
       "type": "dandan",

--- a/danmu_api/sources/douban.js
+++ b/danmu_api/sources/douban.js
@@ -23,7 +23,7 @@ export default class DoubanSource extends BaseSource {
 
       // 兜底策略：如果 searchDoubanTitles 失败或返回空结果，使用 searchDoubanTitlesByPublic
       if (!data || (!data?.subjects?.items?.length && !data?.smart_box?.length)) {
-        log("info", "searchDoubanTitles failed or empty, trying searchDoubanTitlesByPublic");
+        log("info", "[Douban] searchDoubanTitles failed or empty, trying searchDoubanTitlesByPublic");
         const fallbackResponse = await searchDoubanTitlesByPublic(keyword);
         const fallbackData = fallbackResponse?.data;
 
@@ -46,11 +46,11 @@ export default class DoubanSource extends BaseSource {
         tmpAnimes = [...tmpAnimes, ...data.smart_box];
       }
 
-      log("info", `douban animes.length: ${tmpAnimes.length}`);
+      log("info", `[Douban] douban animes.length: ${tmpAnimes.length}`);
 
       return tmpAnimes;
     } catch (error) {
-      log("error", "getDoubanAnimes error:", {
+      log("error", "[Douban] getDoubanAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -160,7 +160,7 @@ export default class DoubanSource extends BaseSource {
         const doubanId = anime.target_id;
         let animeType = anime?.type_name;
         if (animeType !== "电影" && animeType !== "电视剧") return;
-        log("info", "doubanId: ", doubanId, anime?.target?.title, animeType);
+        log("info", "[Douban] doubanId: ", doubanId, anime?.target?.title, animeType);
 
         // 获取平台详情页面url
         const response = await getDoubanDetail(doubanId);
@@ -171,7 +171,7 @@ export default class DoubanSource extends BaseSource {
           if (!vendor) {
             continue;
           }
-          log("info", "vendor uri: ", vendor.uri);
+          log("info", "[Douban] vendor uri: ", vendor.uri);
 
           if (response.data?.genres.includes('真人秀')) {
             animeType = "综艺";

--- a/danmu_api/sources/hanjutv.js
+++ b/danmu_api/sources/hanjutv.js
@@ -99,7 +99,7 @@ export default class HanjutvSource extends BaseSource {
    * 统一的错误日志格式
    */
   logError(tag, error) {
-    log("error", `${tag}:`, {
+    log("error", `[Hanjutv] ${tag}:`, {
       message: error.message,
       name: error.name,
       stack: error.stack,
@@ -395,7 +395,7 @@ export default class HanjutvSource extends BaseSource {
       }
 
       if (resultList.length === 0) {
-        log("info", "hanjutvSearchresp: s5 与 TV 接口均无有效结果");
+        log("info", "[Hanjutv] hanjutvSearchresp: s5 与 TV 接口均无有效结果");
         return [];
       }
 
@@ -417,7 +417,7 @@ export default class HanjutvSource extends BaseSource {
       const sid = String(id || "").trim();
       if (!sid) return null;
       const detail = await this.tryGet(() => loader(sid), null, errorTag);
-      if (!detail) { log("info", `${missingLogTag}: series 不存在`); return null; }
+      if (!detail) { log("info", `[Hanjutv] ${missingLogTag}: series 不存在`); return null; }
       return detail;
     } catch (error) { this.logError(errorTag, error); return null; }
   }
@@ -482,7 +482,7 @@ export default class HanjutvSource extends BaseSource {
       }
 
       if (episodes.length === 0) {
-        log("info", "getHanjutvHxqEpisodes: episodes 不存在");
+        log("info", "[Hanjutv] getHanjutvHxqEpisodes: episodes 不存在");
         return [];
       }
 
@@ -504,7 +504,7 @@ export default class HanjutvSource extends BaseSource {
       }, [], "getHanjutvTvEpisodes error");
 
       if (episodes.length === 0) {
-        log("info", "getHanjutvTvEpisodes: episodes 不存在");
+        log("info", "[Hanjutv] getHanjutvTvEpisodes: episodes 不存在");
         return [];
       }
 
@@ -833,7 +833,7 @@ export default class HanjutvSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取韩剧TV弹幕分段列表...", id);
+    log("info", "[Hanjutv] 获取韩剧TV弹幕分段列表...", id);
 
     // 韩剧TV 当前没有可复用的分片清单接口，统一走整集拉取。
     return new SegmentListResponse({

--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -86,12 +86,12 @@ export default class IqiyiSource extends BaseSource {
 
         // 优先处理意图卡片 (template 112)
         if (template.template === 112 && template.intentAlbumInfos) {
-          log("debug", `[iQiyi] 找到意图卡片 (template 112)，处理 ${template.intentAlbumInfos.length} 个结果`);
+          log("info", `[iQiyi] 找到意图卡片 (template 112)，处理 ${template.intentAlbumInfos.length} 个结果`);
           albumsToProcess = template.intentAlbumInfos;
         }
         // 然后处理普通结果卡片
         else if ([101, 102, 103].includes(template.template) && template.albumInfo) {
-          log("debug", `[iQiyi] 找到普通结果卡片 (template ${template.template})`);
+          log("info", `[iQiyi] 找到普通结果卡片 (template ${template.template})`);
           albumsToProcess = [template.albumInfo];
         }
 
@@ -125,7 +125,7 @@ export default class IqiyiSource extends BaseSource {
 
     // 过滤外站付费播放
     if (album.btnText === '外站付费播放') {
-      log("debug", `[iQiyi] 过滤掉外站付费播放内容: ${album.title}`);
+      log("info", `[iQiyi] 过滤掉外站付费播放内容: ${album.title}`);
       return null;
     }
 
@@ -173,7 +173,7 @@ export default class IqiyiSource extends BaseSource {
     if (mediaType.includes("电影")) {
       const qipuId = album.qipuId || album.playQipuId;
       if (!qipuId) {
-        log("debug", `[iQiyi] 电影缺少 qipuId: ${album.title}`);
+        log("info", `[iQiyi] 电影缺少 qipuId: ${album.title}`);
         return null;
       }
 
@@ -204,13 +204,13 @@ export default class IqiyiSource extends BaseSource {
     // 非电影类型：从 pageUrl 提取 link_id
     const url = album.pageUrl;
     if (!url) {
-      log("debug", `[iQiyi] 非电影内容缺少 pageUrl: ${album.title}`);
+      log("info", `[iQiyi] 非电影内容缺少 pageUrl: ${album.title}`);
       return null;
     }
 
     const linkIdMatch = url.match(/v_(\w+?)\.html/);
     if (!linkIdMatch) {
-      log("debug", `[iQiyi] 无法从 pageUrl 提取 link_id: ${url}`);
+      log("info", `[iQiyi] 无法从 pageUrl 提取 link_id: ${url}`);
       return null;
     }
     const linkId = linkIdMatch[1];
@@ -353,11 +353,11 @@ export default class IqiyiSource extends BaseSource {
       for (const block of blocks) {
         // 查找 video_list 类型的块（新版API）
         if (block.bk_type === "video_list" && block.data?.data) {
-          log("debug", `[iQiyi] 找到 video_list 类型的分集数据块, bk_id: ${block.bk_id}`);
+          log("info", `[iQiyi] 找到 video_list 类型的分集数据块, bk_id: ${block.bk_id}`);
 
           // 检查是否是分集选择器块
           if (!block.tag || !block.tag.includes("episodes")) {
-            log("debug", `[iQiyi] 跳过非分集块: ${block.bk_id}`);
+            log("info", `[iQiyi] 跳过非分集块: ${block.bk_id}`);
             continue;
           }
 
@@ -409,7 +409,7 @@ export default class IqiyiSource extends BaseSource {
         }
         // 兼容旧版 API 的 album_episodes 类型
         else if (block.bk_type === "album_episodes" && block.data?.data) {
-          log("debug", "[iQiyi] 找到 album_episodes 类型的分集数据块");
+          log("info", "[iQiyi] 找到 album_episodes 类型的分集数据块");
           foundEpisodes = true;
 
           const episodeGroups = block.data.data;
@@ -518,7 +518,7 @@ export default class IqiyiSource extends BaseSource {
       const queryString = buildQueryString(params);
       const url = `https://mesh.if.iqiyi.com/tvg/v2/lw/base_info?${queryString}`;
 
-      log("debug", `[iQiyi] 请求电影详情: ${url}`);
+      log("info", `[iQiyi] 请求电影详情: ${url}`);
 
       const response = await httpGet(url, {
         headers: {
@@ -563,7 +563,7 @@ export default class IqiyiSource extends BaseSource {
       }
 
       log("error", "[iQiyi] base_info API 响应中未找到视频ID");
-      log("debug", `[iQiyi] 响应数据结构: ${JSON.stringify(data).substring(0, 1000)}...`);
+      log("info", `[iQiyi] 响应数据结构: ${JSON.stringify(data).substring(0, 1000)}...`);
       return null;
 
     } catch (error) {
@@ -728,7 +728,7 @@ export default class IqiyiSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求爱奇艺弹幕...", id);
+    log("info", "[iQiyi] 开始从本地请求爱奇艺弹幕...", id);
 
     // 获取页面标题
     let res;
@@ -740,14 +740,14 @@ export default class IqiyiSource extends BaseSource {
         },
       });
     } catch (error) {
-      log("error", "请求页面失败:", error);
+      log("error", "[iQiyi] 请求页面失败:", error);
       return [];
     }
 
     // 使用正则表达式提取 <title> 标签内容
     const titleMatch = res.data.match(/<title[^>]*>(.*?)<\/title>/i);
     const title = titleMatch ? titleMatch[1].split("_")[0] : "未知标题";
-    log("info", `标题: ${title}`);
+    log("info", `[iQiyi] 标题: ${title}`);
 
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -756,7 +756,7 @@ export default class IqiyiSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[iQiyi] 弹幕分段数量: ${segmentList.length}`);
 
     // 创建请求Promise数组
     const promises = [];
@@ -777,7 +777,7 @@ export default class IqiyiSource extends BaseSource {
         contents.push(...data);
       });
     } catch (error) {
-      log("error", "解析弹幕数据失败:", error);
+      log("error", "[iQiyi] 解析弹幕数据失败:", error);
       return [];
     }
 
@@ -787,7 +787,7 @@ export default class IqiyiSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取爱奇艺视频弹幕分段列表...", id);
+    log("info", "[iQiyi] 获取爱奇艺视频弹幕分段列表...", id);
 
     // 弹幕 API 基础地址
     const api_decode_base = "https://pcw-api.iq.com/api/decode/";
@@ -798,14 +798,14 @@ export default class IqiyiSource extends BaseSource {
     try {
       const idMatch = id.match(/v_(\w+)/);
       if (!idMatch) {
-        log("error", "无法从 URL 中提取 tvid");
+        log("error", "[iQiyi] 无法从 URL 中提取 tvid");
         return new SegmentListResponse({
           "type": "qiyi",
           "segmentList": []
         });
       }
       tvid = idMatch[1];
-      log("info", `tvid: ${tvid}`);
+      log("info", `[iQiyi] tvid: ${tvid}`);
 
       // 获取 tvid 的解码信息
       const decodeUrl = `${api_decode_base}${tvid}?platformId=3&modeCode=intl&langCode=sg`;
@@ -817,9 +817,9 @@ export default class IqiyiSource extends BaseSource {
       });
       const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
       tvid = data.data.toString();
-      log("info", `解码后 tvid: ${tvid}`);
+      log("info", `[iQiyi] 解码后 tvid: ${tvid}`);
     } catch (error) {
-      log("error", "请求解码信息失败:", error);
+      log("error", "[iQiyi] 请求解码信息失败:", error);
       return new SegmentListResponse({
         "type": "qiyi",
         "segmentList": []
@@ -840,16 +840,16 @@ export default class IqiyiSource extends BaseSource {
       const videoInfo = data.data;
       duration = Number(videoInfo.durationSec) || 0;
       if (videoInfo.displayBarrage === false) {
-        log("info", "爱奇艺视频未开启弹幕");
+        log("info", "[iQiyi] 爱奇艺视频未开启弹幕");
         return new SegmentListResponse({
           "type": "qiyi",
           "duration": duration,
           "segmentList": []
         });
       }
-      log("info", `时长: ${duration}`);
+      log("info", `[iQiyi] 时长: ${duration}`);
     } catch (error) {
-      log("error", "请求视频基础信息失败:", error);
+      log("error", "[iQiyi] 请求视频基础信息失败:", error);
       return new SegmentListResponse({
         "type": "qiyi",
         "segmentList": []
@@ -859,7 +859,7 @@ export default class IqiyiSource extends BaseSource {
     // 当前爱奇艺弹幕分片按 60 秒切片，并使用 md5 后缀校验。
     const segmentDuration = 60;
     const page = Math.ceil(duration / segmentDuration);
-    log("info", `弹幕分段数量: ${page}`);
+    log("info", `[iQiyi] 弹幕分段数量: ${page}`);
 
     // 构建分段列表
     const segmentList = [];
@@ -910,7 +910,7 @@ export default class IqiyiSource extends BaseSource {
 
       return this._parseIqiyiProtoDanmu(payload);
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[iQiyi] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }
@@ -938,7 +938,7 @@ export default class IqiyiSource extends BaseSource {
         const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("brotli"));
         return new Uint8Array(await new Response(stream).arrayBuffer());
       } catch {
-        log("info", "DecompressionStream Brotli 解压失败，尝试 Node zlib");
+        log("info", "[iQiyi] DecompressionStream Brotli 解压失败，尝试 Node zlib");
       }
     }
 

--- a/danmu_api/sources/kan360.js
+++ b/danmu_api/sources/kan360.js
@@ -26,7 +26,7 @@ export default class Kan360Source extends BaseSource {
         );
 
         const data = await response.data;
-        log("info", `360kan zongyi response: ${JSON.stringify(data)}`);
+        log("info", `[360kan] 360kan zongyi response: ${JSON.stringify(data)}`);
 
         const episodeList = data.data.list;
         if (!episodeList) {
@@ -49,7 +49,7 @@ export default class Kan360Source extends BaseSource {
           });
         }
 
-        log("info", `links.length: ${links.length}`);
+        log("info", `[360kan] links.length: ${links.length}`);
       }
       // Sort links by pubdate numerically
       links.sort((a, b) => {
@@ -61,7 +61,7 @@ export default class Kan360Source extends BaseSource {
 
       return links;
     } catch (error) {
-      log("error", "get360Animes error:", {
+      log("error", "[360kan] get360Animes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -85,7 +85,7 @@ export default class Kan360Source extends BaseSource {
         return Number(result.data.allupinfo[site]);
       }
     } catch (error) {
-      log("error", "getNumber error:", error && error.message ? error.message : error);
+      log("error", "[360kan] getNumber error:", error && error.message ? error.message : error);
     }
     return null;
   }
@@ -102,7 +102,7 @@ export default class Kan360Source extends BaseSource {
       });
       return res.data;
     } catch (error) {
-      log("error", "get360Detail error:", error && error.message ? error.message : error);
+      log("error", "[360kan] get360Detail error:", error && error.message ? error.message : error);
     }
     return null;
   }
@@ -131,7 +131,7 @@ export default class Kan360Source extends BaseSource {
             try {
               data = JSON.parse(jsonText);
             } catch (e) {
-              log('error', `getEpisodesV2 JSON parse error: ${e.message}`);
+              log('error', `[360kan] getEpisodesV2 JSON parse error: ${e.message}`);
               return [];
             }
           } else {
@@ -139,7 +139,7 @@ export default class Kan360Source extends BaseSource {
             try {
               data = JSON.parse(data);
             } catch (e) {
-              log('error', `getEpisodesV2 unexpected response format`);
+              log('error', `[360kan] getEpisodesV2 unexpected response format`);
               return [];
             }
           }
@@ -169,7 +169,7 @@ export default class Kan360Source extends BaseSource {
 
       return [];
     } catch (error) {
-      log('error', 'getEpisodesV2 error:', {
+      log('error', '[360kan] getEpisodesV2 error:', {
         message: error && error.message ? error.message : String(error),
         stack: error && error.stack ? error.stack : undefined,
       });
@@ -190,18 +190,18 @@ export default class Kan360Source extends BaseSource {
       );
 
       const data = response.data;
-      log("info", `360kan response: ${JSON.stringify(data)}`);
+      log("info", `[360kan] 360kan response: ${JSON.stringify(data)}`);
 
       let tmpAnimes = [];
       if ('rows' in data.data.longData) {
         tmpAnimes = data.data.longData.rows;
       }
 
-      log("info", `360kan animes.length: ${tmpAnimes.length}`);
+      log("info", `[360kan] 360kan animes.length: ${tmpAnimes.length}`);
 
       return tmpAnimes;
     } catch (error) {
-      log("error", "get360Animes error:", {
+      log("error", "[360kan] get360Animes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,

--- a/danmu_api/sources/leshi.js
+++ b/danmu_api/sources/leshi.js
@@ -99,7 +99,7 @@ export default class LeshiSource extends BaseSource {
 
       const htmlContent = response.data;
 
-      log("debug", `[Leshi] 搜索请求成功，响应长度: ${htmlContent.length} 字符`);
+      log("info", `[Leshi] 搜索请求成功，响应长度: ${htmlContent.length} 字符`);
 
       // 解析HTML，提取data-info属性
       const results = [];
@@ -114,13 +114,13 @@ export default class LeshiSource extends BaseSource {
         matches.push(match);
       }
 
-      log("debug", `[Leshi] 从HTML中找到 ${matches.length} 个 data-info 块`);
+      log("info", `[Leshi] 从HTML中找到 ${matches.length} 个 data-info 块`);
 
       for (const match of matches) {
         try {
           let dataInfoStr = match[1];
 
-          log("debug", `[Leshi] 提取到 data-info 原始字符串: ${dataInfoStr.substring(0, 200)}...`);
+          log("info", `[Leshi] 提取到 data-info 原始字符串: ${dataInfoStr.substring(0, 200)}...`);
 
           // 解析JavaScript对象字面量为JSON
           // 1. 先将所有单引号替换为双引号
@@ -130,7 +130,7 @@ export default class LeshiSource extends BaseSource {
 
           const dataInfo = JSON.parse(dataInfoStr);
 
-          log("debug", `[Leshi] 成功解析 data-info，pid=${dataInfo.pid}, type=${dataInfo.type}`);
+          log("info", `[Leshi] 成功解析 data-info，pid=${dataInfo.pid}, type=${dataInfo.type}`);
 
           // 提取基本信息
           let pid = dataInfo.pid || '';
@@ -238,10 +238,10 @@ export default class LeshiSource extends BaseSource {
           };
 
           results.push(result);
-          log("debug", `[Leshi] 解析成功 - ${title} (pid=${pid}, type=${resultType}, episodes=${episodeCount})`);
+          log("info", `[Leshi] 解析成功 - ${title} (pid=${pid}, type=${resultType}, episodes=${episodeCount})`);
 
         } catch (e) {
-          log("warning", `[Leshi] 解析搜索结果项失败: ${e}`);
+          log("warn", `[Leshi] 解析搜索结果项失败: ${e}`);
           continue;
         }
       }
@@ -250,7 +250,7 @@ export default class LeshiSource extends BaseSource {
         log("info", `[Leshi] 网络搜索 '${keyword}' 完成，找到 ${results.length} 个有效结果。`);
         log("info", `[Leshi] 搜索结果列表:`);
         for (const r of results) {
-          log("info", `  - ${r.title} (ID: ${r.mediaId}, 类型: ${r.type}, 年份: ${r.year})`);
+          log("info", `[Leshi]   - ${r.title} (ID: ${r.mediaId}, 类型: ${r.type}, 年份: ${r.year})`);
         }
       } else {
         log("info", `[Leshi] 网络搜索 '${keyword}' 完成，找到 0 个结果。`);
@@ -282,17 +282,17 @@ export default class LeshiSource extends BaseSource {
           const response = await httpGet(url, { timeout: 10000 });
           if (response && response.data && response.status === 200) {
             htmlContent = response.data;
-            log("debug", `成功获取页面: ${url}`);
+            log("info", `[Leshi] 成功获取页面: ${url}`);
             break;
           }
         } catch (e) {
-          log("debug", `尝试URL失败 ${url}: ${e}`);
+          log("info", `[Leshi] 尝试URL失败 ${url}: ${e}`);
           continue;
         }
       }
 
       if (!htmlContent) {
-        log("error", `无法获取作品页面: media_id=${id}`);
+        log("error", `[Leshi] 无法获取作品页面: media_id=${id}`);
         return [];
       }
 
@@ -303,7 +303,7 @@ export default class LeshiSource extends BaseSource {
       const twxjContainerMatch = /<div class="show_cnt twxj-[^"]*">[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/.exec(htmlContent);
       
       if (twxjContainerMatch) {
-        log("debug", `找到图文选集容器`);
+        log("info", `[Leshi] 找到图文选集容器`);
         return this.parseEpisodesFromHtml(twxjContainerMatch[0], id);
       }
       
@@ -311,12 +311,12 @@ export default class LeshiSource extends BaseSource {
       const sjxjContainerMatch = /<div class="show_cnt sjxj-[^"]*">[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/.exec(htmlContent);
       
       if (sjxjContainerMatch) {
-        log("debug", `找到数字选集容器`);
+        log("info", `[Leshi] 找到数字选集容器`);
         return this.parseEpisodesFromHtml(sjxjContainerMatch[0], id);
       }
       
       // 如果以上都没找到，尝试查找整个剧集区域
-      log("debug", `未找到特定选集容器，尝试查找第一集视频列表...`);
+      log("info", `[Leshi] 未找到特定选集容器，尝试查找第一集视频列表...`);
       
       const firstVideoListMatch = /<div class="show_play first_videolist[\s\S]*?<\/div>\s*<\/div>\s*<\/div>/.exec(htmlContent);
       if (firstVideoListMatch) {
@@ -325,7 +325,7 @@ export default class LeshiSource extends BaseSource {
         return this.parseEpisodesFromHtml(containerHtml, id);
       }
       
-      log("error", `无法找到剧集列表容器: media_id=${id}`);
+      log("error", `[Leshi] 无法找到剧集列表容器: media_id=${id}`);
       
       // 从htmlContent直接匹配查找 https://www.le.com/ptv/vplay/77917395.html 形式的链接
       const regex = /https:\/\/www\.le\.com\/ptv\/vplay\/(\d+)\.html/g;
@@ -368,19 +368,19 @@ export default class LeshiSource extends BaseSource {
       const containerMatches = htmlContent.match(episodeContainerRegex);
       
       if (!containerMatches || containerMatches.length === 0) {
-        log("debug", `在HTML中未找到剧集容器div.col_4，尝试查找dl.dl_temp元素`);
+        log("info", `[Leshi] 在HTML中未找到剧集容器div.col_4，尝试查找dl.dl_temp元素`);
         // 如果没找到div.col_4，直接查找dl.dl_temp
         const episodeRegex = /<dl class="dl_temp">[\s\S]*?<\/dl>/g;
         const matches = htmlContent.match(episodeRegex);
         
         if (!matches || matches.length === 0) {
-          log("debug", `在HTML中未找到剧集元素，尝试更广泛的选择器`);
+          log("info", `[Leshi] 在HTML中未找到剧集元素，尝试更广泛的选择器`);
           // 尝试更广泛的匹配
           const broaderRegex = /<dl[^>]*class="[^"]*dl_temp[^"]*"[^>]*>[\s\S]*?<\/dl>/g;
           const broaderMatches = htmlContent.match(broaderRegex);
           
           if (!broaderMatches || broaderMatches.length === 0) {
-            log("error", `无法从HTML中解析到任何剧集: media_id=${mediaId}`);
+            log("error", `[Leshi] 无法从HTML中解析到任何剧集: media_id=${mediaId}`);
             return [];
           }
           
@@ -400,7 +400,7 @@ export default class LeshiSource extends BaseSource {
       }
       
       if (dlElements.length === 0) {
-        log("error", `从容器中未能提取到任何dl.dl_temp元素: media_id=${mediaId}`);
+        log("error", `[Leshi] 从容器中未能提取到任何dl.dl_temp元素: media_id=${mediaId}`);
         return [];
       }
       
@@ -419,7 +419,7 @@ export default class LeshiSource extends BaseSource {
         // 提取链接 - 优先匹配 vplay 链接
         const linkMatch = /<a[^>]+href="(\/\/www\.le\.com\/ptv\/vplay\/(\d+)\.html)"[^>]*>/.exec(element);
         if (!linkMatch) {
-          log("debug", `跳过无法解析链接的剧集元素`);
+          log("info", `[Leshi] 跳过无法解析链接的剧集元素`);
           continue;
         }
         
@@ -471,7 +471,7 @@ export default class LeshiSource extends BaseSource {
         // 过滤掉预告片或其他非正常剧集（可选）
         const isPreview = /预告|Preview|preview/.test(title);
         if (isPreview) {
-          log("debug", `跳过预告片: ${title}`);
+          log("info", `[Leshi] 跳过预告片: ${title}`);
           continue;
         }
         
@@ -485,7 +485,7 @@ export default class LeshiSource extends BaseSource {
         episodes.push(episode);
         
       } catch (e) {
-        log("warning", `[Leshi] 解析单个剧集失败: ${e.message}`);
+        log("warn", `[Leshi] 解析单个剧集失败: ${e.message}`);
         continue;
       }
     }
@@ -582,7 +582,7 @@ export default class LeshiSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求乐视网弹幕...", id);
+    log("info", "[Leshi] 开始从本地请求乐视网弹幕...", id);
 
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -591,7 +591,7 @@ export default class LeshiSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Leshi] 弹幕分段数量: ${segmentList.length}`);
 
     // 并发请求所有弹幕段，限制并发数量为5
     const MAX_CONCURRENT = 10;
@@ -623,7 +623,7 @@ export default class LeshiSource extends BaseSource {
             break;
           }
         } else {
-          log("error", `获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
+          log("error", `[Leshi] 获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
         }
       }
       
@@ -634,7 +634,7 @@ export default class LeshiSource extends BaseSource {
     }
 
     if (allComments.length === 0) {
-      log("info", `乐视网: 该视频暂无弹幕数据 (vid=${id})`);
+      log("info", `[Leshi] 乐视网: 该视频暂无弹幕数据 (vid=${id})`);
       return [];
     }
 
@@ -670,13 +670,13 @@ export default class LeshiSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Leshi] 请求分片弹幕失败:", error);
       return [];
     }
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取乐视网弹幕分段列表...", id);
+    log("info", "[Leshi] 获取乐视网弹幕分段列表...", id);
 
     // 从ID中提取video_id
     let videoId = id;
@@ -701,7 +701,7 @@ export default class LeshiSource extends BaseSource {
       });
     }
 
-    log("info", `乐视网: 视频时长 ${duration}秒，分为 ${segments.length} 个时间段`);
+    log("info", `[Leshi] 乐视网: 视频时长 ${duration}秒，分为 ${segments.length} 个时间段`);
 
     return new SegmentListResponse({
       "type": "leshi",
@@ -718,7 +718,7 @@ export default class LeshiSource extends BaseSource {
       const response = await httpGet(`https://www.le.com/ptv/vplay/${videoId}.html`, { timeout: 10000 });
       
       if (!response || !response.data) {
-        log("warning", `乐视网: 获取视频时长失败，使用默认值2400秒`);
+        log("warn", `[Leshi] 乐视网: 获取视频时长失败，使用默认值2400秒`);
         return 2400;
       }
       
@@ -749,7 +749,7 @@ export default class LeshiSource extends BaseSource {
       // 默认返回40分钟
       return 2400;
     } catch (e) {
-      log("warning", `获取视频时长失败: ${e}，使用默认值2400秒`);
+      log("warn", `[Leshi] 获取视频时长失败: ${e}，使用默认值2400秒`);
       return 2400;
     }
   }
@@ -783,7 +783,7 @@ export default class LeshiSource extends BaseSource {
           t: Math.round(timeVal * 100) / 100
         };
       } catch (error) {
-        log("error", `格式化弹幕失败: ${error.message}, 弹幕数据:`, comment);
+        log("error", `[Leshi] 格式化弹幕失败: ${error.message}, 弹幕数据:`, comment);
         return null;
       }
     }).filter(comment => comment !== null);

--- a/danmu_api/sources/maiduidui.js
+++ b/danmu_api/sources/maiduidui.js
@@ -103,7 +103,7 @@ class MaiduiduiSource extends BaseSource {
       return animes;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getMaiduiduiAnimes error:", {
+      log("error", "[Maiduidui] getMaiduiduiAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -144,7 +144,7 @@ class MaiduiduiSource extends BaseSource {
       return 0;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getMaiduiduiDetail error:", {
+      log("error", "[Maiduidui] getMaiduiduiDetail error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -185,7 +185,7 @@ class MaiduiduiSource extends BaseSource {
       return eps;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getMaiduiduiEposides error:", {
+      log("error", "[Maiduidui] getMaiduiduiEposides error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -278,7 +278,7 @@ class MaiduiduiSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求埋堆堆弹幕...", id);
+    log("info", "[Maiduidui] 开始从本地请求埋堆堆弹幕...", id);
     
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -287,7 +287,7 @@ class MaiduiduiSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Maiduidui] 弹幕分段数量: ${segmentList.length}`);
 
     // 并发请求所有弹幕段，限制并发数量为20
     const MAX_CONCURRENT = 20;
@@ -315,7 +315,7 @@ class MaiduiduiSource extends BaseSource {
             allComments.push(...comments);
           }
         } else {
-          log("error", `获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
+          log("error", `[Maiduidui] 获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
         }
       }
       
@@ -326,7 +326,7 @@ class MaiduiduiSource extends BaseSource {
     }
 
     if (allComments.length === 0) {
-      log("info", `埋堆堆: 该视频暂无弹幕数据 (vid=${id})`);
+      log("info", `[Maiduidui] 埋堆堆: 该视频暂无弹幕数据 (vid=${id})`);
       return [];
     }
 
@@ -336,13 +336,13 @@ class MaiduiduiSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取埋堆堆弹幕分段列表...", id);
+    log("info", "[Maiduidui] 获取埋堆堆弹幕分段列表...", id);
 
     const idInfo = this.extractByRegex(id);
     const uuid = idInfo.uuid;
     const duration = await this.getDetail(id);
-    log("info", "uuid:", uuid);
-    log("info", "duration:", duration);
+    log("info", "[Maiduidui] uuid:", uuid);
+    log("info", "[Maiduidui] duration:", duration);
 
     const segmentDuration = 60; // 每个分片1分钟
     const segmentList = [];
@@ -396,7 +396,7 @@ class MaiduiduiSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Maiduidui] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }

--- a/danmu_api/sources/mango.js
+++ b/danmu_api/sources/mango.js
@@ -217,13 +217,13 @@ export default class MangoSource extends BaseSource {
 
         // 过滤掉预告片 (isnew === "2")
         if (ep.isnew === "2") {
-          log("debug", `[Mango] 过滤预告片: ${fullTitle}`);
+          log("info", `[Mango] 过滤预告片: ${fullTitle}`);
           return false;
         }
 
         // 使用专属黑名单过滤
         if (mangoBlacklist.test(fullTitle)) {
-          log("debug", `[Mango] 黑名单过滤: ${fullTitle}`);
+          log("info", `[Mango] 黑名单过滤: ${fullTitle}`);
           return false;
         }
 
@@ -306,7 +306,7 @@ export default class MangoSource extends BaseSource {
       return [];
     }
 
-    log("debug", `[Mango] 综艺处理开始，原始分集数: ${rawEpisodes.length}`);
+    log("info", `[Mango] 综艺处理开始，原始分集数: ${rawEpisodes.length}`);
 
     // 检查是否有"第N期"格式
     const hasQiFormat = rawEpisodes.some(ep => {
@@ -314,7 +314,7 @@ export default class MangoSource extends BaseSource {
       return /第\d+期/.test(fullTitle);
     });
 
-    log("debug", `[Mango] 综艺格式分析: 有期数格式=${hasQiFormat}`);
+    log("info", `[Mango] 综艺格式分析: 有期数格式=${hasQiFormat}`);
 
     const episodeInfos = [];
     const qiInfoMap = new Map(); // 存储期数信息的映射
@@ -339,28 +339,28 @@ export default class MangoSource extends BaseSource {
           if (!hasInvalidSuffix) {
             qiInfoMap.set(ep, [parseInt(qiNum), upMidDown]);
             episodeInfos.push(ep);
-            log("debug", `[Mango] 综艺保留上中下格式: ${fullTitle}`);
+            log("info", `[Mango] 综艺保留上中下格式: ${fullTitle}`);
           } else {
-            log("debug", `[Mango] 综艺过滤上中下格式+后缀: ${fullTitle}`);
+            log("info", `[Mango] 综艺过滤上中下格式+后缀: ${fullTitle}`);
           }
         } else if (qiPureMatch && !hasUpMidDown && !/会员版|纯享版|特别版|独家版|加更|Plus|\+|花絮|预告|彩蛋|抢先|精选|未播|回顾|特辑|幕后|访谈|采访|混剪|合集|盘点|总结|删减|未播放|NG|番外|片段|看点|精彩|制作|导演|演员|拍摄|片尾曲|插曲|主题曲|背景音乐|OST|音乐|歌曲/.test(fullTitle)) {
           // 匹配纯粹的"第N期"格式
           const qiNum = qiPureMatch[1];
           qiInfoMap.set(ep, [parseInt(qiNum), '']);
           episodeInfos.push(ep);
-          log("debug", `[Mango] 综艺保留标准期数: ${fullTitle}`);
+          log("info", `[Mango] 综艺保留标准期数: ${fullTitle}`);
         } else {
-          log("debug", `[Mango] 综艺过滤非标准期数格式: ${fullTitle}`);
+          log("info", `[Mango] 综艺过滤非标准期数格式: ${fullTitle}`);
         }
       } else {
         // 没有任何"第N期"格式时：全部保留（除了明显的广告）
         if (fullTitle.includes('广告') || fullTitle.includes('推广')) {
-          log("debug", `[Mango] 跳过广告内容: ${fullTitle}`);
+          log("info", `[Mango] 跳过广告内容: ${fullTitle}`);
           continue;
         }
 
         episodeInfos.push(ep);
-        log("debug", `[Mango] 综艺保留原始标题: ${fullTitle}`);
+        log("info", `[Mango] 综艺保留原始标题: ${fullTitle}`);
       }
     }
 
@@ -403,7 +403,7 @@ export default class MangoSource extends BaseSource {
       });
     }
 
-    log("debug", `[Mango] 综艺处理完成，过滤后分集数: ${episodeInfos.length}`);
+    log("info", `[Mango] 综艺处理完成，过滤后分集数: ${episodeInfos.length}`);
     return episodeInfos;
   }
 
@@ -531,7 +531,7 @@ export default class MangoSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求芒果TV弹幕...", id);
+    log("info", "[Mango] 开始从本地请求芒果TV弹幕...", id);
 
     // 获取弹幕分段列表
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -540,7 +540,7 @@ export default class MangoSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Mango] 弹幕分段数量: ${segmentList.length}`);
 
     // 创建请求Promise数组
     const promises = [];
@@ -578,7 +578,7 @@ export default class MangoSource extends BaseSource {
         }
       });
     } catch (error) {
-      log("error", "解析弹幕数据失败:", error);
+      log("error", "[Mango] 解析弹幕数据失败:", error);
       return [];
     }
 
@@ -588,7 +588,7 @@ export default class MangoSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取芒果TV弹幕分段列表...", id);
+    log("info", "[Mango] 获取芒果TV弹幕分段列表...", id);
 
     // 弹幕和视频信息 API 基础地址
     const api_video_info = "https://pcweb.api.mgtv.com/video/info";
@@ -603,7 +603,7 @@ export default class MangoSource extends BaseSource {
     if (match) {
       path = match[2].split('/').filter(Boolean);  // 分割路径并去掉空字符串
     } else {
-      log("error", 'Invalid URL');
+      log("error", '[Mango] Invalid URL');
       return new SegmentListResponse({
         "type": "imgo",
         "segmentList": []
@@ -612,7 +612,7 @@ export default class MangoSource extends BaseSource {
     const cid = path[path.length - 2];
     const vid = path[path.length - 1].split(".")[0];
 
-    log("info", `获取弹幕分段列表 - cid: ${cid}, vid: ${vid}`);
+    log("info", `[Mango] 获取弹幕分段列表 - cid: ${cid}, vid: ${vid}`);
 
     // 获取视频信息
     let res;
@@ -631,7 +631,7 @@ export default class MangoSource extends BaseSource {
           "segmentList": []
         });
       }
-      log("error", "请求视频信息失败:", error);
+      log("error", "[Mango] 请求视频信息失败:", error);
       return new SegmentListResponse({
         "type": "imgo",
         "segmentList": []
@@ -655,7 +655,7 @@ export default class MangoSource extends BaseSource {
 
       // 检查数据结构
       if (!ctlBarrage.data || !ctlBarrage.data.cdn_list || !ctlBarrage.data.cdn_version) {
-        log("warn", `新API缺少必要字段，返回空分段列表`);
+        log("warn", `[Mango] 新API缺少必要字段，返回空分段列表`);
         useNewApi = false;
       }
 
@@ -692,7 +692,7 @@ export default class MangoSource extends BaseSource {
         "segmentList": segmentList
       });
     } catch (error) {
-      log("error", "请求弹幕分段数据失败:", error);
+      log("error", "[Mango] 请求弹幕分段数据失败:", error);
       return new SegmentListResponse({
         "type": "imgo",
         "segmentList": []
@@ -721,7 +721,7 @@ export default class MangoSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Mango] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }

--- a/danmu_api/sources/migu.js
+++ b/danmu_api/sources/migu.js
@@ -92,7 +92,7 @@ class MiguSource extends BaseSource {
       return animes;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getMiguAnimes error:", {
+      log("error", "[Migu] getMiguAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -120,7 +120,7 @@ class MiguSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!resp || !resp.data) {
-        log("info", "getMiguDetail: 请求失败或无数据返回");
+        log("info", "[Migu] getMiguDetail: 请求失败或无数据返回");
         return { duration: 0, epsID: null };
       }
 
@@ -130,7 +130,7 @@ class MiguSource extends BaseSource {
       return { duration, epsID };
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getMiguDetail error:", {
+      log("error", "[Migu] getMiguDetail error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -149,7 +149,7 @@ class MiguSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!detailResp || !detailResp.data) {
-        log("info", "getMiguEposides: 请求失败或无数据返回");
+        log("info", "[Migu] getMiguEposides: 请求失败或无数据返回");
         return [];
       }
 
@@ -167,12 +167,12 @@ class MiguSource extends BaseSource {
             pID 
           }];
         }
-        log("info", "getMiguEposides: eps 不存在");
+        log("info", "[Migu] getMiguEposides: eps 不存在");
         return [];
       }
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getMiguEposides error:", {
+      log("error", "[Migu] getMiguEposides error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -265,7 +265,7 @@ class MiguSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求咪咕视频弹幕...", id);
+    log("info", "[Migu] 开始从本地请求咪咕视频弹幕...", id);
     
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -274,7 +274,7 @@ class MiguSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Migu] 弹幕分段数量: ${segmentList.length}`);
 
     // 并发请求所有弹幕段，限制并发数量为50
     const MAX_CONCURRENT = 100;
@@ -302,7 +302,7 @@ class MiguSource extends BaseSource {
             allComments.push(...comments);
           }
         } else {
-          log("error", `获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
+          log("error", `[Migu] 获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
         }
       }
       
@@ -313,7 +313,7 @@ class MiguSource extends BaseSource {
     }
 
     if (allComments.length === 0) {
-      log("info", `咪咕视频: 该视频暂无弹幕数据 (vid=${id})`);
+      log("info", `[Migu] 咪咕视频: 该视频暂无弹幕数据 (vid=${id})`);
       return [];
     }
 
@@ -323,14 +323,14 @@ class MiguSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取咪咕视频弹幕分段列表...", id);
+    log("info", "[Migu] 获取咪咕视频弹幕分段列表...", id);
 
     const itemId = this.extractEpId(id);
     const detail = await this.getDetail(itemId);
     const durationSec = time_to_second(detail.duration);
-    log("info", "itemId:", itemId);
-    log("info", "durationSec:", durationSec);
-    log("info", "epsID:", detail.epsID);
+    log("info", "[Migu] itemId:", itemId);
+    log("info", "[Migu] durationSec:", durationSec);
+    log("info", "[Migu] epsID:", detail.epsID);
 
     const segmentDuration = 30; // 每个分片30秒钟
     const segmentList = [];
@@ -376,7 +376,7 @@ class MiguSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Migu] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }

--- a/danmu_api/sources/other.js
+++ b/danmu_api/sources/other.js
@@ -27,18 +27,18 @@ export default class OtherSource extends BaseSource {
         }
       );
 
-      log("info", `danmu response from ${globals.otherServer}: ↓↓↓`);
+      log("info", `[Other] danmu response from ${globals.otherServer}: ↓↓↓`);
       printFirst200Chars(response.data);
 
       return response.data;
     } catch (error) {
-      log("error", `请求 ${globals.otherServer} 失败:`, error);
+      log("error", `[Other] 请求 ${globals.otherServer} 失败:`, error);
       return [];
     }
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取第三方服务器弹幕分段列表...", id);
+    log("info", "[Other] 获取第三方服务器弹幕分段列表...", id);
 
     return new SegmentListResponse({
       "type": "other_server",

--- a/danmu_api/sources/sohu.js
+++ b/danmu_api/sources/sohu.js
@@ -172,7 +172,7 @@ export default class SohuSource extends BaseSource {
       if (start > 0 && end > start) {
         data = JSON.parse(data.substring(start, end));
       } else {
-        log("error", "搜狐视频: 无法解析JSONP响应");
+        log("error", "[Sohu] 搜狐视频: 无法解析JSONP响应");
         return null;
       }
     } else if (typeof data === "string") {
@@ -195,7 +195,7 @@ export default class SohuSource extends BaseSource {
       const videosData = data.videos || [];
 
       if (!videosData || videosData.length === 0) {
-        log("warning", `搜狐视频: 未找到分集列表 (media_id=${id})`);
+        log("warn", `[Sohu] 搜狐视频: 未找到分集列表 (media_id=${id})`);
         return [];
       }
 
@@ -374,7 +374,7 @@ export default class SohuSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求搜狐视频弹幕...", id);
+    log("info", "[Sohu] 开始从本地请求搜狐视频弹幕...", id);
 
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -383,7 +383,7 @@ export default class SohuSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Sohu] 弹幕分段数量: ${segmentList.length}`);
 
     // 并发请求所有弹幕段，限制并发数量为5
     const MAX_CONCURRENT = 10;
@@ -415,7 +415,7 @@ export default class SohuSource extends BaseSource {
             break;
           }
         } else {
-          log("error", `获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
+          log("error", `[Sohu] 获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
         }
       }
       
@@ -426,7 +426,7 @@ export default class SohuSource extends BaseSource {
     }
 
     if (allComments.length === 0) {
-      log("info", `搜狐视频: 该视频暂无弹幕数据 (vid=${id})`);
+      log("info", `[Sohu] 搜狐视频: 该视频暂无弹幕数据 (vid=${id})`);
       return [];
     }
 
@@ -445,7 +445,7 @@ export default class SohuSource extends BaseSource {
       const response = await httpGet(segment.url, { headers, timeout: 10000 });
 
       if (!response || !response.data) {
-        log("error", `搜狐视频: 弹幕段响应为空 (${segment.segment_start}-${segment.segment_end}s)`);
+        log("error", `[Sohu] 搜狐视频: 弹幕段响应为空 (${segment.segment_start}-${segment.segment_end}s)`);
         return [];
       }
 
@@ -454,22 +454,22 @@ export default class SohuSource extends BaseSource {
         const comments = data.info?.comments || [];
 
         if (comments && comments.length > 0) {
-          log("info", `搜狐视频: 获取到 ${comments.length} 条弹幕 (${segment.segment_start}-${segment.segment_end}s)`);
+          log("info", `[Sohu] 搜狐视频: 获取到 ${comments.length} 条弹幕 (${segment.segment_start}-${segment.segment_end}s)`);
         }
 
         return comments || [];
       } catch (error) {
-        log("error", `搜狐视频: 解析弹幕响应失败: ${error.message}`);
+        log("error", `[Sohu] 搜狐视频: 解析弹幕响应失败: ${error.message}`);
         return [];
       }
     } catch (error) {
-      log("error", `搜狐视频: 获取弹幕段失败 (vid=${vid}, ${start}-${end}s): ${error.message}`);
+      log("error", `[Sohu] 搜狐视频: 获取弹幕段失败 (vid=${vid}, ${start}-${end}s): ${error.message}`);
       return [];
     }
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取搜狐视频弹幕分段列表...", id);
+    log("info", "[Sohu] 获取搜狐视频弹幕分段列表...", id);
 
     // 解析 episode_id
     const { vid, aid } = await this.extractVidAndAid(id);
@@ -515,7 +515,7 @@ export default class SohuSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Sohu] 请求分片弹幕失败:", error);
       return [];
     }
   }
@@ -561,7 +561,7 @@ export default class SohuSource extends BaseSource {
           like: comment.fcount
         };
       } catch (error) {
-        log("error", `格式化弹幕失败: ${error.message}, 弹幕数据:`, comment);
+        log("error", `[Sohu] 格式化弹幕失败: ${error.message}, 弹幕数据:`, comment);
         return null;
       }
     }).filter(comment => comment !== null);

--- a/danmu_api/sources/tencent.js
+++ b/danmu_api/sources/tencent.js
@@ -535,12 +535,12 @@ export default class TencentSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求腾讯视频弹幕...", id);
+    log("info", "[Tencent] 开始从本地请求腾讯视频弹幕...", id);
 
     // 解析 URL 获取 vid
     let vid = this.extractVid(id);
 
-    log("info", `vid: ${vid}`);
+    log("info", `[Tencent] vid: ${vid}`);
 
     // 获取页面标题
     let res;
@@ -552,14 +552,14 @@ export default class TencentSource extends BaseSource {
         },
       });
     } catch (error) {
-      log("error", "请求页面失败:", error);
+      log("error", "[Tencent] 请求页面失败:", error);
       return [];
     }
 
     // 使用正则表达式提取 <title> 标签内容
     const titleMatch = res.data.match(/<title[^>]*>(.*?)<\/title>/i);
     const title = titleMatch ? titleMatch[1].split("_")[0] : "未知标题";
-    log("info", `标题: ${title}`);
+    log("info", `[Tencent] 标题: ${title}`);
 
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -568,7 +568,7 @@ export default class TencentSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Tencent] 弹幕分段数量: ${segmentList.length}`);
 
     // 创建请求Promise数组
     const promises = [];
@@ -604,7 +604,7 @@ export default class TencentSource extends BaseSource {
         contents.push(...data.barrage_list);
       });
     } catch (error) {
-      log("error", "解析弹幕数据失败:", error);
+      log("error", "[Tencent] 解析弹幕数据失败:", error);
       return [];
     }
 
@@ -614,7 +614,7 @@ export default class TencentSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取腾讯视频弹幕分段列表...", id);
+    log("info", "[Tencent] 获取腾讯视频弹幕分段列表...", id);
 
     // 弹幕 API 基础地址
     const api_danmaku_base = "https://dm.video.qq.com/barrage/base/";
@@ -622,7 +622,7 @@ export default class TencentSource extends BaseSource {
 
     let vid = this.extractVid(id);
 
-    log("info", `获取弹幕分段列表 - vid: ${vid}`);
+    log("info", `[Tencent] 获取弹幕分段列表 - vid: ${vid}`);
 
     // 获取弹幕基础数据
     let res;
@@ -640,7 +640,7 @@ export default class TencentSource extends BaseSource {
           "segmentList": []
         });
       }
-      log("error", "请求弹幕基础数据失败:", error);
+      log("error", "[Tencent] 请求弹幕基础数据失败:", error);
       return new SegmentListResponse({
         "type": "qq",
         "segmentList": []
@@ -693,7 +693,7 @@ export default class TencentSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Tencent] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }

--- a/danmu_api/sources/tmdb.js
+++ b/danmu_api/sources/tmdb.js
@@ -45,11 +45,11 @@ export default class TmdbSource extends BaseSource {
         await this._getDoubanInfo(imdbId, mediaType, doubanIds);
       } else {
         const seasons = await getImdbSeasons(imdbId);
-        log("info", "imdb seasons:", seasons.data.seasons);
+        log("info", "[TMDB] imdb seasons:", seasons.data.seasons);
 
         const seasonPromises = (seasons?.data?.seasons ?? []).map(async (season) => {
           let finalImdbId = imdbId;
-          log("info", "imdb season:", season.season);
+          log("info", "[TMDB] imdb season:", season.season);
 
           try {
             if (Number(season.season) !== 1) {
@@ -59,7 +59,7 @@ export default class TmdbSource extends BaseSource {
 
             await this._getDoubanInfo(finalImdbId, mediaType, doubanIds);
           } catch (error) {
-            log("error", `处理第 ${season.season} 季失败，继续执行其他季:`, error);
+            log("error", `[TMDB] 处理第 ${season.season} 季失败，继续执行其他季:`, error);
           }
         });
 
@@ -68,7 +68,7 @@ export default class TmdbSource extends BaseSource {
 
       return doubanIds;
     } catch (error) {
-      log("error", "getTmdbIds error:", {
+      log("error", "[TMDB] getTmdbIds error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -90,14 +90,14 @@ export default class TmdbSource extends BaseSource {
         tmdbItems = data.results.filter(item => (item.name || item.title) === keyword);
       }
 
-      log("info", `tmdb items.length: ${tmdbItems.length}`);
+      log("info", `[TMDB] tmdb items.length: ${tmdbItems.length}`);
 
       const doubanPromises = tmdbItems.map(async (tmdbItem) => {
         try {
           const doubanIds = await this.getDoubanIdByTmdbId(tmdbItem.media_type, tmdbItem.id);
           return doubanIds;
         } catch (error) {
-          log("error", `获取 TMDB ID ${tmdbItem.id} 的豆瓣 ID 失败，继续处理其他条目:`, error);
+          log("error", `[TMDB] 获取 TMDB ID ${tmdbItem.id} 的豆瓣 ID 失败，继续处理其他条目:`, error);
           return []; // 失败返回空数组，不中断合并
         }
       });
@@ -107,7 +107,7 @@ export default class TmdbSource extends BaseSource {
 
       return tmpAnimes;
     } catch (error) {
-      log("error", "getTmdbAnimes error:", {
+      log("error", "[TMDB] getTmdbAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,

--- a/danmu_api/sources/vod.js
+++ b/danmu_api/sources/vod.js
@@ -28,17 +28,17 @@ export default class VodSource extends BaseSource {
       );
       // 检查 response.data.list 是否存在且长度大于 0
       if (response && response.data && response.data.list && response.data.list.length > 0) {
-        log("info", `请求 ${serverName}(${server}) 成功`);
+        log("info", `[VOD] 请求 ${serverName}(${server}) 成功`);
         const data = response.data;
-        log("info", `${serverName} response: ↓↓↓`);
+        log("info", `[VOD] ${serverName} response: ↓↓↓`);
         printFirst200Chars(data);
         return { serverName, list: data.list };
       } else {
-        log("info", `请求 ${serverName}(${server}) 成功，但 response.data.list 为空`);
+        log("info", `[VOD] 请求 ${serverName}(${server}) 成功，但 response.data.list 为空`);
         return { serverName, list: [] };
       }
     } catch (error) {
-      log("error", `请求 ${serverName}(${server}) 失败:`, {
+      log("error", `[VOD] 请求 ${serverName}(${server}) 失败:`, {
         message: error.message,
         name: error.name,
         stack: error.stack,

--- a/danmu_api/sources/xigua.js
+++ b/danmu_api/sources/xigua.js
@@ -77,7 +77,7 @@ class XiguaSource extends BaseSource {
           }
         });
       } else {
-        log("info", "xiguaSearchresp: 相关视频的section 不存在");
+        log("info", "[Xigua] xiguaSearchresp: 相关视频的section 不存在");
         return [];
       }
 
@@ -86,7 +86,7 @@ class XiguaSource extends BaseSource {
       return animes;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getXiguaAnimes error:", {
+      log("error", "[Xigua] getXiguaAnimes error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -110,7 +110,7 @@ class XiguaSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!resp || !resp.data) {
-        log("info", "getXiguaDetail: 请求失败或无数据返回");
+        log("info", "[Xigua] getXiguaDetail: 请求失败或无数据返回");
         return 0;
       }
 
@@ -118,7 +118,7 @@ class XiguaSource extends BaseSource {
       return match ? parseFloat(match[1]) : 0;
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getXiguaDetail error:", {
+      log("error", "[Xigua] getXiguaDetail error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -139,7 +139,7 @@ class XiguaSource extends BaseSource {
 
       // 判断 resp 和 resp.data 是否存在
       if (!detailResp || !detailResp.data) {
-        log("info", "getXiguaEposides: 请求失败或无数据返回");
+        log("info", "[Xigua] getXiguaEposides: 请求失败或无数据返回");
         return [];
       }
 
@@ -164,15 +164,15 @@ class XiguaSource extends BaseSource {
           return playlistUrls;
           
         } catch (e) {
-          log("error", '解析episodes_list失败:', e);
+          log("error", "[Xigua] 解析episodes_list失败:", e);
         }
       } else {
-        log("info", "getXiguaEposides: episodes_list 不存在");
+        log("info", "[Xigua] getXiguaEposides: episodes_list 不存在");
         return [];
       }
     } catch (error) {
       // 捕获请求中的错误
-      log("error", "getXiguaEposides error:", {
+      log("error", "[Xigua] getXiguaEposides error:", {
         message: error.message,
         name: error.name,
         stack: error.stack,
@@ -266,7 +266,7 @@ class XiguaSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求西瓜视频弹幕...", id);
+    log("info", "[Xigua] 开始从本地请求西瓜视频弹幕...", id);
     
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -275,7 +275,7 @@ class XiguaSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `弹幕分段数量: ${segmentList.length}`);
+    log("info", `[Xigua] 弹幕分段数量: ${segmentList.length}`);
 
     // 并发请求所有弹幕段，限制并发数量为50
     const MAX_CONCURRENT = 100;
@@ -303,7 +303,7 @@ class XiguaSource extends BaseSource {
             allComments.push(...comments);
           }
         } else {
-          log("error", `获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
+          log("error", `[Xigua] 获取弹幕段失败 (${start}-${end}s):`, result.reason.message);
         }
       }
       
@@ -314,7 +314,7 @@ class XiguaSource extends BaseSource {
     }
 
     if (allComments.length === 0) {
-      log("info", `西瓜视频: 该视频暂无弹幕数据 (vid=${id})`);
+      log("info", `[Xigua] 西瓜视频: 该视频暂无弹幕数据 (vid=${id})`);
       return [];
     }
 
@@ -324,12 +324,12 @@ class XiguaSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取西瓜视频弹幕分段列表...", id);
+    log("info", "[Xigua] 获取西瓜视频弹幕分段列表...", id);
 
     const itemId = id.split('/').pop();
     const duration = await this.getDetail(id) * 1000;
-    log("info", "itemId:", itemId);
-    log("info", "duration:", duration);
+    log("info", "[Xigua] itemId:", itemId);
+    log("info", "[Xigua] duration:", duration);
 
     const segmentDuration = 300000; // 每个分片5分钟
     const segmentList = [];
@@ -380,7 +380,7 @@ class XiguaSource extends BaseSource {
 
       return contents;
     } catch (error) {
-      log("error", "请求分片弹幕失败:", error);
+      log("error", "[Xigua] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }

--- a/danmu_api/sources/youku.js
+++ b/danmu_api/sources/youku.js
@@ -391,7 +391,7 @@ export default class YoukuSource extends BaseSource {
   }
 
    async getEpisodeDanmu(id) {
-    log("info", "开始从本地请求优酷弹幕...", id);
+    log("info", "[Youku] 开始从本地请求优酷弹幕...", id);
 
     if (!id) {
       return [];
@@ -438,7 +438,7 @@ export default class YoukuSource extends BaseSource {
           }
         }
       } catch (e) {
-        log("error", "优酷分段批量请求失败:", e.message);
+        log("error", "[Youku] 优酷分段批量请求失败:", e.message);
       }
     }
 
@@ -448,7 +448,7 @@ export default class YoukuSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "获取优酷弹幕分段列表...", id);
+    log("info", "[Youku] 获取优酷弹幕分段列表...", id);
 
     if (!id) {
       return new SegmentListResponse({
@@ -475,14 +475,14 @@ export default class YoukuSource extends BaseSource {
     if (match) {
       path = match[2].split('/').filter(Boolean);  // 分割路径并去掉空字符串
       path.unshift("");
-      log("info", path);
+      log("info", "[Youku]", path);
     } else {
-      log("error", 'Invalid URL');
+      log("error", "[Youku] Invalid URL");
       return [];
     }
     const video_id = path[path.length - 1].split(".")[0].slice(3);
 
-    log("info", `video_id: ${video_id}`);
+    log("info", `[Youku] video_id: ${video_id}`);
 
     // 获取页面标题和视频时长
     let res;
@@ -496,14 +496,14 @@ export default class YoukuSource extends BaseSource {
         allow_redirects: false
       });
     } catch (error) {
-      log("error", "请求视频信息失败:", error);
+      log("error", "[Youku] 请求视频信息失败:", error);
       return [];
     }
 
     const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
     const title = data.title;
     const duration = data.duration;
-    log("info", `标题: ${title}, 时长: ${duration}`);
+    log("info", `[Youku] 标题: ${title}, 时长: ${duration}`);
 
     // 获取 cna 和 tk_enc
     let cna, _m_h5_tk_enc, _m_h5_tk;
@@ -517,14 +517,14 @@ export default class YoukuSource extends BaseSource {
         },
         allow_redirects: false
       });
-      log("info", `cnaRes: ${JSON.stringify(cnaRes)}`);
-      log("info", `cnaRes.headers: ${JSON.stringify(cnaRes.headers)}`);
+      log("info", `[Youku] cnaRes: ${JSON.stringify(cnaRes)}`);
+      log("info", `[Youku] cnaRes.headers: ${JSON.stringify(cnaRes.headers)}`);
       const etag = cnaRes.headers["etag"] || cnaRes.headers["Etag"];
-      log("info", `etag: ${etag}`);
+      log("info", `[Youku] etag: ${etag}`);
       // const match = cnaRes.headers["set-cookie"].match(/cna=([^;]+)/);
       // cna = match ? match[1] : null;
       cna = etag.replace(/^"|"$/g, '');
-      log("info", `cna: ${cna}`);
+      log("info", `[Youku] cna: ${cna}`);
 
       let tkEncRes;
       while (!tkEncRes) {
@@ -536,10 +536,10 @@ export default class YoukuSource extends BaseSource {
           allow_redirects: false
         });
       }
-      log("info", `tkEncRes: ${JSON.stringify(tkEncRes)}`);
-      log("info", `tkEncRes.headers: ${JSON.stringify(tkEncRes.headers)}`);
+      log("info", `[Youku] tkEncRes: ${JSON.stringify(tkEncRes)}`);
+      log("info", `[Youku] tkEncRes.headers: ${JSON.stringify(tkEncRes.headers)}`);
       const tkEncSetCookie = tkEncRes.headers["set-cookie"] || tkEncRes.headers["Set-Cookie"];
-      log("info", `tkEncSetCookie: ${tkEncSetCookie}`);
+      log("info", `[Youku] tkEncSetCookie: ${tkEncSetCookie}`);
 
       // 获取 _m_h5_tk_enc
       const tkEncMatch = tkEncSetCookie.match(/_m_h5_tk_enc=([^;]+)/);
@@ -549,10 +549,10 @@ export default class YoukuSource extends BaseSource {
       const tkH5Match = tkEncSetCookie.match(/_m_h5_tk=([^;]+)/);
       _m_h5_tk = tkH5Match ? tkH5Match[1] : null;
 
-      log("info", `_m_h5_tk_enc: ${_m_h5_tk_enc}`);
-      log("info", `_m_h5_tk: ${_m_h5_tk}`);
+      log("info", `[Youku] _m_h5_tk_enc: ${_m_h5_tk_enc}`);
+      log("info", `[Youku] _m_h5_tk: ${_m_h5_tk}`);
     } catch (error) {
-      log("error", "获取 cna 或 tk_enc 失败:", error);
+      log("error", "[Youku] 获取 cna 或 tk_enc 失败:", error);
       return [];
     }
 
@@ -634,7 +634,7 @@ export default class YoukuSource extends BaseSource {
 
       const queryString = buildQueryString(params);
       const url = `${api_danmaku}?${queryString}`;
-      log("info", `piece_url: ${url}`);
+      log("info", `[Youku] piece_url: ${url}`);
 
       return {
         "type": "youku",
@@ -660,7 +660,7 @@ export default class YoukuSource extends BaseSource {
   }
 
   async getEpisodeSegmentDanmu(segment) {
-    log("info", "开始从本地请求优酷分段弹幕...", segment.url);
+    log("info", "[Youku] 开始从本地请求优酷分段弹幕...", segment.url);
 
     const response = await httpPost(segment.url, buildQueryString({ data: segment.data }), {
       headers: {

--- a/danmu_api/ui/css/components.css.js
+++ b/danmu_api/ui/css/components.css.js
@@ -261,6 +261,51 @@ export const componentsCssContent = /* css */ `
 
 
 
+/* 日志过滤交互面板及标签样式 */
+.log-filters-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.filter-btn {
+    background: transparent;
+    color: #888;
+    border: 1px solid #555;
+    padding: 4px 14px;
+    border-radius: 20px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: all 0.3s;
+    text-transform: capitalize;
+}
+
+.filter-btn:hover {
+    border-color: #999;
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.filter-btn.active {
+    background: rgba(191, 161, 255, 0.1);
+    color: #bfa1ff;
+    border-color: #bfa1ff;
+    text-shadow: 0.3px 0 0 currentColor, -0.3px 0 0 currentColor;
+}
+
+.log-tag {
+    color: #bfa1ff;
+    font-weight: bold;
+    margin-right: 4px;
+    display: inline-block;
+}
+
+.log-entry.error .log-tag {
+    color: #ffb74d;
+}
+
+
+
 /* 表单帮助文本 */
 .form-help {
     font-size: 12px;

--- a/danmu_api/ui/js/logview.js
+++ b/danmu_api/ui/js/logview.js
@@ -1,5 +1,60 @@
 // language=JavaScript
 export const logviewJsContent = /* javascript */ `
+// 日志全局过滤状态
+let currentLogFilter = 'ALL';
+
+// 获取日志的严格归属分类
+function getLogCategory(message) {
+    // 匹配行首的连续方括号标签 (需双重转义)
+    const prefixMatch = message.match(/^(?:\\s*\\[[^\\]]+\\])+/);
+    if (!prefixMatch) {
+        // 无标签行作为续行继承上一行的分类
+        return '_inherit_';
+    }
+    
+    const tags = prefixMatch[0].match(/\\[([^\\]]+)\\]/g).map(t => t.replace(/[\\[\\]]/g, '').trim());
+    
+    // 归类合并工具日志
+    // 只要行首包含 Merge，或者包含合并映射独有的子标签，强行将其收束至 Merge 专属分类
+    if (tags.some(t => t.toLowerCase() === 'merge' || ['匹配', '落单', '补全', '合集', '略过', 'Merge-Check'].some(key => t.includes(key)))) {
+        return 'merge';
+    }
+    
+    // 排除时间戳和底层无意义标签，抓取真正的业务源
+    const validTags = tags.filter(t => 
+        !/^\\d{4}-\\d{2}-\\d{2}[T ]/.test(t) && // 排除 ISO 时间戳格式（YYYY-MM-DDTHH:MM:SS）
+        !/^\\d{2}:\\d{2}(:\\d{2})?$/.test(t) &&  // 排除 HH:MM:SS 时间格式（JSON 续行）
+        !t.includes('08:00') &&
+        t !== '请求模拟' && 
+        t !== '网络请求'
+    );
+    
+    if (validTags.length === 0) {
+        // 全部标签被时间戳等过滤规则排除，作为续行继承上一行的分类
+        return '_inherit_';
+    }
+    
+    // 统一转换为小写，确保大小写变体(如 Bahamut 和 bahamut)收束至同一内部标识符
+    let category = validTags[0].toLowerCase();
+    
+    // 标签归一化：将变体标签映射到标准分类
+    const normalizationMap = {
+        'vod fastest mode': 'vod',
+        'custom source': 'custom',
+        'bilibili-proxy': 'bilibili',
+        'tmdb-source': 'tmdb',
+        'path check': 'system',
+        'path fix': 'system',
+        'base': 'system',
+        'fongmi': 'system',
+    };
+    if (normalizationMap[category]) {
+        category = normalizationMap[category];
+    }
+    
+    return category;
+}
+
 // 日志相关
 function addLog(message, type = 'info') {
     const timestamp = new Date().toLocaleTimeString();
@@ -10,11 +65,93 @@ function addLog(message, type = 'info') {
 
 function renderLogs() {
     const container = document.getElementById('log-container');
-    container.innerHTML = logs.map(log =>
-        \`<div class="log-entry \${log.type}">[\${log.timestamp}] \${log.message}</div>\`
-    ).join('');
+    const filterContainer = document.getElementById('log-filters') || createFilterContainer();
+    
+    let filteredLogs = logs;
+    if (currentLogFilter !== 'ALL') {
+        // 采用严格归属校验，同时支持续行上下文继承
+        let lastCategory = 'system';
+        filteredLogs = logs.filter(log => {
+            let category = getLogCategory(log.message);
+            if (category === '_inherit_') {
+                // 续行继承上一个明确分类行
+                category = lastCategory;
+            } else {
+                lastCategory = category;
+            }
+            return category === currentLogFilter;
+        });
+    }
+
+    container.innerHTML = filteredLogs.map(log => {
+        let highlightedMessage = log.message;
+        
+        // 行首连续标签高亮 (需双重转义)
+        const prefixMatch = log.message.match(/^(?:\\s*\\[[^\\]]+\\])+/);
+        if (prefixMatch) {
+            const prefix = prefixMatch[0];
+            const rest = log.message.slice(prefix.length);
+            const coloredPrefix = prefix.replace(/\\[([^\\]]+)\\]/g, '<span class="log-tag">[$1]</span>');
+            highlightedMessage = coloredPrefix + rest;
+        }
+        
+        return \`<div class="log-entry \${log.type}">[\${log.timestamp}] \${highlightedMessage}</div>\`;
+    }).join('');
     container.scrollTop = container.scrollHeight;
+    
+    updateFilterUI();
 }
+
+function createFilterContainer() {
+    const controls = document.querySelector('.log-controls');
+    const filterDiv = document.createElement('div');
+    filterDiv.id = 'log-filters';
+    filterDiv.className = 'log-filters-container';
+    controls.parentNode.insertBefore(filterDiv, document.getElementById('log-container'));
+    return filterDiv;
+}
+
+// 标签显示顺序：ALL → 系统 → 工具 → 源，组内字母序
+const tagGroupOrder = [
+    ['system', 'ai'],
+    ['utils', 'cache', 'merge'],
+    ['360kan', 'aiyifan', 'animeko', 'bahamut', 'bilibili', 'custom', 'dandan', 'douban', 'hanjutv', 'iqiyi', 'leshi', 'maiduidui', 'mango', 'migu', 'other', 'renren', 'sohu', 'tencent', 'tmdb', 'vod', 'xigua', 'youku'],
+];
+const tagOrderMap = {};
+tagGroupOrder.forEach((group, gi) => group.forEach((tag, ti) => tagOrderMap[tag] = gi * 1000 + ti));
+
+function updateFilterUI() {
+    const filterContainer = document.getElementById('log-filters');
+    let html = \`<button class="filter-btn \${currentLogFilter === 'ALL' ? 'active' : ''}" onclick="setLogFilter('ALL')">ALL</button>\`;
+    
+    const currentTags = new Set();
+    let lastCategory = 'system';
+    logs.forEach(log => {
+        let category = getLogCategory(log.message);
+        // 续行继承上一个明确分类行
+        if (category === '_inherit_') {
+            category = lastCategory;
+        } else {
+            lastCategory = category;
+        }
+        // 所有分类标签均生成筛选按钮
+        currentTags.add(category);
+    });
+
+    [...currentTags].sort((a, b) => {
+        const ai = tagOrderMap[a] ?? 99999, bi = tagOrderMap[b] ?? 99999;
+        return ai !== bi ? ai - bi : a.localeCompare(b);
+    }).forEach(tag => {
+        html += \`<button class="filter-btn \${currentLogFilter === tag ? 'active' : ''}" onclick="setLogFilter('\${tag}')">\${tag}</button>\`;
+    });
+    
+    filterContainer.innerHTML = html;
+}
+
+window.setLogFilter = function(tag) {
+    currentLogFilter = tag;
+    renderLogs();
+};
 
 // 从API获取真实日志数据
 async function fetchRealLogs() {

--- a/danmu_api/utils/aiyifan-util.js
+++ b/danmu_api/utils/aiyifan-util.js
@@ -142,7 +142,7 @@ export function extractPConfigFromHtml(html) {
         return signingConfig;
       }
     } catch (error) {
-      log("warn", '[Aiyifan] 解析 injectJson 失败，回退到 pConfig 提取: ' + (error.message || '未知错误'));
+      log("warn", '[Utils] [Aiyifan] 解析 injectJson 失败，回退到 pConfig 提取: ' + (error.message || '未知错误'));
     }
   }
 
@@ -322,7 +322,7 @@ export class AiyifanSigningProvider {
 
     this.signingConfig = signingConfig;
     this.signingConfigFetchedAt = now;
-    log("info", '[Aiyifan] 已更新桌面站签名配置: ' + signingConfig.publicKey.slice(0, 12) + '...');
+    log("info", '[Utils] [Aiyifan] 已更新桌面站签名配置: ' + signingConfig.publicKey.slice(0, 12) + '...');
     return signingConfig;
   }
 

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -137,7 +137,7 @@ async function fetchNpmLatestVersion(packageName) {
         const data = await response.json();
         return data?.version || null;
     } catch (e) {
-        log("warn", `[Bangumi-Data] 查询 ${packageName} 版本号失败: ${e.message}`);
+        log("warn", `[Utils] [Bangumi-Data] 查询 ${packageName} 版本号失败: ${e.message}`);
         return null;
     }
 }
@@ -163,18 +163,18 @@ async function selectBestDataSource() {
         if (officialVer) cachedOfficialVersion = officialVer;
 
         if (!customVer || !officialVer) {
-            log("info", `[Bangumi-Data] 版本检测不完整 (custom=${customVer}, official=${officialVer})，默认使用自定义源`);
+            log("info", `[Utils] [Bangumi-Data] 版本检测不完整 (custom=${customVer}, official=${officialVer})，默认使用自定义源`);
             return 'custom';
         }
 
         const cmp = compareVersions(customVer, officialVer);
         const selected = cmp >= 0 ? 'custom' : 'official';
 
-        log("info", `[Bangumi-Data] 版本对比: @wan0ge/bangumi-data@${customVer} vs bangumi-data@${officialVer} => 使用${selected === 'custom' ? '自定义' : '官方'}源`);
+        log("info", `[Utils] [Bangumi-Data] 版本对比: @wan0ge/bangumi-data@${customVer} vs bangumi-data@${officialVer} => 使用${selected === 'custom' ? '自定义' : '官方'}源`);
 
         return selected;
     } catch (e) {
-        log("warn", `[Bangumi-Data] 数据源选择异常，回退到自定义源: ${e.message}`);
+        log("warn", `[Utils] [Bangumi-Data] 数据源选择异常，回退到自定义源: ${e.message}`);
         return 'custom';
     }
 }
@@ -198,19 +198,19 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
         if (fs.existsSync(CACHE_DIR)) {
             cachePath = path.join(CACHE_DIR, CACHE_FILENAME);
         } else if (!hasLoggedCacheWarning) {
-            log("warn", "[Bangumi-Data] 未检测到根目录的 .cache 文件夹！");
-            log("warn", "[Bangumi-Data] 按照项目规范，请手动挂载或创建 .cache 目录以启用持久化。");
-            log("warn", "[Bangumi-Data] 本次运行已退化为纯内存模式 (重启后需重新下载)。");
+            log("warn", "[Utils] [Bangumi-Data] 未检测到根目录的 .cache 文件夹！");
+            log("warn", "[Utils] [Bangumi-Data] 按照项目规范，请手动挂载或创建 .cache 目录以启用持久化。");
+            log("warn", "[Utils] [Bangumi-Data] 本次运行已退化为纯内存模式 (重启后需重新下载)。");
             hasLoggedCacheWarning = true;
         }
     } else if (!hasLoggedCacheWarning) {
-        log("info", `[Bangumi-Data] 检测到 ${deployPlatform} 云环境，当前运行于纯内存加速模式。`);
+        log("info", `[Utils] [Bangumi-Data] 检测到 ${deployPlatform} 云环境，当前运行于纯内存加速模式。`);
         hasLoggedCacheWarning = true;
     }
 
     // 幽灵死锁自愈机制 (针对 Serverless 强杀)
     if (isDownloading && (Date.now() - downloadLockTime > DOWNLOAD_TIMEOUT_MS)) {
-        log("warn", "[Bangumi-Data] 检测到下载状态锁死 (由于 Serverless 进程休眠/强杀导致)，强制释放锁...");
+        log("warn", "[Utils] [Bangumi-Data] 检测到下载状态锁死 (由于 Serverless 进程休眠/强杀导致)，强制释放锁...");
         isDownloading = false;
     }
 
@@ -222,7 +222,7 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
 
         // 当内存过期或配置强制更新时，仅在核心请求触发后台静默更新
         if (isDataDependentRequest && !isDownloading) {
-            log("info", `[Bangumi-Data] 内存数据${cacheDays === 0 ? '强制更新' : '已过期'}，保留老数据服务本次请求，启动后台静默更新...`);
+            log("info", `[Utils] [Bangumi-Data] 内存数据${cacheDays === 0 ? '强制更新' : '已过期'}，保留老数据服务本次请求，启动后台静默更新...`);
             isDownloading = true;
             downloadLockTime = Date.now();
             downloadAndCache(cachePath).finally(() => { isDownloading = false; });
@@ -255,11 +255,11 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
             const totalMemMB = (process.memoryUsage().rss / 1024 / 1024).toFixed(2);
             memoryCacheTime = Date.now(); 
 
-            log("info", `[Bangumi-Data] 成功从本地磁盘加载基础数据，条目数: ${memoryCache.items.length}，解析耗时: ${loadTimeMs} ms，约占内存: ${memoryFootprintMB} MB`);
+            log("info", `[Utils] [Bangumi-Data] 成功从本地磁盘加载基础数据，条目数: ${memoryCache.items.length}，解析耗时: ${loadTimeMs} ms，约占内存: ${memoryFootprintMB} MB`);
 
             if (cacheDays === 0 || (Date.now() - stats.mtimeMs >= expireMs)) {
                 if (isDataDependentRequest && !isDownloading) {
-                    log("info", `[Bangumi-Data] 磁盘数据${cacheDays === 0 ? '强制更新' : '已过期'}，保留老数据服务本次请求，启动后台静默更新...`);
+                    log("info", `[Utils] [Bangumi-Data] 磁盘数据${cacheDays === 0 ? '强制更新' : '已过期'}，保留老数据服务本次请求，启动后台静默更新...`);
                     isDownloading = true;
                     downloadLockTime = Date.now();
                     downloadAndCache(cachePath).finally(() => { isDownloading = false; });
@@ -267,14 +267,14 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
             }
             return;
         } catch (e) {
-            log("error", "[Bangumi-Data] 磁盘缓存解析失败，准备重新下载", e.message);
+            log("error", "[Utils] [Bangumi-Data] 磁盘缓存解析失败，准备重新下载", e.message);
             memoryCache = null; 
         }
     }
 
     // 内存与磁盘均无有效数据时的获取逻辑
     if (!isDownloading) {
-        log("info", `[Bangumi-Data] 未命中任何有效缓存，正在获取基础数据...`);
+        log("info", `[Utils] [Bangumi-Data] 未命中任何有效缓存，正在获取基础数据...`);
         isDownloading = true;
         downloadLockTime = Date.now();
 
@@ -283,18 +283,18 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
         if (isDataDependentRequest) {
             await downloadPromise; 
         } else {
-            log("info", `[Bangumi-Data] 当前非核心请求，数据获取转入后台异步执行`);
+            log("info", `[Utils] [Bangumi-Data] 当前非核心请求，数据获取转入后台异步执行`);
             if (ctx && typeof ctx.waitUntil === 'function') {
-                log("info", `[Bangumi-Data] 调用 ctx.waitUntil 延长 Serverless 生命周期`);
+                log("info", `[Utils] [Bangumi-Data] 调用 ctx.waitUntil 延长 Serverless 生命周期`);
                 ctx.waitUntil(downloadPromise);
             }
         }
     } else if (isDataDependentRequest) {
-        log("info", `[Bangumi-Data] 正在等待基础数据下载完成...`);
+        log("info", `[Utils] [Bangumi-Data] 正在等待基础数据下载完成...`);
         let waitCount = 0;
         while (isDownloading) {
             if (waitCount > 150) { // 最多等待 15 秒 (150 * 100ms)
-                log("warn", "[Bangumi-Data] 等待排队超时，放弃等待");
+                log("warn", "[Utils] [Bangumi-Data] 等待排队超时，放弃等待");
                 isDownloading = false;
                 break;
             }
@@ -378,7 +378,7 @@ function pruneBangumiData(rawData) {
  * @returns {Promise<void>}
  */
 async function downloadAndCache(cachePath) {
-    log("info", "[Bangumi-Data] 开始优选节点下载最新数据并执行精简...");
+    log("info", "[Utils] [Bangumi-Data] 开始优选节点下载最新数据并执行精简...");
     try {
         const memBefore = process.memoryUsage().heapUsed;
         const startTime = Date.now();
@@ -457,7 +457,7 @@ async function downloadAndCache(cachePath) {
         }
 
         const downloadTime = ((Date.now() - startTime) / 1000).toFixed(2);
-        log("info", `[Bangumi-Data] 精简数据已成功写入磁盘 (节点: ${new URL(winner.url).hostname} ,阶段耗时: ${downloadTime} 秒)`);
+        log("info", `[Utils] [Bangumi-Data] 精简数据已成功写入磁盘 (节点: ${new URL(winner.url).hostname} ,阶段耗时: ${downloadTime} 秒)`);
 
         // 数据处理流
         memoryCache = winner.resultData;
@@ -472,11 +472,11 @@ async function downloadAndCache(cachePath) {
         const totalMemMB = (process.memoryUsage().rss / 1024 / 1024).toFixed(2);
         memoryCacheTime = Date.now();
 
-        log("info", `[Bangumi-Data] 加载到内存成功，保留/原始条目数: ${memoryCache.items.length} / ${winner.originalCount}，处理耗时: ${parseTimeMs} ms，全链路总耗时: ${totalTime} 秒，净增内存: ${memoryFootprintMB} MB (当前项目总占用: ${totalMemMB} MB)`);
+        log("info", `[Utils] [Bangumi-Data] 加载到内存成功，保留/原始条目数: ${memoryCache.items.length} / ${winner.originalCount}，处理耗时: ${parseTimeMs} ms，全链路总耗时: ${totalTime} 秒，净增内存: ${memoryFootprintMB} MB (当前项目总占用: ${totalMemMB} MB)`);
     } catch (e) {
         // 提取所有请求均失败时的具体错误信息
         const errorMessage = e instanceof AggregateError ? e.errors.map(err => err.message).join(' | ') : e.message;
-        log("error", "[Bangumi-Data] 下载失败 (所有 CDN 均未响应或报错):", errorMessage);
+        log("error", "[Utils] [Bangumi-Data] 下载失败 (所有 CDN 均未响应或报错):", errorMessage);
     }
 }
 
@@ -746,7 +746,7 @@ export function clearBangumiDataCache(clearDisk = false) {
         queryCache.clear(); // 释放查询缓存
         charInvertedIndex.clear(); // 释放倒排索引内存
         const totalMemMB = (process.memoryUsage().rss / 1024 / 1024).toFixed(2);
-        log("info", `[Bangumi-Data] 内存缓存已主动释放 (原条目数: ${itemCount}，释放: ${memoryFootprintMB} MB，当前项目总占用: ${totalMemMB} MB)`);
+        log("info", `[Utils] [Bangumi-Data] 内存缓存已主动释放 (原条目数: ${itemCount}，释放: ${memoryFootprintMB} MB，当前项目总占用: ${totalMemMB} MB)`);
         memoryFootprintMB = '0.00'; // 重置探针
         hasLoggedCacheWarning = false; // 重置警告标记
     }
@@ -762,9 +762,9 @@ export function clearBangumiDataCache(clearDisk = false) {
                 const tmpPath = `${cachePath}.tmp${i}`;
                 if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
             }
-            log("info", `[Bangumi-Data] 磁盘缓存已同步清理`);
+            log("info", `[Utils] [Bangumi-Data] 磁盘缓存已同步清理`);
         } catch (e) {
-            log("error", `[Bangumi-Data] 磁盘缓存清理失败: ${e.message}`);
+            log("error", `[Utils] [Bangumi-Data] 磁盘缓存清理失败: ${e.message}`);
         }
     }
 }

--- a/danmu_api/utils/cache-util.js
+++ b/danmu_api/utils/cache-util.js
@@ -93,7 +93,7 @@ function getActiveSearchCacheEntries() {
 
         if (cacheAgeMinutes > globals.searchCacheMinutes) {
             globals.searchCache.delete(keyword);
-            log("info", `Search cache for "${keyword}" expired after ${cacheAgeMinutes.toFixed(2)} minutes`);
+            log("info", `[Cache] Search cache for "${keyword}" expired after ${cacheAgeMinutes.toFixed(2)} minutes`);
             continue;
         }
 
@@ -251,7 +251,7 @@ export function isSearchCacheValid(keyword) {
     if (cacheAgeMinutes > globals.searchCacheMinutes) {
         // 缓存已过期，删除它
         globals.searchCache.delete(keyword);
-        log("info", `Search cache for "${keyword}" expired after ${cacheAgeMinutes.toFixed(2)} minutes`);
+        log("info", `[Cache] Search cache for "${keyword}" expired after ${cacheAgeMinutes.toFixed(2)} minutes`);
         return false;
     }
 
@@ -261,7 +261,7 @@ export function isSearchCacheValid(keyword) {
 // 获取搜索缓存
 export function getSearchCache(keyword, detailsMap = null) {
     if (isSearchCacheValid(keyword)) {
-        log("info", `Using search cache for "${keyword}"`);
+        log("info", `[Cache] Using search cache for "${keyword}"`);
         const cached = globals.searchCache.get(keyword);
 
         if (detailsMap instanceof Map && Array.isArray(cached.details)) {
@@ -285,7 +285,7 @@ export function setSearchCache(keyword, results, detailsMap = null) {
         timestamp: Date.now()
     });
 
-    log("info", `Cached search results for "${keyword}" (${results.length} animes)`);
+    log("info", `[Cache] Cached search results for "${keyword}" (${results.length} animes)`);
 }
 
 // 检查弹幕缓存是否有效（未过期）
@@ -301,7 +301,7 @@ export function isCommentCacheValid(videoUrl) {
     if (cacheAgeMinutes > globals.commentCacheMinutes) {
         // 缓存已过期，删除它
         globals.commentCache.delete(videoUrl);
-        log("info", `Comment cache for "${videoUrl}" expired after ${cacheAgeMinutes.toFixed(2)} minutes`);
+        log("info", `[Cache] Comment cache for "${videoUrl}" expired after ${cacheAgeMinutes.toFixed(2)} minutes`);
         return false;
     }
 
@@ -311,7 +311,7 @@ export function isCommentCacheValid(videoUrl) {
 // 获取弹幕缓存
 export function getCommentCache(videoUrl) {
     if (isCommentCacheValid(videoUrl)) {
-        log("info", `Using comment cache for "${videoUrl}"`);
+        log("info", `[Cache] Using comment cache for "${videoUrl}"`);
         return globals.commentCache.get(videoUrl).comments;
     }
     return null;
@@ -324,7 +324,7 @@ export function setCommentCache(videoUrl, comments) {
         timestamp: Date.now()
     });
 
-    log("info", `Cached comments for "${videoUrl}" (${comments.length} comments)`);
+    log("info", `[Cache] Cached comments for "${videoUrl}" (${comments.length} comments)`);
 }
 
 // 添加元素到 episodeIds：检查 url 是否存在，若不存在则以自增 id 添加
@@ -332,7 +332,7 @@ export function addEpisode(url, title) {
     // 检查是否已存在相同的 url 和 title
     const existingEpisode = globals.episodeIds.find(episode => episode.url === url && episode.title === title);
     if (existingEpisode) {
-        log("info", `Episode with URL ${url} and title ${title} already exists in episodeIds, returning existing episode.`);
+        log("info", `[Cache] Episode with URL ${url} and title ${title} already exists in episodeIds, returning existing episode.`);
         return existingEpisode; // 返回已存在的 episode
     }
 
@@ -343,7 +343,7 @@ export function addEpisode(url, title) {
     // 添加新对象
     globals.episodeIds.push(newEpisode);
 
-    log("info", `Added to episodeIds: ${JSON.stringify(newEpisode)}`);
+    log("info", `[Cache] Added to episodeIds: ${JSON.stringify(newEpisode)}`);
     return newEpisode; // 返回新添加的对象
 }
 
@@ -353,10 +353,10 @@ export function removeEpisodeByUrl(url) {
     globals.episodeIds = globals.episodeIds.filter(episode => episode.url !== url);
     const removedCount = initialLength - globals.episodeIds.length;
     if (removedCount > 0) {
-        log("info", `Removed ${removedCount} episode(s) from episodeIds with URL: ${url}`);
+        log("info", `[Cache] Removed ${removedCount} episode(s) from episodeIds with URL: ${url}`);
         return true;
     }
-    log("error", `No episode found in episodeIds with URL: ${url}`);
+    log("error", `[Cache] No episode found in episodeIds with URL: ${url}`);
     return false;
 }
 
@@ -364,17 +364,17 @@ export function removeEpisodeByUrl(url) {
 export function findUrlById(id) {
     const episode = globals.episodeIds.find(episode => episode.id === id);
     if (episode) {
-        log("info", `Found URL for ID ${id}: ${episode.url}`);
+        log("info", `[Cache] Found URL for ID ${id}: ${episode.url}`);
         return episode.url;
     }
 
     const resolved = resolveEpisodeContextById(id);
     if (resolved?.link?.url) {
-        log("info", `Found URL for ID ${id} via cached anime details: ${resolved.link.url}`);
+        log("info", `[Cache] Found URL for ID ${id} via cached anime details: ${resolved.link.url}`);
         return resolved.link.url;
     }
 
-    log("error", `No URL found for ID: ${id}`);
+    log("error", `[Cache] No URL found for ID: ${id}`);
     return null;
 }
 
@@ -382,17 +382,17 @@ export function findUrlById(id) {
 export function findIndexById(id) {
     const index = globals.episodeIds.findIndex(episode => episode.id === id);
     if (index !== -1) {
-        log("info", `Found index for ID ${id}: ${index}`);
+        log("info", `[Cache] Found index for ID ${id}: ${index}`);
         return index;
     }
 
     const resolved = resolveEpisodeContextById(id);
     if (resolved) {
-        log("info", `Found index for ID ${id} via cached anime details: ${resolved.index}`);
+        log("info", `[Cache] Found index for ID ${id} via cached anime details: ${resolved.index}`);
         return resolved.index;
     }
 
-    log("error", `No index found for ID: ${id}`);
+    log("error", `[Cache] No index found for ID: ${id}`);
     return -1;
 }
 
@@ -400,17 +400,17 @@ export function findIndexById(id) {
 export function findTitleById(id) {
     const episode = globals.episodeIds.find(episode => episode.id === id);
     if (episode) {
-        log("info", `Found TITLE for ID ${id}: ${episode.title}`);
+        log("info", `[Cache] Found TITLE for ID ${id}: ${episode.title}`);
         return episode.title;
     }
 
     const resolved = resolveEpisodeContextById(id);
     if (resolved?.link?.title) {
-        log("info", `Found TITLE for ID ${id} via cached anime details: ${resolved.link.title}`);
+        log("info", `[Cache] Found TITLE for ID ${id} via cached anime details: ${resolved.link.title}`);
         return resolved.link.title;
     }
 
-    log("error", `No TITLE found for ID: ${id}`);
+    log("error", `[Cache] No TITLE found for ID: ${id}`);
     return null;
 }
 
@@ -418,11 +418,11 @@ export function findTitleById(id) {
 export function findAnimeTitleById(id) {
     const resolved = resolveEpisodeContextById(id);
     if (resolved?.anime?.animeTitle) {
-        log("info", `Found animeTitle for ID ${id}: ${resolved.anime.animeTitle}`);
+        log("info", `[Cache] Found animeTitle for ID ${id}: ${resolved.anime.animeTitle}`);
         return resolved.anime.animeTitle;
     }
 
-    log("error", `No animeTitle found for ID: ${id}`);
+    log("error", `[Cache] No animeTitle found for ID: ${id}`);
     return null;
 }
 
@@ -432,7 +432,7 @@ export function addAnime(anime, detailStore = null) {
     try {
         // 确保 anime 有 links 属性且是数组
         if (!anime.links || !Array.isArray(anime.links)) {
-            log("error", `Invalid or missing links in anime: ${JSON.stringify(anime)}`);
+            log("error", `[Cache] Invalid or missing links in anime: ${JSON.stringify(anime)}`);
             return false;
         }
 
@@ -445,7 +445,7 @@ export function addAnime(anime, detailStore = null) {
                     newLinks.push(episode); // 仅添加成功添加的 episode
                 }
             } else {
-                log("error", `Invalid link in anime, missing url: ${JSON.stringify(link)}`);
+                log("error", `[Cache] Invalid link in anime, missing url: ${JSON.stringify(link)}`);
             }
         });
 
@@ -461,22 +461,22 @@ export function addAnime(anime, detailStore = null) {
         if (existingAnimeIndex !== -1) {
             // 如果存在，先删除旧的
             globals.animes.splice(existingAnimeIndex, 1);
-            log("info", `Removed old anime at index: ${existingAnimeIndex}`);
+            log("info", `[Cache] Removed old anime at index: ${existingAnimeIndex}`);
         }
 
         // 将新的添加到数组末尾（最新位置）
         globals.animes.push(animeCopy);
-        log("info", `Added anime to latest position: ${anime.animeId}`);
+        log("info", `[Cache] Added anime to latest position: ${anime.animeId}`);
 
         // 检查是否超过 MAX_ANIMES，超过则删除最早的
         if (globals.animes.length > globals.MAX_ANIMES) {
             const removeSuccess = removeEarliestAnime();
             if (!removeSuccess) {
-                log("error", "Failed to remove earliest anime, but continuing");
+                log("error", "[Cache] Failed to remove earliest anime, but continuing");
             }
         }
 
-        log("info", `animes: ${JSON.stringify(
+        log("info", `[Cache] animes: ${JSON.stringify(
           globals.animes.map(anime => ({
             links: anime.links,
             animeId: anime.animeId,
@@ -488,20 +488,20 @@ export function addAnime(anime, detailStore = null) {
 
         return true;
     } catch (error) {
-        log("error", `addAnime failed: ${error.message}`);
+        log("error", `[Cache] addAnime failed: ${error.message}`);
         return false;
     }
 }
 // 删除最早添加的 anime，并从 episodeIds 删除其 links 中的 url
 export function removeEarliestAnime() {
     if (globals.animes.length === 0) {
-        log("error", "No animes to remove.");
+        log("error", "[Cache] No animes to remove.");
         return false;
     }
 
     // 移除最早的 anime（第一个元素）
     const removedAnime = globals.animes.shift();
-    log("info", `Removed earliest anime: ${JSON.stringify(removedAnime)}`);
+    log("info", `[Cache] Removed earliest anime: ${JSON.stringify(removedAnime)}`);
 
     // 从 episodeIds 删除该 anime 的所有 links 中的 url
     if (removedAnime.links && Array.isArray(removedAnime.links)) {
@@ -557,7 +557,7 @@ export function storeAnimeIdsToMap(curAnimes, key) {
     if (globals.lastSelectMap.size > globals.MAX_LAST_SELECT_MAP) {
         const firstKey = globals.lastSelectMap.keys().next().value;
         globals.lastSelectMap.delete(firstKey);
-        log("info", `Removed earliest entry from lastSelectMap: ${firstKey}`);
+        log("info", `[Cache] Removed earliest entry from lastSelectMap: ${firstKey}`);
     }
 }
 
@@ -618,14 +618,14 @@ export function cleanupExpiredIPs(currentTime) {
     if (validTimestamps.length === 0) {
       globals.requestHistory.delete(ip);
       cleanedCount++;
-      log("info", `[Rate Limit] Cleaned up expired IP record: ${ip}`);
+      log("info", `[Utils] [Rate Limit] Cleaned up expired IP record: ${ip}`);
     } else if (validTimestamps.length < timestamps.length) {
       globals.requestHistory.set(ip, validTimestamps);
     }
   }
 
   if (cleanedCount > 0) {
-    log("info", `[Rate Limit] Cleanup completed: removed ${cleanedCount} expired IP records`);
+    log("info", `[Utils] [Rate Limit] Cleanup completed: removed ${cleanedCount} expired IP records`);
   }
 }
 
@@ -660,7 +660,7 @@ export function writeCacheToFile(key, value) {
 export async function getLocalCaches() {
   if (!globals.localCacheInitialized) {
     try {
-      log("info", 'getLocalCaches start.');
+      log("info", '[Cache] getLocalCaches start.');
 
       // 从本地缓存文件读取数据并恢复到 globals 中
       globals.animes = JSON.parse(readCacheFromFile('animes')) || globals.animes;
@@ -673,7 +673,7 @@ export async function getLocalCaches() {
       const lastSelectMapData = readCacheFromFile('lastSelectMap');
       if (lastSelectMapData) {
         globals.lastSelectMap = new Map(Object.entries(JSON.parse(lastSelectMapData)));
-        log("info", `Restored lastSelectMap from local cache with ${globals.lastSelectMap.size} entries`);
+        log("info", `[Cache] Restored lastSelectMap from local cache with ${globals.lastSelectMap.size} entries`);
       }
 
       // 更新哈希值
@@ -685,9 +685,9 @@ export async function getLocalCaches() {
       globals.lastHashes.lastSelectMap = simpleHash(JSON.stringify(Object.fromEntries(globals.lastSelectMap)));
 
       globals.localCacheInitialized = true;
-      log("info", 'getLocalCaches completed successfully.');
+      log("info", '[Cache] getLocalCaches completed successfully.');
     } catch (error) {
-      log("error", `getLocalCaches failed: ${error.message}`, error.stack);
+      log("error", `[Cache] getLocalCaches failed: ${error.message}`, error.stack);
       globals.localCacheInitialized = true; // 标记为已初始化，避免重复尝试
     }
   }
@@ -696,7 +696,7 @@ export async function getLocalCaches() {
 // 更新本地缓存
 export async function updateLocalCaches() {
   try {
-    log("info", 'updateLocalCaches start.');
+    log("info", '[Cache] updateLocalCaches start.');
     const updates = [];
 
     // 检查每个变量的哈希值
@@ -721,17 +721,17 @@ export async function updateLocalCaches() {
 
     // 输出更新日志
     if (updates.length > 0) {
-      log("info", `Updated local caches for keys: ${updates.map(u => u.key).join(', ')}`);
+      log("info", `[Cache] Updated local caches for keys: ${updates.map(u => u.key).join(', ')}`);
       updates.forEach(({ key, hash }) => {
         globals.lastHashes[key] = hash; // 更新本地哈希
       });
     } else {
-      log("info", 'No changes detected, skipping local cache update.');
+      log("info", '[Cache] No changes detected, skipping local cache update.');
     }
 
   } catch (error) {
-    log("error", `updateLocalCaches failed: ${error.message}`, error.stack);
-    log("error", `Error details - Name: ${error.name}, Cause: ${error.cause ? error.cause.message : 'N/A'}`);
+    log("error", `[Cache] updateLocalCaches failed: ${error.message}`, error.stack);
+    log("error", `[Cache] Error details - Name: ${error.name}, Cause: ${error.cause ? error.cause.message : 'N/A'}`);
   }
 }
 
@@ -752,7 +752,7 @@ export async function judgeLocalCacheValid(urlPath, deployPlatform) {
         }
       }
     } catch (error) {
-      console.warn('Node.js modules not available:', error.message);
+      log("warn", "[Cache] Node.js modules not available:", error.message);
       globals.localCacheValid = false;
     }
   }

--- a/danmu_api/utils/codec-util.js
+++ b/danmu_api/utils/codec-util.js
@@ -539,7 +539,7 @@ function aesDecryptBase64(cipherB64, keyStr) {
     const unpadded = pkcs7Unpad(decryptedBytes);
     return utf8BytesToString(unpadded);
   } catch (e) {
-    log("error", e);
+    log("error", "[Utils] [Codec]", e);
     return null;
   }
 }

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -17,11 +17,11 @@ export function printFirst200Chars(data) {
   } else if (typeof data === 'object') {
     dataToPrint = JSON.stringify(data);  // 如果是对象，转为字符串
   } else {
-    log("error", "Unsupported data type");
+    log("error", "[Utils] [Common] Unsupported data type");
     return;
   }
 
-  log("info", dataToPrint.slice(0, 200));  // 打印前200个字符
+  log("info", "[Utils] [Common]", dataToPrint.slice(0, 200));  // 打印前200个字符
 }
 
 // 正则表达式：提取episode标题中的内容
@@ -172,7 +172,7 @@ export function createDynamicPlatformOrder(preferredPlatform) {
 
   // 验证平台是否有效
   if (!globals.allowedPlatforms.includes(preferredPlatform)) {
-    log("warn", `Invalid platform: ${preferredPlatform}, using default order`);
+    log("warn", `[Utils] [Common] Invalid platform: ${preferredPlatform}, using default order`);
     return [...globals.platformOrderArr];
   }
 

--- a/danmu_api/utils/danmu-util.js
+++ b/danmu_api/utils/danmu-util.js
@@ -300,16 +300,16 @@ export function convertToDanmakuJson(contents, platform) {
         // 去除两边的 `/` 并转化为正则
         return new RegExp(pattern.slice(1, -1));
       } catch (e) {
-        log("error", `无效的正则表达式: ${pattern}`, e);
+        log("error", `[Utils] [Danmu] 无效的正则表达式: ${pattern}`, e);
         return null;
       }
     }
     return null; // 如果不是有效的正则格式则返回 null
   }).filter(regex => regex !== null); // 过滤掉无效的项
 
-  log("info", `原始屏蔽词字符串: ${globals.blockedWords}`);
+  log("info", `[Utils] [Danmu] 原始屏蔽词字符串: ${globals.blockedWords}`);
   const regexArrayToString = array => Array.isArray(array) ? array.map(regex => regex.toString()).join('\n') : String(array);
-  log("info", `屏蔽词列表: ${regexArrayToString(regexArray)}`);
+  log("info", `[Utils] [Danmu] 屏蔽词列表: ${regexArrayToString(regexArray)}`);
 
   // 过滤列表
   const filteredDanmus = danmus.filter(item => {
@@ -317,7 +317,7 @@ export function convertToDanmakuJson(contents, platform) {
   });
 
   // 按n分钟内去重
-  log("info", `去重分钟数: ${globals.groupMinute}`);
+  log("info", `[Utils] [Danmu] 去重分钟数: ${globals.groupMinute}`);
   const groupedDanmus = groupDanmusByMinute(filteredDanmus, globals.groupMinute, isMultiSource);
 
   // 处理点赞数
@@ -369,10 +369,10 @@ export function convertToDanmakuJson(contents, platform) {
 
     // 统计输出转换结果
     if (topBottomCount > 0) {
-      log("info", `[danmu convert] 转换了 ${topBottomCount} 条顶部/底部弹幕为浮动弹幕`);
+      log("info", `[Utils] [Danmu] [danmu convert] 转换了 ${topBottomCount} 条顶部/底部弹幕为浮动弹幕`);
     }
     if (colorCount > 0) {
-      log("info", `[danmu convert] 转换了 ${colorCount} 条弹幕颜色`);
+      log("info", `[Utils] [Danmu] [danmu convert] 转换了 ${colorCount} 条弹幕颜色`);
     }
   }
 
@@ -382,15 +382,15 @@ export function convertToDanmakuJson(contents, platform) {
       ...danmu,
       m: traditionalized(danmu.m)
     }));
-    log("info", `[danmu convert] 转换了 ${convertedDanmus.length} 条弹幕为繁体字`);
+    log("info", `[Utils] [Danmu] [danmu convert] 转换了 ${convertedDanmus.length} 条弹幕为繁体字`);
   }
 
-  log("info", `danmus_original: ${danmus.length}`);
-  log("info", `danmus_filter: ${filteredDanmus.length}`);
-  log("info", `danmus_group: ${groupedDanmus.length}`);
-  log("info", `danmus_limit: ${convertedDanmus.length}`);
+  log("info", `[Utils] [Danmu] danmus_original: ${danmus.length}`);
+  log("info", `[Utils] [Danmu] danmus_filter: ${filteredDanmus.length}`);
+  log("info", `[Utils] [Danmu] danmus_group: ${groupedDanmus.length}`);
+  log("info", `[Utils] [Danmu] danmus_limit: ${convertedDanmus.length}`);
   // 输出前五条弹幕
-  log("info", "Top 5 danmus:", JSON.stringify(convertedDanmus.slice(0, 5), null, 2));
+  log("info", "[Utils] [Danmu] Top 5 danmus:", JSON.stringify(convertedDanmus.slice(0, 5), null, 2));
   return convertedDanmus;
 }
 
@@ -494,14 +494,14 @@ export function formatDanmuResponse(danmuData, queryFormat) {
   let format = queryFormat || globals.danmuOutputFormat;
   format = format.toLowerCase();
 
-  log("info", `[Format] Using format: ${format}`);
+  log("info", `[Utils] [Danmu] [Format] Using format: ${format}`);
 
   if (format === 'xml') {
     try {
       const xmlData = convertDanmuToXml(danmuData);
       return xmlResponse(xmlData);
     } catch (error) {
-      log("error", `Failed to convert to XML: ${error.message}`);
+      log("error", `[Utils] [Danmu] Failed to convert to XML: ${error.message}`);
       // 转换失败时回退到 JSON
       return jsonResponse(danmuData);
     }

--- a/danmu_api/utils/douban-util.js
+++ b/danmu_api/utils/douban-util.js
@@ -28,7 +28,7 @@ async function doubanApiGet(url) {
 
     return response;
   } catch (error) {
-    log("error", "[DOUBAN] GET API error:", {
+    log("error", "[Utils] [Douban] GET API error:", {
       message: error.message,
       name: error.name,
       stack: error.stack,
@@ -55,7 +55,7 @@ async function doubanApiPost(url, data={}) {
 
     return response;
   } catch (error) {
-    log("error", "[DOUBAN] POST API error:", {
+    log("error", "[Utils] [Douban] POST API error:", {
       message: error.message,
       name: error.name,
       stack: error.stack,

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -1,5 +1,26 @@
 import { globals } from '../configs/globals.js';
 import { log } from './log-util.js'
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+// 跨异步生命周期链路的日志上下文追踪器
+export const sourceLogContext = new AsyncLocalStorage();
+
+// 源调度键名（sourceOrderArr）到日志标签规范名称的映射
+// sourceOrderArr 中部分键名与对应源文件的标签命名不一致（如 360→360kan, imgo→mango）
+// 此映射表统一转换，确保 HTTP 日志标签与源文件内部标签一致
+const SOURCE_KEY_TO_LOG_NAME = {
+  '360': '360kan',
+  'imgo': 'mango',
+};
+
+/**
+ * 将 sourceOrderArr 中的调度键名转换为日志标签规范名称
+ * @param {string} sourceKey - sourceOrderArr 中的键名
+ * @returns {string} 对应的日志标签名称，如无映射则返回原值
+ */
+export function toLogSourceName(sourceKey) {
+  return SOURCE_KEY_TO_LOG_NAME[sourceKey] || sourceKey;
+}
 
 // =====================
 // 请求工具方法
@@ -31,12 +52,15 @@ export async function httpGet(url, options = {}) {
 
   // 执行请求，包含重试逻辑
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    // 获取当前异步生命周期的源标识
+    const currentSource = sourceLogContext.getStore() || "system";
+
     if (attempt > 0) {
-      log("info", `[请求模拟] 第 ${attempt} 次重试: ${url}`);
+      log("info", `[${currentSource}] [请求模拟] 第 ${attempt} 次重试: ${url}`);
       // 可选：添加重试延迟（指数退避）
       await new Promise(resolve => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt - 1), 5000)));
     } else {
-      log("info", `[请求模拟] HTTP GET: ${url}`);
+      log("info", `[${currentSource}] [请求模拟] HTTP GET: ${url}`);
     }
 
     // 设置超时时间（默认5秒）
@@ -51,7 +75,7 @@ export async function httpGet(url, options = {}) {
       // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
       let response;
       if (typeof WebAssembly === 'undefined') {
-        log("info", "iOS环境降级使用node-fetch");
+        log("info", "[Utils] [HTTP] iOS环境降级使用node-fetch");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, {
           method: 'GET',
@@ -81,7 +105,7 @@ export async function httpGet(url, options = {}) {
       let data;
 
       if (options.base64Data) {
-        log("info", "base64模式");
+        log("info", "[Utils] [HTTP] base64模式");
 
         // 先拿二进制
         const arrayBuffer = await response.arrayBuffer();
@@ -97,7 +121,7 @@ export async function httpGet(url, options = {}) {
         data = btoa(binary); // 得到 base64 字符串
 
       } else if (options.zlibMode) {
-        log("info", "zlib模式")
+        log("info", "[Utils] [HTTP] zlib模式")
 
         // 获取 ArrayBuffer
         const arrayBuffer = await response.arrayBuffer();
@@ -113,12 +137,12 @@ export async function httpGet(url, options = {}) {
           try {
             decodedData = await decompressedStream.text();
           } catch (e) {
-            log("error", "[请求模拟] 解压缩失败", e);
+            log("error", `[${currentSource}] [请求模拟] 解压缩失败`, e);
             throw e;
           }
         } else {
           // iOS巨魔环境降级处理：使用pako库
-          log("info", "iOS环境降级使用pako解压");
+          log("info", "[Utils] [HTTP] iOS环境降级使用pako解压");
           try {
             // 动态导入pako库
             const pako = await import('pako');
@@ -127,7 +151,7 @@ export async function httpGet(url, options = {}) {
             // 转换为字符串
             decodedData = new TextDecoder('utf-8').decode(inflateResult);
           } catch (e) {
-            log("error", "[请求模拟] pako解压缩失败", e);
+            log("error", `[${currentSource}] [请求模拟] pako解压缩失败`, e);
             throw e;
           }
         }
@@ -164,7 +188,7 @@ export async function httpGet(url, options = {}) {
 
       // 请求成功，返回结果
       if (attempt > 0) {
-        log("info", `[请求模拟] 重试成功`);
+        log("info", `[${currentSource}] [请求模拟] 重试成功`);
       }
 
       // 模拟 iOS 环境：返回 { data: ... } 结构
@@ -177,6 +201,7 @@ export async function httpGet(url, options = {}) {
     } catch (error) {
       clearTimeout(timeoutId);
       lastError = error;
+      const currentSource = sourceLogContext.getStore() || "system";
 
       // 如果是外部信号导致的中断，停止重试并直接抛出
       if (options.signal?.aborted) {
@@ -185,13 +210,13 @@ export async function httpGet(url, options = {}) {
 
       // 检查是否是超时错误
       if (error.name === 'AbortError') {
-        log("error", `[请求模拟] 请求超时:`, error.message);
+        log("error", `[${currentSource}] [请求模拟] 请求超时:`, error.message);
         log("error", '详细诊断:');
         log("error", '- URL:', url);
         log("error", '- 超时时间:', `${timeout}ms`);
         log("error", `- 当前尝试: ${attempt + 1}/${maxRetries + 1}`);
       } else {
-        log("error", `[请求模拟] 请求失败:`, error.message);
+        log("error", `[${currentSource}] [请求模拟] 请求失败:`, error.message);
         log("error", '详细诊断:');
         log("error", '- URL:', url);
         log("error", '- 错误类型:', error.name);
@@ -205,14 +230,15 @@ export async function httpGet(url, options = {}) {
 
       // 如果还有重试机会，继续循环；否则在循环结束后抛出错误
       if (attempt < maxRetries) {
-        log("info", `[请求模拟] 准备重试...`);
+        log("info", `[${currentSource}] [请求模拟] 准备重试...`);
         continue;
       }
     }
   }
 
   // 所有重试都失败，抛出最后一个错误
-  log("error", `[请求模拟] 所有重试均失败 (${maxRetries + 1} 次尝试)`);
+  const finalSource = sourceLogContext.getStore() || "system";
+  log("error", `[${finalSource}] [请求模拟] 所有重试均失败 (${maxRetries + 1} 次尝试)`);
   throw lastError;
 }
 
@@ -224,12 +250,14 @@ export async function httpPost(url, body, options = {}) {
 
   // 执行请求，包含重试逻辑
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const currentSource = sourceLogContext.getStore() || "system";
+
     if (attempt > 0) {
-      log("info", `[请求模拟] 第 ${attempt} 次重试: ${url}`);
+      log("info", `[${currentSource}] [请求模拟] 第 ${attempt} 次重试: ${url}`);
       // 可选：添加重试延迟（指数退避）
       await new Promise(resolve => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt - 1), 5000)));
     } else {
-      log("info", `[请求模拟] HTTP POST: ${url}`);
+      log("info", `[${currentSource}] [请求模拟] HTTP POST: ${url}`);
     }
 
     // 设置超时时间（默认5秒）
@@ -259,7 +287,7 @@ export async function httpPost(url, body, options = {}) {
       // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
       let response;
       if (typeof WebAssembly === 'undefined') {
-        log("info", "iOS环境降级使用node-fetch");
+        log("info", "[Utils] [HTTP] iOS环境降级使用node-fetch");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, fetchOptions);
       } else {
@@ -272,7 +300,7 @@ export async function httpPost(url, body, options = {}) {
       const data = await response.text();
 
       if (!response.ok && !validStatusCodes.includes(response.status)) {
-        log("error", `[请求模拟] response data: `, data);
+        log("error", `[${currentSource}] [请求模拟] response data: `, data);
         throw new Error(`HTTP error! status: ${response.status}`);
       }
 
@@ -285,7 +313,7 @@ export async function httpPost(url, body, options = {}) {
 
       // 请求成功，返回结果
       if (attempt > 0) {
-        log("info", `[请求模拟] 重试成功`);
+        log("info", `[${currentSource}] [请求模拟] 重试成功`);
       }
 
       // 模拟 iOS 环境：返回 { data: ... } 结构
@@ -298,6 +326,7 @@ export async function httpPost(url, body, options = {}) {
     } catch (error) {
       clearTimeout(timeoutId);
       lastError = error;
+      const currentSource = sourceLogContext.getStore() || "system";
 
       // 如果是外部信号导致的中断，停止重试并直接抛出
       if (options.signal?.aborted) {
@@ -306,13 +335,13 @@ export async function httpPost(url, body, options = {}) {
 
       // 检查是否是超时错误
       if (error.name === 'AbortError') {
-        log("error", `[请求模拟] 请求超时:`, error.message);
+        log("error", `[${currentSource}] [请求模拟] 请求超时:`, error.message);
         log("error", '详细诊断:');
         log("error", '- URL:', url);
         log("error", '- 超时时间:', `${timeout}ms`);
         log("error", `- 当前尝试: ${attempt + 1}/${maxRetries + 1}`);
       } else {
-        log("error", `[请求模拟] 请求失败:`, error.message);
+        log("error", `[${currentSource}] [请求模拟] 请求失败:`, error.message);
         log("error", '详细诊断:');
         log("error", '- URL:', url);
         log("error", '- 错误类型:', error.name);
@@ -326,14 +355,15 @@ export async function httpPost(url, body, options = {}) {
 
       // 如果还有重试机会，继续循环；否则在循环结束后抛出错误
       if (attempt < maxRetries) {
-        log("info", `[请求模拟] 准备重试...`);
+        log("info", `[${currentSource}] [请求模拟] 准备重试...`);
         continue;
       }
     }
   }
 
   // 所有重试都失败，抛出最后一个错误
-  log("error", `[请求模拟] 所有重试均失败 (${maxRetries + 1} 次尝试)`);
+  const finalSource = sourceLogContext.getStore() || "system";
+  log("error", `[${finalSource}] [请求模拟] 所有重试均失败 (${maxRetries + 1} 次尝试)`);
   throw lastError;
 }
 
@@ -349,7 +379,8 @@ export async function httpPost(url, body, options = {}) {
  * @returns {Promise<{data: any, status: number, headers: Record<string, string>}>}
  */
 async function httpRequestMethod(method, url, body, options = {}) {
-  log("info", `[请求模拟] HTTP ${method}: ${url}`);
+  const currentSource = sourceLogContext.getStore() || "system";
+  log("info", `[${currentSource}] [请求模拟] HTTP ${method}: ${url}`);
 
   const { headers = {} } = options;
   const validStatusCodes = Array.isArray(options.validStatusCodes) ? options.validStatusCodes : [];
@@ -378,7 +409,7 @@ async function httpRequestMethod(method, url, body, options = {}) {
     const textData = await response.text();
 
     if (!response.ok && !validStatusCodes.includes(response.status)) {
-      log("error", `[请求模拟] response data: `, textData);
+      log("error", `[${currentSource}] [请求模拟] response data: `, textData);
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
@@ -395,7 +426,8 @@ async function httpRequestMethod(method, url, body, options = {}) {
       headers: Object.fromEntries(response.headers.entries())
     };
   } catch (error) {
-    log("error", `[请求模拟] 请求失败:`, error.message);
+    const currentSource = sourceLogContext.getStore() || "system";
+    log("error", `[${currentSource}] [请求模拟] 请求失败:`, error.message);
     log("error", '详细诊断:');
     log("error", '- URL:', url);
     log("error", '- 错误类型:', error.name);
@@ -452,7 +484,8 @@ export async function getPageTitle(url) {
     return url;
 
   } catch (error) {
-    log("error", `获取标题失败: ${error.message}`);
+    const currentSource = sourceLogContext.getStore() || "system";
+    log("error", `[${currentSource}] 获取标题失败: ${error.message}`);
     return url;
   }
 }
@@ -618,7 +651,8 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
   linkSignal(options.signal, controller);
 
   try {
-    log("info", `[流式请求] HTTP GET: ${url}`);
+    const currentSource = sourceLogContext.getStore() || "system";
+    log("info", `[${currentSource}] [流式请求] HTTP GET: ${url}`);
 
     const response = await fetch(url, {
       method: 'GET',
@@ -634,11 +668,12 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
 
     // 环境兼容性回退
     if (!reader) {
-      log("warn", "[流式请求] 环境不支持流式读取,回退到普通请求");
+      const currentSource = sourceLogContext.getStore() || "system";
+      log("warn", `[${currentSource}] [流式请求] 环境不支持流式读取,回退到普通请求`);
       const text = await response.text();
       clearTimeout(timeoutId);
       if (checkCallback && !checkCallback(text.slice(0, SNIFF_LIMIT))) {
-          log("info", "[流式请求] 检测到无效数据(回退模式),丢弃结果");
+          log("info", `[${currentSource}] [流式请求] 检测到无效数据(回退模式),丢弃结果`);
           return null;
       }
       try { return JSON.parse(text); } catch { return text; }
@@ -669,7 +704,8 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
 
         // 执行回调检查
         if (!checkCallback(checkBuffer)) {
-          log("info", `[流式请求] 嗅探到无效特征(已读${receivedLength}字节),立即熔断`);
+          const currentSource = sourceLogContext.getStore() || "system";
+          log("info", `[${currentSource}] [流式请求] 嗅探到无效特征(已读${receivedLength}字节),立即熔断`);
           controller.abort();
           isAborted = true;
           break;
@@ -705,11 +741,12 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
     }
 
   } catch (error) {
+    const currentSource = sourceLogContext.getStore() || "system";
     clearTimeout(timeoutId);
     if (error.name === 'AbortError') {
        return null;
     }
-    log("error", `[流式请求] 失败: ${error.message}`);
+    log("error", `[${currentSource}] [流式请求] 失败: ${error.message}`);
     return null;
   }
 }

--- a/danmu_api/utils/imdb-util.js
+++ b/danmu_api/utils/imdb-util.js
@@ -21,7 +21,7 @@ async function imdbApiGet(url) {
 
     return response;
   } catch (error) {
-    log("error", "[IMDB] API error:", {
+    log("error", "[Utils] [IMDB] API error:", {
       message: error.message,
       name: error.name,
       stack: error.stack,

--- a/danmu_api/utils/local-redis-util.js
+++ b/danmu_api/utils/local-redis-util.js
@@ -20,7 +20,7 @@ async function createLocalRedisClient() {
   const localRedisUrl = globals.localRedisUrl;
 
   try {
-    log("info", `[local-redis] 正在连接本地 Redis`);
+    log("info", `[Utils] [Local-Redis] 正在连接本地 Redis`);
 
     const { createClient } = await import('redis');
     
@@ -38,22 +38,22 @@ async function createLocalRedisClient() {
 
     // 连接错误处理
     localRedisClient.on('error', (err) => {
-      log("error", `[local-redis] 连接错误`);
+      log("error", `[Utils] [Local-Redis] 连接错误`);
       globals.localRedisValid = false;
     });
 
     // 连接成功处理
     localRedisClient.on('connect', () => {
-      log("info", `[local-redis] 连接成功`);
+      log("info", `[Utils] [Local-Redis] 连接成功`);
     });
 
     await localRedisClient.connect();
     globals.localRedisValid = true;
-    log("info", `[local-redis] Redis 客户端初始化完成`);
+    log("info", `[Utils] [Local-Redis] Redis 客户端初始化完成`);
     
     return localRedisClient;
   } catch (error) {
-    log("error", `[local-redis] 初始化失败:`, error.message);
+    log("error", `[Utils] [Local-Redis] 初始化失败:`, error.message);
     globals.localRedisValid = false;
     return null;
   }
@@ -70,7 +70,7 @@ async function checkLocalRedisConnection() {
     const result = await localRedisClient.ping();
     return result === 'PONG';
   } catch (error) {
-    log("error", `[local-redis] 连接检查失败:`, error.message);
+    log("error", `[Utils] [Local-Redis] 连接检查失败:`, error.message);
     globals.localRedisValid = false;
     return false;
   }
@@ -90,7 +90,7 @@ export async function getLocalRedisKey(key) {
     const result = await localRedisClient.get(key);
     return result;
   } catch (error) {
-    log("error", `[local-redis] GET 请求失败:`, error.message);
+    log("error", `[Utils] [Local-Redis] GET 请求失败:`, error.message);
     return null;
   }
 }
@@ -102,7 +102,7 @@ export async function setLocalRedisKey(key, value) {
 
   // 检查值是否变化
   if (globals.lastHashes[key] === currentHash) {
-    log("info", `[local-redis] 键 ${key} 无变化，跳过 SET 请求`);
+    log("info", `[Utils] [Local-Redis] 键 ${key} 无变化，跳过 SET 请求`);
     return { result: "OK" }; // 模拟成功响应
   }
 
@@ -117,10 +117,10 @@ export async function setLocalRedisKey(key, value) {
 
     const result = await localRedisClient.set(key, serializedValue);
     globals.lastHashes[key] = currentHash; // 更新哈希值
-    log("info", `[local-redis] 键 ${key} 更新成功`);
+    log("info", `[Utils] [Local-Redis] 键 ${key} 更新成功`);
     return { result };
   } catch (error) {
-    log("error", `[local-redis] SET 请求失败:`, error.message);
+    log("error", `[Utils] [Local-Redis] SET 请求失败:`, error.message);
     return { result: "ERROR" };
   }
 }
@@ -132,7 +132,7 @@ export async function setLocalRedisKeyWithExpiry(key, value, expirySeconds) {
 
   // 检查值是否变化
   if (globals.lastHashes[key] === currentHash) {
-    log("info", `[local-redis] 键 ${key} 无变化，跳过 SETEX 请求`);
+    log("info", `[Utils] [Local-Redis] 键 ${key} 无变化，跳过 SETEX 请求`);
     return { result: "OK" }; // 模拟成功响应
   }
 
@@ -147,10 +147,10 @@ export async function setLocalRedisKeyWithExpiry(key, value, expirySeconds) {
 
     const result = await localRedisClient.setEx(key, expirySeconds, serializedValue);
     globals.lastHashes[key] = currentHash; // 更新哈希值
-    log("info", `[local-redis] 键 ${key} 更新成功（带过期时间 ${expirySeconds}s）`);
+    log("info", `[Utils] [Local-Redis] 键 ${key} 更新成功（带过期时间 ${expirySeconds}s）`);
     return { result };
   } catch (error) {
-    log("error", `[local-redis] SETEX 请求失败:`, error.message);
+    log("error", `[Utils] [Local-Redis] SETEX 请求失败:`, error.message);
     return { result: "ERROR" };
   }
 }
@@ -159,7 +159,7 @@ export async function setLocalRedisKeyWithExpiry(key, value, expirySeconds) {
 export async function getLocalRedisCaches() {
   if (!globals.localCacheInitialized) {
     try {
-      log("info", 'getLocalRedisCaches start.');
+      log("info", '[Utils] [Local-Redis] getLocalRedisCaches start.');
       
       if (!(await checkLocalRedisConnection())) {
         await createLocalRedisClient();
@@ -182,7 +182,7 @@ export async function getLocalRedisCaches() {
       const lastSelectMapData = results[4] ? JSON.parse(results[4]) : null;
       if (lastSelectMapData && typeof lastSelectMapData === 'object') {
         globals.lastSelectMap = new Map(Object.entries(lastSelectMapData));
-        log("info", `Restored lastSelectMap from Local Redis with ${globals.lastSelectMap.size} entries`);
+        log("info", `[Utils] [Local-Redis] Restored lastSelectMap from Local Redis with ${globals.lastSelectMap.size} entries`);
       }
       globals.todayReqNum = results[5] ? parseInt(results[5], 10) : globals.todayReqNum;
 
@@ -195,9 +195,9 @@ export async function getLocalRedisCaches() {
       globals.lastHashes.todayReqNum = simpleHash(JSON.stringify(globals.todayReqNum));
 
       globals.localCacheInitialized = true;
-      log("info", 'getLocalRedisCaches completed successfully.');
+      log("info", '[Utils] [Local-Redis] getLocalRedisCaches completed successfully.');
     } catch (error) {
-      log("error", `getLocalRedisCaches failed: ${error.message}`, error.stack);
+      log("error", `[Utils] [Local-Redis] getLocalRedisCaches failed: ${error.message}`, error.stack);
       globals.localCacheInitialized = true; // 标记为已初始化，避免重复尝试
     }
   }
@@ -206,7 +206,7 @@ export async function getLocalRedisCaches() {
 // 优化后的 updateLocalRedisCaches，仅更新有变化的变量
 export async function updateLocalRedisCaches() {
   try {
-    log("info", 'updateLocalRedisCaches start.');
+    log("info", '[Utils] [Local-Redis] updateLocalRedisCaches start.');
     
     if (!(await checkLocalRedisConnection())) {
       await createLocalRedisClient();
@@ -239,7 +239,7 @@ export async function updateLocalRedisCaches() {
 
     // 如果有需要更新的键，执行批量更新
     if (updates.length > 0) {
-      log("info", `Updating ${updates.length} changed keys: ${updates.map(u => u.key).join(', ')}`);
+      log("info", `[Utils] [Local-Redis] Updating ${updates.length} changed keys: ${updates.map(u => u.key).join(', ')}`);
 
       const promises = updates.map(async ({ key, value }) => {
         return setLocalRedisKey(key, value);
@@ -256,7 +256,7 @@ export async function updateLocalRedisCaches() {
           successCount++;
         } else {
           failureCount++;
-          log("warn", `Failed to update Local Redis key: ${updates[index]?.key}, result: ${JSON.stringify(result)}`);
+          log("warn", `[Utils] [Local-Redis] Failed to update Local Redis key: ${updates[index]?.key}, result: ${JSON.stringify(result)}`);
         }
       });
 
@@ -265,16 +265,16 @@ export async function updateLocalRedisCaches() {
         updates.forEach(({ key, hash }) => {
           globals.lastHashes[key] = hash;
         });
-        log("info", `Local Redis update completed successfully: ${successCount} keys updated`);
+        log("info", `[Utils] [Local-Redis] Local Redis update completed successfully: ${successCount} keys updated`);
       } else {
-        log("warn", `Local Redis update partially failed: ${successCount} succeeded, ${failureCount} failed`);
+        log("warn", `[Utils] [Local-Redis] Local Redis update partially failed: ${successCount} succeeded, ${failureCount} failed`);
       }
     } else {
-      log("info", 'No changes detected, skipping Local Redis update.');
+      log("info", '[Utils] [Local-Redis] No changes detected, skipping Local Redis update.');
     }
   } catch (error) {
-    log("error", `updateLocalRedisCaches failed: ${error.message}`, error.stack);
-    log("error", `Error details - Name: ${error.name}, Cause: ${error.cause ? error.cause.message : 'N/A'}`);
+    log("error", `[Utils] [Local-Redis] updateLocalRedisCaches failed: ${error.message}`, error.stack);
+    log("error", `[Utils] [Local-Redis] Error details - Name: ${error.name}, Cause: ${error.cause ? error.cause.message : 'N/A'}`);
   }
 }
 
@@ -293,7 +293,7 @@ export async function judgeLocalRedisValid(path) {
         }
       }
     } catch (error) {
-      log("error", `[local-redis] 连接检查失败:`, error.message);
+      log("error", `[Utils] [Local-Redis] 连接检查失败:`, error.message);
       globals.localRedisValid = false;
     }
   }
@@ -306,9 +306,9 @@ export async function closeLocalRedisConnection() {
       await localRedisClient.quit();
       localRedisClient = null;
       globals.localRedisValid = false;
-      log("info", '[local-redis] 连接已关闭');
+      log("info", '[Utils] [Local-Redis] 连接已关闭');
     } catch (error) {
-      log("error", `[local-redis] 关闭连接失败:`, error.message);
+      log("error", `[Utils] [Local-Redis] 关闭连接失败:`, error.message);
     }
   }
 }

--- a/danmu_api/utils/merge-util.js
+++ b/danmu_api/utils/merge-util.js
@@ -2538,7 +2538,7 @@ async function processMergeTask(params) {
                     const sLen = route.sec.end - route.sec.start + 1;
                     const pLen = route.prim.end - route.prim.start + 1;
                     if (sLen !== pLen) {
-                        log("warn", `[映射表] 路由区间跨度不对等，跳过此段: E${route.sec.start}~E${route.sec.end} > E${route.prim.start}~E${route.prim.end}`);
+                        log("warn", `[Merge] [映射表] 路由区间跨度不对等，跳过此段: E${route.sec.start}~E${route.sec.end} > E${route.prim.start}~E${route.prim.end}`);
                         continue;
                     }
                     for (let i = 0; i < sLen; i++) {

--- a/danmu_api/utils/redis-util.js
+++ b/danmu_api/utils/redis-util.js
@@ -9,7 +9,7 @@ import { simpleHash, serializeValue } from "./codec-util.js";
 // 使用 GET 发送简单命令（如 PING 检查连接）
 export async function pingRedis() {
   const url = `${globals.redisUrl}/ping`;
-  log("info", `[redis] 开始发送 PING 请求:`, url);
+  log("info", `[Utils] [Redis] 开始发送 PING 请求:`, url);
   try {
     const response = await fetch(url, {
       method: 'GET',
@@ -19,11 +19,11 @@ export async function pingRedis() {
     });
     return await response.json(); // 预期: ["PONG"]
   } catch (error) {
-    log("error", `[redis] 请求失败:`, error.message);
-    log("error", '- 错误类型:', error.name);
+    log("error", `[Utils] [Redis] 请求失败:`, error.message);
+    log("error", '- [Utils] [Redis] 错误类型:', error.name);
     if (error.cause) {
-      log("error", '- 码:', error.cause.code);  // e.g., 'ECONNREFUSED', 'ETIMEDOUT', 'ECONNRESET'
-      log("error", '- 原因:', error.cause.message);
+      log("error", '- [Utils] [Redis] 码:', error.cause.code);  // e.g., 'ECONNREFUSED', 'ETIMEDOUT', 'ECONNRESET'
+      log("error", '- [Utils] [Redis] 原因:', error.cause.message);
     }
   }
 }
@@ -31,7 +31,7 @@ export async function pingRedis() {
 // 使用 GET 发送 GET 命令（读取键值）
 export async function getRedisKey(key) {
   const url = `${globals.redisUrl}/get/${key}`;
-  log("info", `[redis] 开始发送 GET 请求:`, url);
+  log("info", `[Utils] [Redis] 开始发送 GET 请求:`, url);
   try {
     const response = await fetch(url, {
       method: 'GET',
@@ -41,11 +41,11 @@ export async function getRedisKey(key) {
     });
     return await response.json(); // 预期: ["value"] 或 null
   } catch (error) {
-    log("error", `[redis] 请求失败:`, error.message);
-    log("error", '- 错误类型:', error.name);
+    log("error", `[Utils] [Redis] 请求失败:`, error.message);
+    log("error", '- [Utils] [Redis] 错误类型:', error.name);
     if (error.cause) {
-      log("error", '- 码:', error.cause.code);  // e.g., 'ECONNREFUSED', 'ETIMEDOUT', 'ECONNRESET'
-      log("error", '- 原因:', error.cause.message);
+      log("error", '- [Utils] [Redis] 码:', error.cause.code);  // e.g., 'ECONNREFUSED', 'ETIMEDOUT', 'ECONNRESET'
+      log("error", '- [Utils] [Redis] 原因:', error.cause.message);
     }
   }
 }
@@ -57,12 +57,12 @@ export async function setRedisKey(key, value) {
 
   // 检查值是否变化
   if (globals.lastHashes[key] === currentHash) {
-    log("info", `[redis] 键 ${key} 无变化，跳过 SET 请求`);
+    log("info", `[Utils] [Redis] 键 ${key} 无变化，跳过 SET 请求`);
     return { result: "OK" }; // 模拟成功响应
   }
 
   const url = `${globals.redisUrl}/set/${key}`;
-  log("info", `[redis] 开始发送 SET 请求:`, url);
+  log("info", `[Utils] [Redis] 开始发送 SET 请求:`, url);
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -74,14 +74,14 @@ export async function setRedisKey(key, value) {
     });
     const result = await response.json();
     globals.lastHashes[key] = currentHash; // 更新哈希值
-    log("info", `[redis] 键 ${key} 更新成功`);
+    log("info", `[Utils] [Redis] 键 ${key} 更新成功`);
     return result; // 预期: ["OK"]
   } catch (error) {
-    log("error", `[redis] SET 请求失败:`, error.message);
-    log("error", '- 错误类型:', error.name);
+    log("error", `[Utils] [Redis] SET 请求失败:`, error.message);
+    log("error", '- [Utils] [Redis] 错误类型:', error.name);
     if (error.cause) {
-      log("error", '- 码:', error.cause.code);
-      log("error", '- 原因:', error.cause.message);
+      log("error", '- [Utils] [Redis] 码:', error.cause.code);
+      log("error", '- [Utils] [Redis] 原因:', error.cause.message);
     }
   }
 }
@@ -93,12 +93,12 @@ export async function setRedisKeyWithExpiry(key, value, expirySeconds) {
 
   // 检查值是否变化
   if (globals.lastHashes[key] === currentHash) {
-    log("info", `[redis] 键 ${key} 无变化，跳过 SETEX 请求`);
+    log("info", `[Utils] [Redis] 键 ${key} 无变化，跳过 SETEX 请求`);
     return { result: "OK" }; // 模拟成功响应
   }
 
   const url = `${globals.redisUrl}/set/${key}?EX=${expirySeconds}`;
-  log("info", `[redis] 开始发送 SETEX 请求:`, url);
+  log("info", `[Utils] [Redis] 开始发送 SETEX 请求:`, url);
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -110,14 +110,14 @@ export async function setRedisKeyWithExpiry(key, value, expirySeconds) {
     });
     const result = await response.json();
     globals.lastHashes[key] = currentHash; // 更新哈希值
-    log("info", `[redis] 键 ${key} 更新成功（带过期时间 ${expirySeconds}s）`);
+    log("info", `[Utils] [Redis] 键 ${key} 更新成功（带过期时间 ${expirySeconds}s）`);
     return result;
   } catch (error) {
-    log("error", `[redis] SETEX 请求失败:`, error.message);
-    log("error", '- 错误类型:', error.name);
+    log("error", `[Utils] [Redis] SETEX 请求失败:`, error.message);
+    log("error", '- [Utils] [Redis] 错误类型:', error.name);
     if (error.cause) {
-      log("error", '- 码:', error.cause.code);
-      log("error", '- 原因:', error.cause.message);
+      log("error", '- [Utils] [Redis] 码:', error.cause.code);
+      log("error", '- [Utils] [Redis] 原因:', error.cause.message);
     }
   }
 }
@@ -125,7 +125,7 @@ export async function setRedisKeyWithExpiry(key, value, expirySeconds) {
 // 通用的 pipeline 请求函数
 export async function runPipeline(commands) {
   const url = `${globals.redisUrl}/pipeline`;
-  log("info", `[redis] 开始发送 PIPELINE 请求:`, url);
+  log("info", `[Utils] [Redis] 开始发送 PIPELINE 请求:`, url);
   try {
     const response = await fetch(url, {
       method: 'POST',
@@ -138,11 +138,11 @@ export async function runPipeline(commands) {
     const result = await response.json();
     return result; // 返回结果数组，按命令顺序
   } catch (error) {
-    log("error", `[redis] Pipeline 请求失败:`, error.message);
-    log("error", '- 错误类型:', error.name);
+    log("error", `[Utils] [Redis] Pipeline 请求失败:`, error.message);
+    log("error", '- [Utils] [Redis] 错误类型:', error.name);
     if (error.cause) {
-      log("error", '- 码:', error.cause.code);
-      log("error", '- 原因:', error.cause.message);
+      log("error", '- [Utils] [Redis] 码:', error.cause.code);
+      log("error", '- [Utils] [Redis] 原因:', error.cause.message);
     }
   }
 }
@@ -151,7 +151,7 @@ export async function runPipeline(commands) {
 export async function getRedisCaches() {
   if (!globals.redisCacheInitialized) {
     try {
-      log("info", 'getRedisCaches start.');
+      log("info", '[Utils] [Redis] getRedisCaches start.');
       const keys = ['animes', 'episodeIds', 'episodeNum', 'reqRecords', 'lastSelectMap', 'todayReqNum'];
       const commands = keys.map(key => ['GET', key]); // 构造 pipeline 命令
       const results = await runPipeline(commands);
@@ -166,7 +166,7 @@ export async function getRedisCaches() {
       const lastSelectMapData = results[4].result ? JSON.parse(results[4].result) : null;
       if (lastSelectMapData && typeof lastSelectMapData === 'object') {
         globals.lastSelectMap = new Map(Object.entries(lastSelectMapData));
-        log("info", `Restored lastSelectMap from Redis with ${globals.lastSelectMap.size} entries`);
+        log("info", `[Utils] [Redis] Restored lastSelectMap from Redis with ${globals.lastSelectMap.size} entries`);
       }
       globals.todayReqNum = results[5].result ? parseInt(results[5].result, 10) : globals.todayReqNum;
 
@@ -179,9 +179,9 @@ export async function getRedisCaches() {
       globals.lastHashes.todayReqNum = simpleHash(JSON.stringify(globals.todayReqNum));
 
       globals.redisCacheInitialized = true;
-      log("info", 'getRedisCaches completed successfully.');
+      log("info", '[Utils] [Redis] getRedisCaches completed successfully.');
     } catch (error) {
-      log("error", `getRedisCaches failed: ${error.message}`, error.stack);
+      log("error", `[Utils] [Redis] getRedisCaches failed: ${error.message}`, error.stack);
       globals.redisCacheInitialized = true; // 标记为已初始化，避免重复尝试
     }
   }
@@ -190,7 +190,7 @@ export async function getRedisCaches() {
 // 优化后的 updateRedisCaches，仅更新有变化的变量
 export async function updateRedisCaches() {
   try {
-    log("info", 'updateCaches start.');
+    log("info", '[Utils] [Redis] updateCaches start.');
     const commands = [];
     const updates = [];
 
@@ -216,7 +216,7 @@ export async function updateRedisCaches() {
 
     // 如果有需要更新的键，执行 pipeline
     if (commands.length > 0) {
-      log("info", `Updating ${commands.length} changed keys: ${updates.map(u => u.key).join(', ')}`);
+      log("info", `[Utils] [Redis] Updating ${commands.length} changed keys: ${updates.map(u => u.key).join(', ')}`);
       const results = await runPipeline(commands);
 
       // 检查每个操作的结果
@@ -229,7 +229,7 @@ export async function updateRedisCaches() {
             successCount++;
           } else {
             failureCount++;
-            log("warn", `Failed to update Redis key: ${updates[index]?.key}, result: ${JSON.stringify(result)}`);
+            log("warn", `[Utils] [Redis] Failed to update Redis key: ${updates[index]?.key}, result: ${JSON.stringify(result)}`);
           }
         });
       }
@@ -239,16 +239,16 @@ export async function updateRedisCaches() {
         updates.forEach(({ key, hash }) => {
           globals.lastHashes[key] = hash;
         });
-        log("info", `Redis update completed successfully: ${successCount} keys updated`);
+        log("info", `[Utils] [Redis] Redis update completed successfully: ${successCount} keys updated`);
       } else {
-        log("warn", `Redis update partially failed: ${successCount} succeeded, ${failureCount} failed`);
+        log("warn", `[Utils] [Redis] Redis update partially failed: ${successCount} succeeded, ${failureCount} failed`);
       }
     } else {
-      log("info", 'No changes detected, skipping Redis update.');
+      log("info", '[Utils] [Redis] No changes detected, skipping Redis update.');
     }
   } catch (error) {
-    log("error", `updateRedisCaches failed: ${error.message}`, error.stack);
-    log("error", `Error details - Name: ${error.name}, Cause: ${error.cause ? error.cause.message : 'N/A'}`);
+    log("error", `[Utils] [Redis] updateRedisCaches failed: ${error.message}`, error.stack);
+    log("error", `[Utils] [Redis] Error details - Name: ${error.name}, Cause: ${error.cause ? error.cause.message : 'N/A'}`);
   }
 }
 

--- a/danmu_api/utils/tmdb-util.js
+++ b/danmu_api/utils/tmdb-util.js
@@ -36,7 +36,7 @@ async function tmdbApiGet(url, options = {}) {
     if (error.name === 'AbortError') {
        throw error;
     }
-    log("error", "[TMDB] Api error:", {
+    log("error", "[Utils] [TMDB] Api error:", {
       message: error.message,
       name: error.name,
       stack: error.stack,
@@ -89,7 +89,7 @@ export async function searchTmdbTitles(title, mediaType = "multi", options = {})
     }
   }
 
-  log("info", `[TMDB] 共获取到 ${allResults.length} 条搜索结果（最多${maxPages}页）`);
+  log("info", `[Utils] [TMDB] 共获取到 ${allResults.length} 条搜索结果（最多${maxPages}页）`);
 
   // 返回与原格式兼容的结构
   return {
@@ -144,7 +144,7 @@ function extractChineseTitleFromAlternatives(altData, mediaType, queryTitle = ""
     const match = titles.find(rule);
     if (match) {
       const bestMatchTitle = getStr(match);
-      log("info", `[TMDB] 按优先级策略成功提取最佳中文别名: ${bestMatchTitle}`);
+      log("info", `[Utils] [TMDB] 按优先级策略成功提取最佳中文别名: ${bestMatchTitle}`);
       return bestMatchTitle;
     }
   }
@@ -168,7 +168,7 @@ async function getChineseTitleForResult(result, signal, queryTitle = "") {
     return resultTitle;
   }
 
-  log("info", `[TMDB] 尝试获取中文别名以寻找更优匹配 (当前标题: "${resultTitle}")`);
+  log("info", `[Utils] [TMDB] 尝试获取中文别名以寻找更优匹配 (当前标题: "${resultTitle}")`);
 
   const mediaType = result.media_type || (result.name ? "tv" : "movie");
 
@@ -188,10 +188,10 @@ async function getChineseTitleForResult(result, signal, queryTitle = "") {
     const chineseTitle = extractChineseTitleFromAlternatives(altResp, mediaType, queryTitle);
 
     if (chineseTitle) {
-      log("info", `[TMDB] 将使用中文别名进行相似匹配: ${chineseTitle}`);
+      log("info", `[Utils] [TMDB] 将使用中文别名进行相似匹配: ${chineseTitle}`);
       return chineseTitle;
     } else {
-      log("info", `[TMDB] 未找到中文别名，使用原标题: ${resultTitle}`);
+      log("info", `[Utils] [TMDB] 未找到中文别名，使用原标题: ${resultTitle}`);
       return resultTitle;
     }
   } catch (error) {
@@ -199,7 +199,7 @@ async function getChineseTitleForResult(result, signal, queryTitle = "") {
     if (error.name === 'AbortError') {
       throw error;
     }
-    log("error", `[TMDB] 获取别名失败: ${error.message}`);
+    log("error", `[Utils] [TMDB] 获取别名失败: ${error.message}`);
     return resultTitle; // 失败则返回原标题
   }
 }
@@ -209,7 +209,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
   // 优化搜索关键词: 剥离 "Season 2", "第二季" 等后缀
   const cleanTitle = cleanSearchQuery(title);
   if (cleanTitle !== title) {
-    log("info", `[TMDB] 优化搜索关键词: "${title}" -> "${cleanTitle}"`);
+    log("info", `[Utils] [TMDB] 优化搜索关键词: "${title}" -> "${cleanTitle}"`);
   }
 
   // 优先尝试使用本地 Bangumi Data 获取原名与翻译，零延迟且无需 API Key
@@ -220,13 +220,13 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
       const displayTitle = m.titles.find(t => t && t.includes(cleanTitle)) || m.titles[1] || m.title;
       const jaOriginalTitle = m.title; // Bangumi Data 的主标题就是原名
 
-      log("info", `[TMDB] Bangumi-Data 本地命中，提取原名成功: 原名=${jaOriginalTitle}, 别名=${displayTitle}`);
+      log("info", `[Utils] [TMDB] Bangumi-Data 本地命中，提取原名成功: 原名=${jaOriginalTitle}, 别名=${displayTitle}`);
       return { title: jaOriginalTitle, cnAlias: displayTitle };
     }
   }
 
   if (!globals.tmdbApiKey) {
-    log("info", "[TMDB] 未配置API密钥，跳过TMDB网络搜索");
+    log("info", "[Utils] [TMDB] 未配置API密钥，跳过TMDB网络搜索");
     return null;
   }
 
@@ -324,7 +324,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
         };
 
         // 第一步：TMDB搜索
-        log("info", `[TMDB] 正在搜索 (Shared Task): ${cleanTitle}`);
+        log("info", `[Utils] [TMDB] 正在搜索 (Shared Task): ${cleanTitle}`);
 
         // 检查 masterController 是否已被中断
         if (backgroundSignal.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -332,14 +332,14 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
         const respZh = await searchTmdbTitles(cleanTitle, "multi", { signal: backgroundSignal });
 
         if (!respZh || !respZh.data) {
-          log("info", "[TMDB] TMDB搜索结果为空");
+          log("info", "[Utils] [TMDB] TMDB搜索结果为空");
           return null;
         }
 
         const dataZh = typeof respZh.data === "string" ? JSON.parse(respZh.data) : respZh.data;
 
         if (!dataZh.results || dataZh.results.length === 0) {
-          log("info", "[TMDB] TMDB未找到任何结果");
+          log("info", "[Utils] [TMDB] TMDB未找到任何结果");
           return null;
         }
 
@@ -359,11 +359,11 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
         }
 
         if (validResults.length === 0) {
-          log("info", `[TMDB] 数据清洗拦截: 搜索结果中没有任何目标类型(动画/日文)的内容`);
+          log("info", `[Utils] [TMDB] 数据清洗拦截: 搜索结果中没有任何目标类型(动画/日文)的内容`);
           return null;
         }
 
-        log("info", `[TMDB] 数据清洗完成: 保留 ${validResults.length} 个有效条目参与匹配，过滤 ${invalidItems.length} 个无关条目${invalidItems.length > 0 ? '，过滤详情: ' + invalidItems.join(', ') : ''}`);
+        log("info", `[Utils] [TMDB] 数据清洗完成: 保留 ${validResults.length} 个有效条目参与匹配，过滤 ${invalidItems.length} 个无关条目${invalidItems.length > 0 ? '，过滤详情: ' + invalidItems.join(', ') : ''}`);
 
         // 第三步：在干净的结果池中找到最相似的结果
         let bestMatch = null;
@@ -387,7 +387,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
           // 如果原标题已经100%匹配，标记跳过后续所有别名搜索
           if (initialScore === 1.0 && !skipAlternativeFetch) {
             skipAlternativeFetch = true;
-            log("info", `[TMDB] 匹配检查 "${resultTitle}" - 相似度: 100.00% (完全匹配，跳过后续所有别名搜索)`);
+            log("info", `[Utils] [TMDB] 匹配检查 "${resultTitle}" - 相似度: 100.00% (完全匹配，跳过后续所有别名搜索)`);
             if (initialScore > bestScore) {
               bestScore = initialScore;
               bestMatch = result;
@@ -409,9 +409,9 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
             finalScore = initialScore;
 
             if (skipAlternativeFetch && isExactMatch) {
-              log("info", `[TMDB] 匹配检查 "${resultTitle}" - 相似度: ${(finalScore * 100).toFixed(2)}% (已找到完全匹配，跳过别名搜索)`);
+              log("info", `[Utils] [TMDB] 匹配检查 "${resultTitle}" - 相似度: ${(finalScore * 100).toFixed(2)}% (已找到完全匹配，跳过别名搜索)`);
             } else {
-              log("info", `[TMDB] 匹配检查 "${resultTitle}" - 相似度: ${(finalScore * 100).toFixed(2)}%`);
+              log("info", `[Utils] [TMDB] 匹配检查 "${resultTitle}" - 相似度: ${(finalScore * 100).toFixed(2)}%`);
             }
           } else {
             // 非完全匹配且未达到别名获取上限，尝试获取别名
@@ -424,12 +424,12 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
               } catch (error) {
                 // 如果是中断错误，抛出
                 if (error.name === 'AbortError') throw error;
-                log("error", `[TMDB] 处理结果失败: ${error.message}`);
+                log("error", `[Utils] [TMDB] 处理结果失败: ${error.message}`);
                 chineseTitle = resultTitle;
               }
             } else {
               chineseTitle = resultTitle;
-              log("info", `[TMDB] 已达到别名获取上限(${MAX_ALTERNATIVE_FETCHES})，使用原标题: ${resultTitle}`);
+              log("info", `[Utils] [TMDB] 已达到别名获取上限(${MAX_ALTERNATIVE_FETCHES})，使用原标题: ${resultTitle}`);
             }
 
             const finalDirectScore = similarity(cleanTitle, chineseTitle);
@@ -438,11 +438,11 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
             const displayInfo = chineseTitle !== resultTitle 
               ? `"${resultTitle}" (别名: ${chineseTitle})` 
               : `"${resultTitle}"`;
-            log("info", `[TMDB] 匹配检查 ${displayInfo} - 相似度: ${(finalScore * 100).toFixed(2)}%`);
+            log("info", `[Utils] [TMDB] 匹配检查 ${displayInfo} - 相似度: ${(finalScore * 100).toFixed(2)}%`);
 
             if (finalScore === 1.0 && !skipAlternativeFetch) {
               skipAlternativeFetch = true;
-              log("info", `[TMDB] 通过别名找到完全匹配，跳过后续所有别名搜索`);
+              log("info", `[Utils] [TMDB] 通过别名找到完全匹配，跳过后续所有别名搜索`);
             }
           }
 
@@ -455,11 +455,11 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
 
         const MIN_SIMILARITY = 0.4;
         if (!bestMatch || bestScore < MIN_SIMILARITY) {
-          log("info", `[TMDB] 最佳匹配相似度过低或未找到匹配 (${bestMatch ? (bestScore * 100).toFixed(2) + '%' : 'N/A'}),跳过`);
+          log("info", `[Utils] [TMDB] 最佳匹配相似度过低或未找到匹配 (${bestMatch ? (bestScore * 100).toFixed(2) + '%' : 'N/A'}),跳过`);
           return null;
         }
 
-        log("info", `[TMDB] TMDB最佳匹配: ${bestMatchChineseTitle}, 相似度: ${(bestScore * 100).toFixed(2)}%`);
+        log("info", `[Utils] [TMDB] TMDB最佳匹配: ${bestMatchChineseTitle}, 相似度: ${(bestScore * 100).toFixed(2)}%`);
 
         // 第四步：获取日语详情
         const mediaType = bestMatch.media_type || (bestMatch.name ? "tv" : "movie");
@@ -469,11 +469,11 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
         let jaOriginalTitle;
         if (!detailResp || !detailResp.data) {
           jaOriginalTitle = bestMatch.name || bestMatch.title;
-          log("info", `[TMDB] 使用中文搜索结果标题: ${jaOriginalTitle}`);
+          log("info", `[Utils] [TMDB] 使用中文搜索结果标题: ${jaOriginalTitle}`);
         } else {
           const detail = typeof detailResp.data === "string" ? JSON.parse(detailResp.data) : detailResp.data;
           jaOriginalTitle = detail.original_name || detail.original_title || detail.name || detail.title;
-          log("info", `[TMDB] 找到日语原名: ${jaOriginalTitle}`);
+          log("info", `[Utils] [TMDB] 找到日语原名: ${jaOriginalTitle}`);
         }
 
         // 返回对象，包含原名和别名
@@ -481,10 +481,10 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
 
       } catch (error) {
          if (error.name === 'AbortError') {
-             log("info", `[TMDB] 后台搜索任务已完全终止 (${cleanTitle})`);
+             log("info", `[Utils] [TMDB] 后台搜索任务已完全终止 (${cleanTitle})`);
              return null;
          }
-         log("error", "[TMDB] Background Search error:", {
+         log("error", "[Utils] [TMDB] Background Search error:", {
             message: error.message,
             name: error.name,
             stack: error.stack,
@@ -504,9 +504,9 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
     };
 
     TMDB_PENDING.set(cleanTitle, task);
-    log("info", `[TMDB] 启动新搜索任务: ${cleanTitle}`);
+    log("info", `[Utils] [TMDB] 启动新搜索任务: ${cleanTitle}`);
   } else {
-    log("info", `[TMDB] 加入正在进行的搜索: ${cleanTitle} (${sourceLabel})`);
+    log("info", `[Utils] [TMDB] 加入正在进行的搜索: ${cleanTitle} (${sourceLabel})`);
   }
 
   // 增加引用计数
@@ -519,7 +519,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
     if (currentTask === task) {
         task.refCount--;
         if (task.refCount <= 0) {
-            log("info", `[TMDB] 所有调用者已取消，终止后台请求: ${cleanTitle}`);
+            log("info", `[Utils] [TMDB] 所有调用者已取消，终止后台请求: ${cleanTitle}`);
             task.controller.abort();
         }
     }
@@ -532,7 +532,7 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
   if (signal) {
     if (signal.aborted) {
         leaveTask();
-        log("info", `[TMDB] 搜索已被中断 (Source: ${sourceLabel})`);
+        log("info", `[Utils] [TMDB] 搜索已被中断 (Source: ${sourceLabel})`);
         return null;
     }
     signal.addEventListener('abort', leaveTask);
@@ -551,10 +551,10 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
 
   } catch (error) {
     if (error.name === 'AbortError') {
-      log("info", `[TMDB] 搜索已被中断 (Source: ${sourceLabel})`);
+      log("info", `[Utils] [TMDB] 搜索已被中断 (Source: ${sourceLabel})`);
       return null;
     }
-    log("error", `[TMDB] 搜索异常: ${error.message}`);
+    log("error", `[Utils] [TMDB] 搜索异常: ${error.message}`);
     return null;
   } finally {
     // 释放并移除终止信号监听器，防止发生内存泄漏
@@ -589,7 +589,7 @@ export async function getTMDBChineseTitle(title, season = null, episode = null) 
       // 找一个不全是外文的翻译作为中文名
       const displayTitle = m.titles.find(t => t && !isNonChinese(t)) || m.titles[1];
       if (displayTitle && !isNonChinese(displayTitle)) {
-        log("info", `[TMDB] 命中本地 Bangumi Data: ${title} -> ${displayTitle}`);
+        log("info", `[Utils] [TMDB] 命中本地 Bangumi Data: ${title} -> ${displayTitle}`);
         return displayTitle;
       }
     }
@@ -605,7 +605,7 @@ export async function getTMDBChineseTitle(title, season = null, episode = null) 
 
     // 检查是否有结果
     if (!searchResponse.data.results || searchResponse.data.results.length === 0) {
-      log("info", '[TMDB] TMDB未找到任何结果');
+      log("info", '[Utils] [TMDB] TMDB未找到任何结果');
       return title;
     }
 
@@ -688,7 +688,7 @@ export function smartTitleReplace(animes, cnAlias) {
   // 若有效替换条目数为0，说明均已处理或无需处理，直接静默退出
   if (validCount === 0) return;
 
-  log("info", `[TMDB] 启动智能替换，目标别名: "${cnAlias}"，待处理条目: ${validCount}`);
+  log("info", `[Utils] [TMDB] 启动智能替换，目标别名: "${cnAlias}"，待处理条目: ${validCount}`);
 
   // 计算所有标题主体部分的 LCP (最长公共前缀)
   const baseTitles = animes.map(a => {
@@ -706,7 +706,7 @@ export function smartTitleReplace(animes, cnAlias) {
   }
 
   if (lcp && lcp.length > 1) {
-    log("info", `[TMDB] 计算出最长公共前缀 (LCP): "${lcp}"`);
+    log("info", `[Utils] [TMDB] 计算出最长公共前缀 (LCP): "${lcp}"`);
   }
 
   // 执行具体的智能替换策略
@@ -720,7 +720,7 @@ export function smartTitleReplace(animes, cnAlias) {
     if (lcp && lcp.length > 1 && originalTitle.startsWith(lcp)) {
       const suffix = originalTitle.substring(lcp.length).trim();
       anime._displayTitle = suffix ? `${cnAlias}${suffix.match(/^[~～:：]/) ? '' : ' '}${suffix}` : cnAlias;
-      log("info", `[TMDB] [LCP模式] "${originalTitle}" -> "${anime._displayTitle}"`);
+      log("info", `[Utils] [TMDB] [LCP模式] "${originalTitle}" -> "${anime._displayTitle}"`);
     } else {
       const match = originalTitle.match(SEPARATOR_REGEX);
       if (match) {
@@ -731,19 +731,19 @@ export function smartTitleReplace(animes, cnAlias) {
           const subMatch = suffix.trim().match(SEPARATOR_REGEX);
           const subSuffix = subMatch ? suffix.trim().substring(subMatch.index) : '';
           anime._displayTitle = `${prefix} ${cnAlias}${subSuffix}`;
-          log("info", `[TMDB] [前缀保护模式] "${originalTitle}" -> "${anime._displayTitle}"`);
+          log("info", `[Utils] [TMDB] [前缀保护模式] "${originalTitle}" -> "${anime._displayTitle}"`);
         } else {
           // 策略 B2: 常规分隔符模式
           anime._displayTitle = cnAlias + suffix;
-          log("info", `[TMDB] [分隔符模式] "${originalTitle}" -> "${anime._displayTitle}"`);
+          log("info", `[Utils] [TMDB] [分隔符模式] "${originalTitle}" -> "${anime._displayTitle}"`);
         }
       } else {
         // 策略 C: 安全兜底模式
         if (isNonChinese(originalTitle)) {
           anime._displayTitle = cnAlias;
-          log("info", `[TMDB] [纯外文全替模式] "${originalTitle}" -> "${anime._displayTitle}"`);
+          log("info", `[Utils] [TMDB] [纯外文全替模式] "${originalTitle}" -> "${anime._displayTitle}"`);
         } else {
-          log("info", `[TMDB] [跳过替换] "${originalTitle}" 含有中文且特征不符，拒绝强制全替以防误杀`);
+          log("info", `[Utils] [TMDB] [跳过替换] "${originalTitle}" 含有中文且特征不符，拒绝强制全替以防误杀`);
         }
       }
     }

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -57,15 +57,15 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
     }
   }
 
-  log("info", `request url: ${JSON.stringify(url)}`);
-  log("info", `request path: ${path}`);
-  log("info", `client ip: ${clientIp}`);
+  log("info", `[system] [Server] request url: ${JSON.stringify(url)}`);
+  log("info", `[system] [Server] request path: ${path}`);
+  log("info", `[system] [Server] client ip: ${clientIp}`);
 
   // --- IP 黑名单拦截 ---
   if (globals.ipBlacklist?.length) {
     const isBlocked = globals.ipBlacklist.some(rule => matchIpBlacklistRule(rule, clientIp));
     if (isBlocked) {
-      log("warn", `[IP Blacklist] Blocked request from IP: ${clientIp}`);
+      log("warn", `[Utils] [IP Blacklist] Blocked request from IP: ${clientIp}`);
       return jsonResponse(
         { errorCode: 403, success: false, errorMessage: "Forbidden" },
         403
@@ -120,8 +120,8 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
 
     if (lastRecord) {
       const lastDate = new Date(lastRecord.timestamp).toDateString();
-      console.log("currentDate: ", currentDate);
-      console.log("lastDate: ", lastDate);
+      log("info", `[system] [Server] currentDate: ${currentDate}`);
+      log("info", `[system] [Server] lastDate: ${lastDate}`);
       if (lastDate !== currentDate) {
         // 新的一天，重置计数
         globals.todayReqNum = 1;
@@ -209,7 +209,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
         }
         // 第一段不是已知的 API 路径，可能是错误的 token
         // 返回 401
-        log("error", `Invalid token in path: ${path}`);
+        log("error", `[system] [Server] Invalid token in path: ${path}`);
         return jsonResponse(
           { errorCode: 401, success: false, errorMessage: "Unauthorized" },
           401
@@ -224,7 +224,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
       if (path === "/api/config" && method === "GET") {
         return handleConfig(false); // 无权限
       }
-      log("error", `Invalid or missing token in path: ${path}`);
+      log("error", `[system] [Server] Invalid or missing token in path: ${path}`);
       return jsonResponse(
         { errorCode: 401, success: false, errorMessage: "Unauthorized" },
         401
@@ -251,7 +251,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
     return handleReqRecords();
   }
 
-  log("info", path);
+  log("info", `[system] [Server] ${path}`);
 
   // 智能处理API路径前缀，确保最终有一个正确的 /api/v2
   if (path !== "/" && path !== "/danmaku" && path !== "/api/logs" && !path.startsWith('/api/env') 
@@ -356,7 +356,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
       // 先检查缓存
       const cachedComments = getCommentCache(videoUrl);
       if (cachedComments !== null) {
-        log("info", `[Rate Limit] Cache hit for URL: ${videoUrl}, skipping rate limit check`);
+        log("info", `[Utils] [Rate Limit] Cache hit for URL: ${videoUrl}, skipping rate limit check`);
         return getCommentByUrl(videoUrl, queryFormat, segmentFlag, includeDuration);
       }
 
@@ -378,7 +378,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
 
         // 如果最近 1 分钟内的请求次数超过限制，返回 429 错误
         if (recentRequests.length >= globals.rateLimitMaxRequests) {
-          log("warn", `[Rate Limit] IP ${clientIp} exceeded rate limit (${recentRequests.length}/${globals.rateLimitMaxRequests} requests in 1 minute)`);
+          log("warn", `[Utils] [Rate Limit] IP ${clientIp} exceeded rate limit (${recentRequests.length}/${globals.rateLimitMaxRequests} requests in 1 minute)`);
           return jsonResponse(
             { errorCode: 429, success: false, errorMessage: "Too many requests, please try again later" },
             429
@@ -388,7 +388,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
         // 记录本次请求时间戳
         recentRequests.push(currentTime);
         globals.requestHistory.set(clientIp, recentRequests);
-        log("info", `[Rate Limit] IP ${clientIp} request count: ${recentRequests.length}/${globals.rateLimitMaxRequests}`);
+        log("info", `[Utils] [Rate Limit] IP ${clientIp} request count: ${recentRequests.length}/${globals.rateLimitMaxRequests}`);
       }
 
       // 通过URL获取弹幕
@@ -397,7 +397,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
 
     // 否则通过commentId获取弹幕
     if (!path.startsWith("/api/v2/comment/")) {
-      log("error", "Missing commentId or url parameter");
+      log("error", "[system] [Server] Missing commentId or url parameter");
       return jsonResponse(
         { errorCode: 400, success: false, errorMessage: "Missing commentId or url parameter" },
         400
@@ -411,7 +411,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
       // 检查弹幕缓存 - 缓存命中时直接返回，不计入限流
       const cachedComments = getCommentCache(urlForComment);
       if (cachedComments !== null) {
-        log("info", `[Rate Limit] Cache hit for URL: ${urlForComment}, skipping rate limit check`);
+        log("info", `[Utils] [Rate Limit] Cache hit for URL: ${urlForComment}, skipping rate limit check`);
         return getComment(path, queryFormat, segmentFlag, clientIp, includeDuration);
       }
     }
@@ -438,7 +438,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
 
       // 如果最近的请求数量大于等于配置的限制次数，则限制请求
       if (recentRequests.length >= globals.rateLimitMaxRequests) {
-        log("warn", `[Rate Limit] IP ${clientIp} exceeded rate limit (${recentRequests.length}/${globals.rateLimitMaxRequests} requests in 1 minute)`);
+        log("warn", `[Utils] [Rate Limit] IP ${clientIp} exceeded rate limit (${recentRequests.length}/${globals.rateLimitMaxRequests} requests in 1 minute)`);
         return jsonResponse(
           { errorCode: 429, success: false, errorMessage: "Too many requests, please try again later" },
           429
@@ -448,7 +448,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
       // 记录本次请求时间戳
       recentRequests.push(currentTime);
       globals.requestHistory.set(clientIp, recentRequests);
-      log("info", `[Rate Limit] IP ${clientIp} request count: ${recentRequests.length}/${globals.rateLimitMaxRequests}`);
+      log("info", `[Utils] [Rate Limit] IP ${clientIp} request count: ${recentRequests.length}/${globals.rateLimitMaxRequests}`);
     }
 
     return getComment(path, queryFormat, segmentFlag, clientIp, includeDuration);
@@ -466,7 +466,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
       try {
         segment = Segment.fromJson(requestBody);
       } catch (e) {
-        log("error", "Invalid JSON in request body for segment");
+        log("error", "[system] [Server] Invalid JSON in request body for segment");
         return jsonResponse(
           { errorCode: 400, success: false, errorMessage: "Invalid JSON in request body" },
           400
@@ -476,7 +476,7 @@ async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
       // 通过URL和平台获取分段弹幕
       return getSegmentComment(segment, queryFormat);
     } catch (error) {
-      log("error", `Error processing segmentcomment request: ${error.message}`);
+      log("error", `[system] [Server] Error processing segmentcomment request: ${error.message}`);
       return jsonResponse(
         { errorCode: 500, success: false, errorMessage: "Internal server error" },
         500

--- a/forward/forward-widget.js
+++ b/forward/forward-widget.js
@@ -556,7 +556,7 @@ async function initGlobals(sourceOrder, otherServer, customSourceApiUrl, vodServ
 // 获取变量数据
 async function getCaches() {
     if (globals.animes.length === 0) {
-        log("info", 'getCaches start.');
+        log("info", '[Forward] getCaches start.');
         const [kv_animes, kv_episodeIds, kv_episodeNum, kv_logBuffer, kv_lastSelectMap] = await Promise.all([
           Widget.storage.get('animes'),
           Widget.storage.get('episodeIds'),
@@ -582,7 +582,7 @@ async function getCaches() {
 
 // 存储更新后的变量
 async function updateCaches() {
-    log("info", 'updateCaches start.');
+    log("info", '[Forward] updateCaches start.');
     await Promise.all([
       Widget.storage.set('animes', globals.animes),
       Widget.storage.set('episodeIds', globals.episodeIds),
@@ -594,7 +594,7 @@ async function updateCaches() {
 
 // 删除存储的变量
 async function removeCaches() {
-    log("info", 'removeCaches start.');
+    log("info", '[Forward] removeCaches start.');
     await Promise.all([
       Widget.storage.remove('animes'),
       Widget.storage.remove('episodeIds'),
@@ -619,7 +619,7 @@ async function searchDanmu(params) {
   // 如果启用了搜索关键字繁转简，则进行转换
   if (globals.animeTitleSimplified) {
     simplifiedTitle = simplized(title);
-    log("info", `searchAnime converted traditional to simplified: ${title} -> ${simplifiedTitle}`);
+    log("info", `[Forward] searchAnime converted traditional to simplified: ${title} -> ${simplifiedTitle}`);
   }
 
   const response = await searchAnime(new URL(`${PREFIX_URL}/api/v2/search/anime?keyword=${simplifiedTitle}`));
@@ -677,7 +677,7 @@ async function searchDanmu(params) {
     }
   }
 
-  log("info", "animes: ", animes);
+  log("info", "[Forward] animes: ", animes);
 
   await updateCaches();
 
@@ -698,7 +698,7 @@ async function getDetailById(params) {
   const response = await getBangumi(`${PREFIX_URL}/api/v2/bangumi/${animeId}`);
   const resJson = await response.json();
 
-  log("info", "bangumi", resJson);
+  log("info", "[Forward] bangumi", resJson);
 
   await updateCaches();
 
@@ -720,11 +720,11 @@ async function getCommentsById(params) {
     const segmentList = Widget.storage.get(storeKey);
     const lastCommentId = Widget.storage.get(commentIdKey);
     
-    log("info", "storeKey:", storeKey);
-    log("info", "commentIdKey:", commentIdKey);
-    log("info", "commentId:", commentId);
-    log("info", "lastCommentId:", lastCommentId);
-    log("info", "segmentList:", segmentList);
+    log("info", "[Forward] storeKey:", storeKey);
+    log("info", "[Forward] commentIdKey:", commentIdKey);
+    log("info", "[Forward] commentId:", commentId);
+    log("info", "[Forward] lastCommentId:", lastCommentId);
+    log("info", "[Forward] segmentList:", segmentList);
 
     if (lastCommentId === commentId && segmentList) {
         return await getDanmuWithSegmentTime({ segmentTime, tmdbId, season, episode, sourceOrder, otherServer, customSourceApiUrl, vodServers, vodReturnMode, vodRequestTimeout, bilibiliCookie, doubanCookie,
@@ -738,12 +738,10 @@ async function getCommentsById(params) {
     const response = await getComment(`${PREFIX_URL}/api/v2/comment/${commentId}`, "json", true);
     const resJson = await response.json();
 
-    log("info", "segmentList:", resJson.comments.segmentList);
+    log("info", "[Forward] segmentList:", resJson.comments.segmentList);
 
     Widget.storage.set(storeKey, resJson.comments.segmentList);
     Widget.storage.set(commentIdKey, commentId);
-
-    console.log("segmentList", resJson.comments.segmentList);
 
     await updateCaches();
 
@@ -770,7 +768,7 @@ async function getDanmuWithSegmentTime(params) {
         const time = Number(segmentTime);
         return time >= start && time < end;
     });
-    log("info", "segment:", segment);
+    log("info", "[Forward] segment:", segment);
     const response = await getSegmentComment(segment);
     const resJson = await response.json();
 

--- a/node-functions/index.js
+++ b/node-functions/index.js
@@ -1,4 +1,5 @@
 import { handleRequest } from '../danmu_api/worker.js';
+import { log } from '../danmu_api/danmu_api/utils/log-util.js';
 
 export const onRequest = async (context) => {
   const { request, env } = context;
@@ -7,8 +8,8 @@ export const onRequest = async (context) => {
   const baseUrl = `https://localhost`;
 
   // 调试：打印 headers 和原始 URL
-  console.log('Request URL:', request.url);
-  console.log('Request Headers:', request.headers);
+  log('info', '[node-functions] Request URL:', request.url);
+  log('info', '[node-functions] Request Headers:', request.headers);
 
   // 构造完整的 URL
   let fullUrl;
@@ -21,9 +22,9 @@ export const onRequest = async (context) => {
     }
 
     fullUrl = new URL(targetUrl, baseUrl).toString();
-    console.log('Request fullUrl:', fullUrl);
+    log('info', '[node-functions] Request fullUrl:', fullUrl);
   } catch (error) {
-    console.error('URL Construction Error:', error);
+    log('error', '[node-functions] URL Construction Error:', error);
     return new Response('Invalid URL', { status: 400 });
   }
 

--- a/node-functions/index.js
+++ b/node-functions/index.js
@@ -1,5 +1,4 @@
 import { handleRequest } from '../danmu_api/worker.js';
-import { log } from '../danmu_api/danmu_api/utils/log-util.js';
 
 export const onRequest = async (context) => {
   const { request, env } = context;
@@ -8,8 +7,8 @@ export const onRequest = async (context) => {
   const baseUrl = `https://localhost`;
 
   // 调试：打印 headers 和原始 URL
-  log('info', '[node-functions] Request URL:', request.url);
-  log('info', '[node-functions] Request Headers:', request.headers);
+  console.log('Request URL:', request.url);
+  console.log('Request Headers:', request.headers);
 
   // 构造完整的 URL
   let fullUrl;
@@ -22,9 +21,9 @@ export const onRequest = async (context) => {
     }
 
     fullUrl = new URL(targetUrl, baseUrl).toString();
-    log('info', '[node-functions] Request fullUrl:', fullUrl);
+    console.log('Request fullUrl:', fullUrl);
   } catch (error) {
-    log('error', '[node-functions] URL Construction Error:', error);
+    console.error('URL Construction Error:', error);
     return new Response('Invalid URL', { status: 400 });
   }
 


### PR DESCRIPTION
#### 实现后用腾讯龙虾全面扫描了18次项目文件，确保了覆盖完全以及无负面影响。
唯一需要注意的事：项目之后新增文件新增日志输出的时候，如果不想在分类里面排序在最后面就需要在`logview.js`将新的日志标签分下类

https://github.com/wan0ge/danmu_api/blob/433e7447a490a29a0e97a99da9d7001af77ceee0/danmu_api/ui/js/logview.js#L114-L119
```
// 标签显示顺序：ALL → 系统 → 工具 → 源，组内字母序
const tagGroupOrder = [
    ['system', 'ai'],
    ['utils', 'cache', 'merge'],
    ['360kan', 'aiyifan', 'animeko', 'bahamut', 'bilibili', 'custom', 'dandan', 'douban', 'hanjutv', 'iqiyi', 'leshi', 'maiduidui', 'mango', 'migu', 'other', 'renren', 'sohu', 'tencent', 'tmdb', 'vod', 'xigua', 'youku'],
];
```

<img width="1810" height="1203" alt="image" src="https://github.com/user-attachments/assets/26376e51-1a9c-426a-8607-808503ce2378" />

基于项目架构建立三级日志标签体系（编排层/工具层/源层），
覆盖 50 个文件。

=== 前端日志分类引擎 (logview.js + components.css.js) ===
- 新增 getLogCategory 标签分类引擎，支持标签提取、归类与续行上下文继承
- ISO 时间戳与 HH:MM:SS 格式精确过滤，避免误杀数字开头标签（如 360kan）
- 续行 _inherit_ 机制：无标签行自动继承上一行分类
- normalizationMap 归一化映射：变体标签统一收束至标准分类
- 标签筛选按钮 UI 按 system → utils/cache/merge → 源 三层分组排序

=== 后端标签规范化 ===
- sources/ 20 个源文件：弹幕提取、搜索函数、JSON 响应等全部 log 调用补全源标签
- utils/ 12 个工具文件：以 [Utils] [Name] 格式统一，保留 [Cache][Merge] 独立标签
- apis/dandan-api.js 采用 [system] [SubName] 层级格式：
  子类别覆盖 Duration / executeSourceHandlers / searchAnime / LogVar-API /
  Episodes / matchAnime / Spillover / getBangumi / Offset / YearFilter /
  Match / Bangumi / SegmentComment
- apis/env-api.js 4 处 console.error 改用 log() 纳入日志缓冲区
- configs/handlers/ 8 个文件补全 [system] [Server] 标签
- worker.js 补全 [system] [Server] / [Utils] [Rate Limit] / [Utils] [IP Blacklist]
- forward/forward-widget.js 补全 [Forward]，删除重复 console.log
- node-functions/index.js console.log → log() 统一纳入日志系统
- TMDB 标签拆分：sources/tmdb.js 保持 [TMDB]，utils/tmdb-util.js 使用 [Utils] [TMDB]
- fetchMergedComments 合并拉取路径补全源级获取弹幕日志

=== 基础设施 ===
- http-util.js 新增 sourceLogContext (AsyncLocalStorage) 跨异步日志上下文追踪
- http-util.js 新增 toLogSourceName() 集中映射函数（360→360kan, imgo→mango）
- http-util.js 诊断续行移除重复标签前缀
- 额外季数检索改为并行 Promise.all
- 前端 JSON 续行切割修复：HH:MM:SS 时间戳识别 + 无标签行自动继承

=== 标签层级 ===
系统层：[system] [Server]             [AI]
工具层：[Utils] [Name]                 [Cache] [Merge]
源层：  [360kan][vod][bilibili][tencent][youku][iqiyi]
        [mango][migu][renren][hanjutv][bahamut][dandan]
        [sohu][leshi][xigua][maiduidui][aiyifan][animeko]
        [Douban][TMDB][custom][other]
插件层：[Forward]