### PR TITLE
fix: 修复特殊字符标题搜索匹配失败

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1400,6 +1400,16 @@ export async function extractTitleSeasonEpisode(cleanFileName) {
   return {title, season, episode, year};
 }
 
+export function buildSearchAnimeUrl(baseUrl, keyword, season = '', episode = '') {
+  const searchUrl = new URL(baseUrl);
+  searchUrl.pathname = searchUrl.pathname.replace(/\/match$/, '/search/anime');
+  searchUrl.search = '';
+  searchUrl.searchParams.set('keyword', keyword || '');
+  searchUrl.searchParams.set('season', season || '');
+  searchUrl.searchParams.set('episode', episode || '');
+  return searchUrl;
+}
+
 // Extracted function for POST /api/v2/match
 export async function matchAnime(url, req, clientIp) {
   try {
@@ -1458,7 +1468,7 @@ export async function matchAnime(url, req, clientIp) {
     const targetPlatform = dynamicPlatformOrder.length > 0 ? dynamicPlatformOrder[0] : null;
 
     const requestAnimeDetailsMap = new Map();
-    let originSearchUrl = new URL(req.url.replace("/match", `/search/anime?keyword=${title}&season=${season || ''}&episode=${episode || ''}`));
+    let originSearchUrl = buildSearchAnimeUrl(req.url, title, season, episode);
     const searchRes = await searchAnime(originSearchUrl, preferAnimeId, preferSource, requestAnimeDetailsMap, targetPlatform);
     const searchData = await searchRes.json();
     log("info", `searchData: ${searchData.animes}`);
@@ -1562,7 +1572,7 @@ export async function searchEpisodes(url) {
   }
 
   // 先搜索动漫
-  let searchUrl = new URL(`/search/anime?keyword=${anime}`, url.origin);
+  let searchUrl = buildSearchAnimeUrl(new URL('/match', url.origin).toString(), anime);
   const requestAnimeDetailsMap = new Map();
 
   const searchRes = await searchAnime(searchUrl, null, null, requestAnimeDetailsMap);

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1400,13 +1400,18 @@ export async function extractTitleSeasonEpisode(cleanFileName) {
   return {title, season, episode, year};
 }
 
-export function buildSearchAnimeUrl(baseUrl, keyword, season = '', episode = '') {
+export function buildSearchAnimeUrl(baseUrl, keyword, season, episode) {
   const searchUrl = new URL(baseUrl);
-  searchUrl.pathname = searchUrl.pathname.replace(/\/match$/, '/search/anime');
+  const apiPrefix = searchUrl.pathname.replace(/\/(?:match|search\/episodes)$/, '');
+  searchUrl.pathname = `${apiPrefix}/search/anime`;
   searchUrl.search = '';
   searchUrl.searchParams.set('keyword', keyword || '');
-  searchUrl.searchParams.set('season', season || '');
-  searchUrl.searchParams.set('episode', episode || '');
+  if (season !== undefined) {
+    searchUrl.searchParams.set('season', season || '');
+  }
+  if (episode !== undefined) {
+    searchUrl.searchParams.set('episode', episode || '');
+  }
   return searchUrl;
 }
 
@@ -1572,7 +1577,7 @@ export async function searchEpisodes(url) {
   }
 
   // 先搜索动漫
-  let searchUrl = buildSearchAnimeUrl(new URL('/match', url.origin).toString(), anime);
+  let searchUrl = buildSearchAnimeUrl(url, anime);
   const requestAnimeDetailsMap = new Map();
 
   const searchRes = await searchAnime(searchUrl, null, null, requestAnimeDetailsMap);

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -5,7 +5,7 @@ dotenv.config();
 import test from 'node:test';
 import assert from 'node:assert';
 import { handleRequest } from './worker.js';
-import { extractTitleSeasonEpisode, getBangumi, getComment, matchAnime, searchAnime } from "./apis/dandan-api.js";
+import { extractTitleSeasonEpisode, getBangumi, getComment, matchAnime, searchAnime, buildSearchAnimeUrl } from "./apis/dandan-api.js";
 import { getRedisKey, pingRedis, setRedisKey, setRedisKeyWithExpiry } from "./utils/redis-util.js";
 import { getLocalRedisKey, setLocalRedisKey, setLocalRedisKeyWithExpiry } from "./utils/local-redis-util.js";
 import { getImdbepisodes } from "./utils/imdb-util.js";
@@ -204,6 +204,16 @@ test('worker.js API endpoints', async (t) => {
     });
 
     assert.equal(seenRedirectMode, 'manual');
+  });
+
+  await t.test('buildSearchAnimeUrl should preserve special characters in keyword', async () => {
+    const searchUrl = buildSearchAnimeUrl(`${urlPrefix}/api/v2/match`, 'Love & Death', 1, 2);
+
+    assert.equal(searchUrl.pathname, '/api/v2/search/anime');
+    assert.equal(searchUrl.searchParams.get('keyword'), 'Love & Death');
+    assert.equal(searchUrl.searchParams.get('season'), '1');
+    assert.equal(searchUrl.searchParams.get('episode'), '2');
+    assert.equal(searchUrl.searchParams.has(' Death'), false);
   });
 
   // 测试标题解析

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -216,6 +216,15 @@ test('worker.js API endpoints', async (t) => {
     assert.equal(searchUrl.searchParams.has(' Death'), false);
   });
 
+  await t.test('buildSearchAnimeUrl should derive /search/anime from /search/episodes requests', async () => {
+    const searchUrl = buildSearchAnimeUrl(`${urlPrefix}/api/v2/search/episodes?anime=Love%20%26%20Death&episode=2`, 'Love & Death');
+
+    assert.equal(searchUrl.pathname, '/api/v2/search/anime');
+    assert.equal(searchUrl.searchParams.get('keyword'), 'Love & Death');
+    assert.equal(searchUrl.searchParams.has('season'), false);
+    assert.equal(searchUrl.searchParams.has('episode'), false);
+  });
+
   // 测试标题解析
   await t.test('PARSE TitleSeasonEpisode', async () => {
     let title, season, episode;


### PR DESCRIPTION
## 改动说明

修复内部构造 `/search/anime` 搜索地址时，标题中的特殊字符可能导致 query 参数被截断的问题。

此前代码通过字符串拼接构造搜索 URL。若标题包含 `&`，例如 `Love & Death`，生成的地址会被解析为：

- `keyword=Love `
- 额外参数 ` Death`

导致实际搜索关键词被截断，影响自动匹配结果。

本次改动改为使用 `URL.searchParams` 构造搜索参数，避免手动拼接 query string 带来的编码问题。

同时顺手把 `searchEpisodes` 中对 `buildSearchAnimeUrl` 的调用方式改得更直接：helper 现在明确从 `/match` 和 `/search/episodes` 两个入口统一生成 `/search/anime` 地址，行为不变，但逻辑更清晰。

## 具体改动

- 新增 `buildSearchAnimeUrl`，统一构造内部 `/search/anime` URL
- `matchAnime` 和 `searchEpisodes` 改用该 helper
- `searchEpisodes` 不再先构造假的 `/match` 地址再做替换
- 增加回归测试，验证 `keyword` 中的 `&` 不会被解析成额外参数
- 增加回归测试，验证从 `/search/episodes` 入口也能正确生成 `/search/anime` 地址

## 测试

```bash
node --test ./danmu_api/worker.test.js
```
结果：8/8 通过