### PR TITLE
feat: 逐源管道解耦 searchAnime 两阶段流程

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -322,10 +322,11 @@ async function executeSourceHandlers(resultData, queryTitle, targetAnimesList, r
     aiyifan: animesAiyifan, animeko: animesAnimeko
   } = resultData;
 
-  // 源Key到handleAnimes调用Promise的映射（每个源使用独立的curAnimes和detailStore）
+  // 仅处理resultData中存在数据的源，避免将undefined传入handleAnimes
+  const activeSourceKeys = globals.sourceOrderArr.filter(key => resultData[key] !== undefined);
   const sourceTasks = [];
 
-  for (const key of globals.sourceOrderArr) {
+  for (const key of activeSourceKeys) {
     const isolatedAnimes = [];
     const isolatedDetailStore = new Map();
 
@@ -585,45 +586,80 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
   }
 
   try {
-    // 根据 sourceOrderArr 动态构建请求数组
+    // 根据 sourceOrderArr 动态构建逐源管道：每个源形成独立的 search → handleAnimes 流水线
     log("info", `Search sourceOrderArr: ${globals.sourceOrderArr}`);
-    const requestPromises = globals.sourceOrderArr.map(source => {
-      if (source === "360") return kan360Source.search(queryTitle);
-      if (source === "vod") return vodSource.search(queryTitle, preferAnimeId, preferSource);
-      if (source === "tmdb") return tmdbSource.search(queryTitle);
-      if (source === "douban") return doubanSource.search(queryTitle);
-      if (source === "renren") return renrenSource.search(queryTitle);
-      if (source === "hanjutv") return hanjutvSource.search(queryTitle);
-      if (source === "bahamut") return bahamutSource.search(queryTitle);
-      if (source === "dandan") return dandanSource.search(queryTitle);
-      if (source === "custom") return customSource.search(queryTitle);
-      if (source === "tencent") return tencentSource.search(queryTitle);
-      if (source === "youku") return youkuSource.search(queryTitle);
-      if (source === "iqiyi") return iqiyiSource.search(queryTitle);
-      if (source === "imgo") return mangoSource.search(queryTitle);
-      if (source === "bilibili") return bilibiliSource.search(queryTitle);
-      if (source === "migu") return miguSource.search(queryTitle);
-      if (source === "sohu") return sohuSource.search(queryTitle);
-      if (source === "leshi") return leshiSource.search(queryTitle);
-      if (source === "xigua") return xiguaSource.search(queryTitle);
-      if (source === "maiduidui") return maiduiduiSource.search(queryTitle);
-      if (source === "aiyifan") return aiyifanSource.search(queryTitle);
-      if (source === "animeko") return animekoSource.search(queryTitle);
-    });
 
-    // 执行所有请求并等待结果
-    const results = await Promise.all(requestPromises);
-
-    // 创建一个对象来存储返回的结果
+    // 存储各源搜索结果的容器，供S2+季度扩展逻辑读取
     const resultData = {};
 
-    // 动态根据 sourceOrderArr 顺序将结果赋值给对应的来源
-    globals.sourceOrderArr.forEach((source, index) => {
-      resultData[source] = results[index];  // 根据顺序赋值
+    // 源Key到对应搜索Promise的映射
+    const sourceSearchMap = {};
+    for (const source of globals.sourceOrderArr) {
+      if (source === "360") sourceSearchMap[source] = kan360Source.search(queryTitle);
+      else if (source === "vod") sourceSearchMap[source] = vodSource.search(queryTitle, preferAnimeId, preferSource);
+      else if (source === "tmdb") sourceSearchMap[source] = tmdbSource.search(queryTitle);
+      else if (source === "douban") sourceSearchMap[source] = doubanSource.search(queryTitle);
+      else if (source === "renren") sourceSearchMap[source] = renrenSource.search(queryTitle);
+      else if (source === "hanjutv") sourceSearchMap[source] = hanjutvSource.search(queryTitle);
+      else if (source === "bahamut") sourceSearchMap[source] = bahamutSource.search(queryTitle);
+      else if (source === "dandan") sourceSearchMap[source] = dandanSource.search(queryTitle);
+      else if (source === "custom") sourceSearchMap[source] = customSource.search(queryTitle);
+      else if (source === "tencent") sourceSearchMap[source] = tencentSource.search(queryTitle);
+      else if (source === "youku") sourceSearchMap[source] = youkuSource.search(queryTitle);
+      else if (source === "iqiyi") sourceSearchMap[source] = iqiyiSource.search(queryTitle);
+      else if (source === "imgo") sourceSearchMap[source] = mangoSource.search(queryTitle);
+      else if (source === "bilibili") sourceSearchMap[source] = bilibiliSource.search(queryTitle);
+      else if (source === "migu") sourceSearchMap[source] = miguSource.search(queryTitle);
+      else if (source === "sohu") sourceSearchMap[source] = sohuSource.search(queryTitle);
+      else if (source === "leshi") sourceSearchMap[source] = leshiSource.search(queryTitle);
+      else if (source === "xigua") sourceSearchMap[source] = xiguaSource.search(queryTitle);
+      else if (source === "maiduidui") sourceSearchMap[source] = maiduiduiSource.search(queryTitle);
+      else if (source === "aiyifan") sourceSearchMap[source] = aiyifanSource.search(queryTitle);
+      else if (source === "animeko") sourceSearchMap[source] = animekoSource.search(queryTitle);
+    }
+
+    // 构建逐源管道：每个源 search 完成后，通过 executeSourceHandlers 处理 handleAnimes
+    // 传入仅含当前源数据的 resultData，使 executeSourceHandlers 仅处理该源
+    const pipelineTasks = globals.sourceOrderArr.map(source => {
+      const isolatedAnimes = [];
+      const isolatedDetailStore = new Map();
+      const pipelinePromise = sourceSearchMap[source].then(async searchResult => {
+        resultData[source] = searchResult;
+        await executeSourceHandlers({ [source]: searchResult }, queryTitle, isolatedAnimes, isolatedDetailStore, querySeason, preferAnimeId, preferSource);
+      });
+      return { key: source, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: pipelinePromise };
     });
 
-    // 优先处理指定的季度（或全量）
-    await executeSourceHandlers(resultData, queryTitle, curAnimes, requestAnimeDetailsMap, querySeason, preferAnimeId, preferSource);
+    // 并发执行所有逐源管道，每个管道内部 search 完成后立即衔接 handleAnimes
+    const pipelineResults = await Promise.allSettled(pipelineTasks.map(task => task.promise));
+
+    // 按SOURCE_ORDER顺序合并各管道的独立结果到目标容器
+    // 先处理的源数据优先保留（animeId去重、detailStore键去重）
+    const existingAnimeIds = new Set(curAnimes.map(a => a.animeId));
+
+    for (let i = 0; i < pipelineTasks.length; i++) {
+      if (pipelineResults[i].status === 'rejected') {
+        log("error", `[searchAnime] 源 ${pipelineTasks[i].key} 管道处理失败: ${pipelineResults[i].reason}`);
+        continue;
+      }
+
+      const { animes: isolatedAnimes, detailStore: isolatedDetailStore } = pipelineTasks[i];
+
+      // 合并动漫结果列表（使用 Set 确保 O(1) 检索，优先源先入为主）
+      for (const anime of isolatedAnimes) {
+        if (!existingAnimeIds.has(anime.animeId)) {
+          curAnimes.push(anime);
+          existingAnimeIds.add(anime.animeId);
+        }
+      }
+
+      // 合并详情缓存（键去重，先到先得）
+      for (const [key, value] of isolatedDetailStore) {
+        if (!requestAnimeDetailsMap.has(key)) {
+          requestAnimeDetailsMap.set(key, value);
+        }
+      }
+    }
 
     // 缓存首季/默认请求结果，剥离附加链接
     if (curAnimes.length > 0) {

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -160,8 +160,13 @@ export default class BahamutSource extends BaseSource {
             log("info", "[Bahamut] 原始搜索成功，中断日语原名搜索");
             return { success: false, source: 'tmdb', aborted: true };
           }
-          // 抛出其他错误（例如 httpGet 超时）
-          throw error;
+          // TMDB搜索失败不阻塞原始搜索结果，与originalSearchPromise保持一致的错误处理策略
+          log("error", "[Bahamut] TMDB搜索失败:", {
+            message: error.message,
+            name: error.name,
+            stack: error.stack,
+          });
+          return { success: false, source: 'tmdb' };
         }
       })();
 
@@ -398,6 +403,8 @@ export default class BahamutSource extends BaseSource {
           episodeCache.set(cacheKey, this.getEpisodes(anime.video_sn));
         }
         const epData = await episodeCache.get(cacheKey);
+        // getEpisodes 网络失败时返回空数组而非对象，必须校验结构有效性
+        if (!epData || typeof epData !== 'object' || Array.isArray(epData)) return null;
         const detail = epData.video;
 
         // episodes 可能在不同键中（如 "0"、"1"），电影类内容尤其常见

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -71,7 +71,7 @@ export default class BahamutSource extends BaseSource {
               "Content-Type": "application/json",
               "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
             },
-			retries: 1,
+			retries: 2,
           });
 
           // 如果原始搜索有结果，中断 TMDB 流程
