### PR TITLE
fix: REMEMBER_LAST_SELECT 偏好记录在季节性缓存分区后失效，同时修复跨源标题别名拒绝写入

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -466,7 +466,17 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
   const cacheKey = querySeason !== null ? `${queryTitle}_S${querySeason}` : queryTitle;
 
   // 检查搜索缓存
-  const cachedResults = getSearchCache(cacheKey, requestAnimeDetailsMap);
+  let cachedResults = getSearchCache(cacheKey, requestAnimeDetailsMap);
+
+  // 如果带季度的特定缓存未命中，尝试获取不带季度的通用搜索缓存
+  if (cachedResults === null && querySeason !== null) {
+    const genericCachedResults = getSearchCache(queryTitle, requestAnimeDetailsMap);
+    if (genericCachedResults !== null) {
+      log("info", `[system] [searchAnime] Cache miss for ${cacheKey}, fallback to generic cache for ${queryTitle}`);
+      cachedResults = genericCachedResults;
+    }
+  }
+
   if (cachedResults !== null) {
     let satisfied = checkEpisodeSatisfied(cachedResults, querySeason, queryEpisode, requestAnimeDetailsMap, targetPlatform);
     if (satisfied) {
@@ -1185,6 +1195,10 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
 
     let matchedEpisode = null;
 
+    // 判定当前循环的 anime 是否为用户手动指定的优选偏好
+    const isPreferredAnime = globals.rememberLastSelect && preferAnimeId != null && 
+        (String(anime.bangumiId) === String(preferAnimeId) || String(anime.animeId) === String(preferAnimeId));
+
     if (season && episode) {
         // 剧集模式逻辑
         const filteredTmpEpisodes = bangumiData.bangumi.episodes.filter(episode => {
@@ -1199,8 +1213,14 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
           targetEpisode = computeTargetEpisode(offsets, season, episode, filteredEpisodes, targetEpisode);
         }
 
-        // 匹配集数 (注意：findEpisodeByNumber 已增强支持模糊平台匹配)
+        // 匹配集数
         matchedEpisode = findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, platform);
+
+        // 如果当前是用户的优选偏好，但由于平台配置限制导致未命中目标平台，则放宽条件无视平台限制提取集数
+        if (!matchedEpisode && isPreferredAnime) {
+            log("info", `[system] [Match] 优选剧集未命中目标平台 ${platform}，放宽条件提取集数`);
+            matchedEpisode = findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, null);
+        }
     } else {
         // 电影模式逻辑
         if (bangumiData.bangumi.episodes.length > 0) {
@@ -1213,6 +1233,9 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
                 
                 if (targetEp) {
                     matchedEpisode = targetEp;
+                } else if (isPreferredAnime) {
+                    log("info", `[system] [Match] 优选电影未命中目标平台 ${platform}，放宽条件提取资源`);
+                    matchedEpisode = bangumiData.bangumi.episodes[0];
                 }
             } else {
                 matchedEpisode = bangumiData.bangumi.episodes[0];
@@ -1234,6 +1257,11 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
             currentScore = 1;
         }
 
+        // 赋予手动指定偏好最高分数权重，确保其在多源匹配中具有绝对优先级
+        if (isPreferredAnime) {
+            currentScore += 9999;
+        }
+
         // 比较并更新最佳结果
         // 逻辑：如果有更好的分数，或者之前没有匹配到任何结果，则更新
         if (currentScore > bestRes.score) {
@@ -1244,9 +1272,8 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
             };
         }
 
-        // 如果没有指定平台偏好 (platform 为空)，则保持原版行为：
-        // 找到第一个符合条件的就立刻返回，不进行后续比较
-        if (!platform) {
+        // 如果没有指定平台偏好 (platform 为空) 或已命中最高优先级的手动优选，立刻跳出查找
+        if (!platform || isPreferredAnime) {
             break; 
         }
         
@@ -2017,7 +2044,7 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
     }
   }
 