@@ -136,7 +136,7 @@ export default class BahamutSource extends BaseSource {
               "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
             },
             signal: tmdbAbortController.signal,
-            retries: 1,
+            retries: 2,
           });
 
           if (tmdbResp && tmdbResp.data && tmdbResp.data.anime && tmdbResp.data.anime.length > 0) {
@@ -240,7 +240,7 @@ export default class BahamutSource extends BaseSource {
           "Content-Type": "application/json",
           "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
         },
-		retries: 1,
+		retries: 2,
       });
 
       // 判断 resp 和 resp.data 是否存在
@@ -511,7 +511,7 @@ export default class BahamutSource extends BaseSource {
           "Content-Type": "application/json",
           "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
         },
-        retries: 1,
+        retries: 2,
       });
 
       // 将当前请求的 episodes 拼接到总数组


### PR DESCRIPTION
#331 的进阶，整体请求流程最大效率化形态：详情阶段不再等待搜索阶段的完成，各源请求流程独立。
算实验性（）暂未测试出负面影响，理论负面影响是瞬时网络并发峰值剧增，并发连接数增加。

如果觉得收益没太大必要可以考虑不合，实际提升不算大

将 searchAnime 中的两阶段阻塞模型（Promise.all(search) → executeSourceHandlers） 改为逐源管道模型：每个源形成独立的 search → executeSourceHandlers 流水线， search 完成后通过 {[source]: searchResult} 调用 executeSourceHandlers 处理该源， 不等待其他源完成。

改动说明：
- 构建 sourceSearchMap 存储各源搜索 Promise（搜索并发度不变）
- 每个源的搜索 Promise 通过 .then() 链式调用 executeSourceHandlers
- 传入仅含当前源数据的 {[source]: searchResult}，使 executeSourceHandlers 仅处理该源
- executeSourceHandlers 增加 activeSourceKeys 过滤，仅处理 resultData 中存在数据的源
- 各管道独立维护 isolatedAnimes 和 isolatedDetailStore
- 所有管道通过 Promise.allSettled 并发执行
- 管道完成后按 SOURCE_ORDER 顺序合并结果（animeId 去重、detailStore 键去重）
- resultData 在管道 .then() 回调中填充，供 S2+ 季度扩展逻辑读取
- executeSourceHandlers 函数未做任何修改，源路由逻辑仍由其集中维护
- Bahamut tmdbSearchPromise 错误处理与 originalSearchPromise 保持一致， 网络失败时返回 {success:false} 而非 throw，避免 Promise.all 快速失败吞掉原始搜索结果
- Bahamut handleAnimes 增加 epData 结构校验，防止 getEpisodes 返回空数组时 TypeError

预期收益：消除阶段壁垒，总耗时从 max(search) + max(handleAnimes)
降低至 max(各源 search + handleAnimes)，约减少 20%