-  const [animeId, source, episodeTitle] = findAnimeIdByCommentId(commentId);
+  const [animeId, source, episodeTitle, animeAliases] = findAnimeIdByCommentId(commentId);
   if (animeId && source) {
     let lastTitle = null;
     let lastSeason = null;
@@ -2035,7 +2062,11 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
 
     log("info", `[system] [LogVar-API] animeTitle：${animeTitle}; lastTitle：${lastTitle}; titleMatches：${titleMatches(animeTitle, lastTitle)}`);
 
-    if (titleMatches(animeTitle, lastTitle)) {
+    // 校验番剧标题或别名是否匹配最新搜索/匹配上下文，别名检查用于兼容不同源对同一番剧的标题命名差异
+    const titleOrAliasMatches = titleMatches(animeTitle, lastTitle) ||
+        (Array.isArray(animeAliases) && animeAliases.some(alias => titleMatches(alias, lastTitle)));
+
+    if (titleOrAliasMatches) {
       log("info", `[system] [LogVar-API] excute setPreferByAnimeId`);
       setPreferByAnimeId(animeId, source, lastSeason, offset);
     }

--- a/danmu_api/utils/cache-util.js
+++ b/danmu_api/utils/cache-util.js
@@ -518,12 +518,21 @@ export function removeEarliestAnime() {
 // 将所有动漫的 animeId 存入 lastSelectMap 的 animeIds 数组中
 export function storeAnimeIdsToMap(curAnimes, key) {
     const uniqueAnimeIds = new Set();
+    
+    const oldValue = globals.lastSelectMap.get(key);
+    
+    // 保留旧的 animeIds，确保包含全量季度的 ID 列表不被单季度搜索结果覆盖
+    if (oldValue && Array.isArray(oldValue.animeIds)) {
+        for (const id of oldValue.animeIds) {
+            uniqueAnimeIds.add(id);
+        }
+    }
+
     for (const anime of curAnimes) {
         uniqueAnimeIds.add(anime.animeId);
     }
 
     // 保存旧的 prefer/source/offsets（兼容旧结构）
-    const oldValue = globals.lastSelectMap.get(key);
     const oldPrefer = oldValue?.prefer;
     const oldSource = oldValue?.source;
     const oldPreferBySeason = oldValue?.preferBySeason;
@@ -565,9 +574,10 @@ export function storeAnimeIdsToMap(curAnimes, key) {
 export function findAnimeIdByCommentId(commentId) {
   const resolved = resolveEpisodeContextById(commentId);
   if (resolved) {
-    return [resolved.anime.animeId, resolved.anime.source, resolved.link.title];
+    // 返回别名列表以支持跨源标题差异的偏好记录校验
+    return [resolved.anime.animeId, resolved.anime.source, resolved.link.title, resolved.anime.aliases || []];
   }
-  return [null, null, null];
+  return [null, null, null, []];
 }
 
 // 通过 animeId 查找 lastSelectMap 中 animeIds 包含该 animeId 的 key，并设置其 prefer 为 animeId


### PR DESCRIPTION
改动涉及问题：
1. PR #303 引入的搜索缓存季度分区导致单季度搜索覆盖 lastSelectMap 的 animeIds， 后续 setPreferByAnimeId 因找不到目标 animeId 而静默失败
2. 手动指定的优选番剧在平台偏好场景下被非优选源覆盖（手动偏好优先级低于平台偏好）
3. 评论 handler 的 titleMatches 仅检查主标题，不同源对同一番剧的标题存在差异 （如 bilibili "正相反的你与我" vs dandan "相反的你和我"），导致跨源的偏好无法记录

修复：
cache-util.js
- storeAnimeIdsToMap: 合并旧 animeIds 而非覆盖，避免单季度搜索结果清空全量 ID
- findAnimeIdByCommentId: 返回 anime.aliases（各源已填充），用于标题兼容校验

dandan-api.js
- searchAnime: 季节性缓存 miss 时回退至泛化（无季度）缓存
- matchAniAndEp: 手动优选番剧增加 isPreferredAnime 标记，含三重保障： 目标平台未命中时放宽平台限制、+9999 评分权重确保优先、命中即时跳出
- getComment: 偏好写入闸门增加别名匹配，防止因标题差异导致偏好静默丢弃