### PR TITLE
feat: 逐源管道解耦 searchAnime 两阶段流程

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -322,10 +322,11 @@ async function executeSourceHandlers(resultData, queryTitle, targetAnimesList, r
     aiyifan: animesAiyifan, animeko: animesAnimeko
   } = resultData;
 
-  // 源Key到handleAnimes调用Promise的映射（每个源使用独立的curAnimes和detailStore）
+  // 仅处理resultData中存在数据的源，避免将undefined传入handleAnimes
+  const activeSourceKeys = globals.sourceOrderArr.filter(key => resultData[key] !== undefined);
   const sourceTasks = [];
 
-  for (const key of globals.sourceOrderArr) {
+  for (const key of activeSourceKeys) {
     const isolatedAnimes = [];
     const isolatedDetailStore = new Map();
 
@@ -586,46 +587,80 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
   }
 
   try {
-    // 根据 sourceOrderArr 动态构建请求数组
+    // 根据 sourceOrderArr 动态构建逐源管道：每个源形成独立的 search → handleAnimes 流水线
     log("info", `[system] [LogVar-API] Search sourceOrderArr: ${globals.sourceOrderArr}`);
-    const requestPromises = globals.sourceOrderArr.map(source => {
-      return sourceLogContext.run(toLogSourceName(source), () => {
-      if (source === "360") return kan360Source.search(queryTitle);
-      if (source === "vod") return vodSource.search(queryTitle, preferAnimeId, preferSource);
-      if (source === "tmdb") return tmdbSource.search(queryTitle);
-      if (source === "douban") return doubanSource.search(queryTitle);
-      if (source === "renren") return renrenSource.search(queryTitle);
-      if (source === "hanjutv") return hanjutvSource.search(queryTitle);
-      if (source === "bahamut") return bahamutSource.search(queryTitle);
-      if (source === "dandan") return dandanSource.search(queryTitle);
-      if (source === "custom") return customSource.search(queryTitle);
-      if (source === "tencent") return tencentSource.search(queryTitle);
-      if (source === "youku") return youkuSource.search(queryTitle);
-      if (source === "iqiyi") return iqiyiSource.search(queryTitle);
-      if (source === "imgo") return mangoSource.search(queryTitle);
-      if (source === "bilibili") return bilibiliSource.search(queryTitle);
-      if (source === "migu") return miguSource.search(queryTitle);
-      if (source === "sohu") return sohuSource.search(queryTitle);
-      if (source === "leshi") return leshiSource.search(queryTitle);
-      if (source === "xigua") return xiguaSource.search(queryTitle);
-      if (source === "maiduidui") return maiduiduiSource.search(queryTitle);
-      if (source === "aiyifan") return aiyifanSource.search(queryTitle);
-      if (source === "animeko") return animekoSource.search(queryTitle);
-    }); });
 
-    // 执行所有请求并等待结果
-    const results = await Promise.all(requestPromises);
-
-    // 创建一个对象来存储返回的结果
+    // 存储各源搜索结果的容器，供S2+季度扩展逻辑读取
     const resultData = {};
 
-    // 动态根据 sourceOrderArr 顺序将结果赋值给对应的来源
-    globals.sourceOrderArr.forEach((source, index) => {
-      resultData[source] = results[index];  // 根据顺序赋值
+    // 源Key到对应搜索Promise的映射
+    const sourceSearchMap = {};
+    for (const source of globals.sourceOrderArr) {
+      if (source === "360") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => kan360Source.search(queryTitle));
+      else if (source === "vod") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => vodSource.search(queryTitle, preferAnimeId, preferSource));
+      else if (source === "tmdb") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => tmdbSource.search(queryTitle));
+      else if (source === "douban") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => doubanSource.search(queryTitle));
+      else if (source === "renren") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => renrenSource.search(queryTitle));
+      else if (source === "hanjutv") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => hanjutvSource.search(queryTitle));
+      else if (source === "bahamut") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => bahamutSource.search(queryTitle));
+      else if (source === "dandan") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => dandanSource.search(queryTitle));
+      else if (source === "custom") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => customSource.search(queryTitle));
+      else if (source === "tencent") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => tencentSource.search(queryTitle));
+      else if (source === "youku") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => youkuSource.search(queryTitle));
+      else if (source === "iqiyi") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => iqiyiSource.search(queryTitle));
+      else if (source === "imgo") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => mangoSource.search(queryTitle));
+      else if (source === "bilibili") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => bilibiliSource.search(queryTitle));
+      else if (source === "migu") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => miguSource.search(queryTitle));
+      else if (source === "sohu") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => sohuSource.search(queryTitle));
+      else if (source === "leshi") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => leshiSource.search(queryTitle));
+      else if (source === "xigua") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => xiguaSource.search(queryTitle));
+      else if (source === "maiduidui") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => maiduiduiSource.search(queryTitle));
+      else if (source === "aiyifan") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => aiyifanSource.search(queryTitle));
+      else if (source === "animeko") sourceSearchMap[source] = sourceLogContext.run(toLogSourceName(source), () => animekoSource.search(queryTitle));
+    }
+
+    // 构建逐源管道：每个源 search 完成后，通过 executeSourceHandlers 处理 handleAnimes
+    // 传入仅含当前源数据的 resultData，使 executeSourceHandlers 仅处理该源
+    const pipelineTasks = globals.sourceOrderArr.map(source => {
+      const isolatedAnimes = [];
+      const isolatedDetailStore = new Map();
+      const pipelinePromise = sourceSearchMap[source].then(async searchResult => {
+        resultData[source] = searchResult;
+        await executeSourceHandlers({ [source]: searchResult }, queryTitle, isolatedAnimes, isolatedDetailStore, querySeason, preferAnimeId, preferSource);
+      });
+      return { key: source, animes: isolatedAnimes, detailStore: isolatedDetailStore, promise: pipelinePromise };
     });
 
-    // 优先处理指定的季度（或全量）
-    await executeSourceHandlers(resultData, queryTitle, curAnimes, requestAnimeDetailsMap, querySeason, preferAnimeId, preferSource);
+    // 并发执行所有逐源管道，每个管道内部 search 完成后立即衔接 handleAnimes
+    const pipelineResults = await Promise.allSettled(pipelineTasks.map(task => task.promise));
+
+    // 按SOURCE_ORDER顺序合并各管道的独立结果到目标容器
+    // 先处理的源数据优先保留（animeId去重、detailStore键去重）
+    const existingAnimeIds = new Set(curAnimes.map(a => a.animeId));
+
+    for (let i = 0; i < pipelineTasks.length; i++) {
+      if (pipelineResults[i].status === 'rejected') {
+        log("error", `[system] [searchAnime] 源 ${pipelineTasks[i].key} 管道处理失败: ${pipelineResults[i].reason}`);
+        continue;
+      }
+
+      const { animes: isolatedAnimes, detailStore: isolatedDetailStore } = pipelineTasks[i];
+
+      // 合并动漫结果列表（使用 Set 确保 O(1) 检索，优先源先入为主）
+      for (const anime of isolatedAnimes) {
+        if (!existingAnimeIds.has(anime.animeId)) {
+          curAnimes.push(anime);
+          existingAnimeIds.add(anime.animeId);
+        }
+      }
+
+      // 合并详情缓存（键去重，先到先得）
+      for (const [key, value] of isolatedDetailStore) {
+        if (!requestAnimeDetailsMap.has(key)) {
+          requestAnimeDetailsMap.set(key, value);
+        }
+      }
+    }
 
     // 缓存首季/默认请求结果，剥离附加链接
     if (curAnimes.length > 0) {

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -71,7 +71,7 @@ export default class BahamutSource extends BaseSource {
               "Content-Type": "application/json",
               "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
             },
-			retries: 1,
+			retries: 3,
           });
 
           // 如果原始搜索有结果，中断 TMDB 流程
@@ -136,7 +136,7 @@ export default class BahamutSource extends BaseSource {
               "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
             },
             signal: tmdbAbortController.signal,
-            retries: 1,
+            retries: 3,
           });
 
           if (tmdbResp && tmdbResp.data && tmdbResp.data.anime && tmdbResp.data.anime.length > 0) {
@@ -160,8 +160,13 @@ export default class BahamutSource extends BaseSource {
             log("info", "[Bahamut] 原始搜索成功，中断日语原名搜索");
             return { success: false, source: 'tmdb', aborted: true };
           }
-          // 抛出其他错误（例如 httpGet 超时）
-          throw error;
+          // TMDB搜索失败不阻塞原始搜索结果，与originalSearchPromise保持一致的错误处理策略
+          log("error", "[Bahamut] TMDB搜索失败:", {
+            message: error.message,
+            name: error.name,
+            stack: error.stack,
+          });
+          return { success: false, source: 'tmdb' };
         }
       })();
 
@@ -235,7 +240,7 @@ export default class BahamutSource extends BaseSource {
           "Content-Type": "application/json",
           "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
         },
-		retries: 1,
+		retries: 3,
       });
 
       // 判断 resp 和 resp.data 是否存在
@@ -250,8 +255,11 @@ export default class BahamutSource extends BaseSource {
         return [];
       }
 
-      // 正常情况下输出 JSON 字符串
-      log("info", `[Bahamut] getBahamutEposides: ${JSON.stringify(resp.data.data)}`);
+      // 正常情况下输出调试所需的关键字段，对齐其他源做法避免全量输出 contentHtml 等冗余数据
+      const { video: vData, anime: aData } = resp.data.data;
+      log("info", `[Bahamut] getBahamutEposides: videoSn=${vData.videoSn}, ` +
+        `animeSn=${aData.animeSn}, title=${aData.title}, ` +
+        `totalEpisode=${aData.totalEpisode}, episodes=${JSON.stringify(aData.episodes)}`);
 
       return resp.data.data;
     } catch (error) {
@@ -398,6 +406,8 @@ export default class BahamutSource extends BaseSource {
           episodeCache.set(cacheKey, this.getEpisodes(anime.video_sn));
         }
         const epData = await episodeCache.get(cacheKey);
+        // getEpisodes 网络失败时返回空数组而非对象，必须校验结构有效性
+        if (!epData || typeof epData !== 'object' || Array.isArray(epData)) return null;
         const detail = epData.video;
 
         // episodes 可能在不同键中（如 "0"、"1"），电影类内容尤其常见
@@ -504,7 +514,7 @@ export default class BahamutSource extends BaseSource {
           "Content-Type": "application/json",
           "User-Agent": "Anime/2.29.2 (7N5749MM3F.tw.com.gamer.anime; build:972; iOS 26.0.0) Alamofire/5.6.4",
         },
-        retries: 1,
+        retries: 3,
       });
 
       // 将当前请求的 episodes 拼接到总数组

--- a/danmu_api/sources/kan360.js
+++ b/danmu_api/sources/kan360.js
@@ -26,9 +26,9 @@ export default class Kan360Source extends BaseSource {
         );
 
         const data = await response.data;
-        log("info", `[360kan] 360kan zongyi response: ${JSON.stringify(data)}`);
-
         const episodeList = data.data.list;
+        log("info", `[360kan] 360kan zongyi response: 第${j}页获取到${episodeList ? episodeList.length : 0}条剧集`);
+
         if (!episodeList) {
           break;
         }
@@ -208,13 +208,13 @@ export default class Kan360Source extends BaseSource {
       );
 
       const data = response.data;
-      log("info", `[360kan] 360kan response: ${JSON.stringify(data)}`);
 
       let tmpAnimes = [];
       if ('rows' in data.data.longData) {
         tmpAnimes = data.data.longData.rows;
       }
 
+      log("info", `[360kan] 360kan response: ${JSON.stringify(tmpAnimes)}`);
       log("info", `[360kan] 360kan animes.length: ${tmpAnimes.length}`);
 
       return tmpAnimes;

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -27,20 +27,29 @@ export function toLogSourceName(sourceKey) {
 // =====================
 
 /**
- * 将外部中断信号链接到内部控制器
+ * 将外部中断信号链接到内部控制器，并返回内存清理函数
  * @param {AbortSignal} externalSignal 外部传入的信号
  * @param {AbortController} internalController 内部使用的控制器
+ * @returns {Function} 监听器清理闭包
  */
 function linkSignal(externalSignal, internalController) {
-  if (externalSignal) {
-    if (externalSignal.aborted) {
-      internalController.abort();
-    } else {
-      externalSignal.addEventListener('abort', () => {
-        internalController.abort();
-      }, { once: true });
-    }
+  if (!externalSignal) return () => {};
+
+  if (externalSignal.aborted) {
+    internalController.abort();
+    return () => {};
   }
+
+  const abortHandler = () => {
+    internalController.abort();
+  };
+
+  externalSignal.addEventListener('abort', abortHandler, { once: true });
+
+  // 返回注销函数，供请求结束后的 finally 块调用，阻断内存泄漏链
+  return () => {
+    externalSignal.removeEventListener('abort', abortHandler);
+  };
 }
 
 export async function httpGet(url, options = {}) {
@@ -57,8 +66,13 @@ export async function httpGet(url, options = {}) {
 
     if (attempt > 0) {
       log("info", `[${currentSource}] [请求模拟] 第 ${attempt} 次重试: ${url}`);
-      // 可选：添加重试延迟（指数退避）
-      await new Promise(resolve => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt - 1), 5000)));
+      // 针对网络层物理阻断（如 ETIMEDOUT, ECONNRESET, AbortError）取消长退避，实现快速重试
+      // 常规服务端报错（如 502, 429）保持指数退避逻辑
+      if (lastError && (lastError.cause?.code === 'ETIMEDOUT' || lastError.cause?.code === 'ECONNRESET' || lastError.name === 'AbortError')) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      } else {
+        await new Promise(resolve => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt - 1), 5000)));
+      }
     } else {
       log("info", `[${currentSource}] [请求模拟] HTTP GET: ${url}`);
     }
@@ -68,8 +82,8 @@ export async function httpGet(url, options = {}) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-    // 链接外部中断信号
-    linkSignal(options.signal, controller);
+    // 链接外部中断信号并获取清理函数
+    const cleanupSignal = linkSignal(options.signal, controller);
 
     try {
       // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
@@ -233,6 +247,9 @@ export async function httpGet(url, options = {}) {
         log("info", `[${currentSource}] [请求模拟] 准备重试...`);
         continue;
       }
+    } finally {
+      // 请求生命周期结束，释放监听器内存引用
+      cleanupSignal();
     }
   }
 
@@ -254,8 +271,13 @@ export async function httpPost(url, body, options = {}) {
 
     if (attempt > 0) {
       log("info", `[${currentSource}] [请求模拟] 第 ${attempt} 次重试: ${url}`);
-      // 可选：添加重试延迟（指数退避）
-      await new Promise(resolve => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt - 1), 5000)));
+      // 针对网络层物理阻断（如 ETIMEDOUT, ECONNRESET, AbortError）取消长退避，实现快速重试
+      // 常规服务端报错（如 502, 429）保持指数退避逻辑
+      if (lastError && (lastError.cause?.code === 'ETIMEDOUT' || lastError.cause?.code === 'ECONNRESET' || lastError.name === 'AbortError')) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+      } else {
+        await new Promise(resolve => setTimeout(resolve, Math.min(1000 * Math.pow(2, attempt - 1), 5000)));
+      }
     } else {
       log("info", `[${currentSource}] [请求模拟] HTTP POST: ${url}`);
     }
@@ -265,8 +287,8 @@ export async function httpPost(url, body, options = {}) {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-    // 链接外部中断信号
-    linkSignal(options.signal, controller);
+    // 链接外部中断信号并获取清理函数
+    const cleanupSignal = linkSignal(options.signal, controller);
 
     // 处理请求头、body 和其他参数
     const { headers = {}, params, allow_redirects = true } = options;
@@ -358,6 +380,9 @@ export async function httpPost(url, body, options = {}) {
         log("info", `[${currentSource}] [请求模拟] 准备重试...`);
         continue;
       }
+    } finally {
+      // 请求生命周期结束，释放监听器内存引用
+      cleanupSignal();
     }
   }
 
@@ -647,8 +672,8 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-  // 链接外部中断信号
-  linkSignal(options.signal, controller);
+  // 链接外部中断信号并获取清理函数
+  const cleanupSignal = linkSignal(options.signal, controller);
 
   try {
     const currentSource = sourceLogContext.getStore() || "system";
@@ -748,5 +773,8 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
     }
     log("error", `[${currentSource}] [流式请求] 失败: ${error.message}`);
     return null;
+  } finally {
+    // 流式请求执行完毕或被熔断拦截，释放监听器内存引用
+    cleanupSignal();
   }
 }


### PR DESCRIPTION
上个[PR](https://github.com/huangxd-/danmu_api/pull/339)遇到的反代场景风控报错发现只是频繁测试导致的，实际与变动并无关系草

#331 的进阶，整体请求流程最大效率化形态：详情阶段不再等待搜索阶段的完成，各源请求流程独立。
算实验性（）暂未测试出负面影响，理论负面影响是瞬时网络并发峰值剧增，并发连接数增加。

如果觉得收益没太大必要可以考虑不合，实际提升不算大

将 searchAnime 中的两阶段阻塞模型（Promise.all(search) → executeSourceHandlers） 改为逐源管道模型：每个源形成独立的 search → executeSourceHandlers 流水线， search 完成后通过 {[source]: searchResult} 调用 executeSourceHandlers 处理该源， 不等待其他源完成。

改动说明：
- 构建 sourceSearchMap 存储各源搜索 Promise（搜索并发度不变）
- 每个源的搜索 Promise 通过 .then() 链式调用 executeSourceHandlers
- 传入仅含当前源数据的 {[source]: searchResult}，使 executeSourceHandlers 仅处理该源
- executeSourceHandlers 增加 activeSourceKeys 过滤，仅处理 resultData 中存在数据的源
- 各管道独立维护 isolatedAnimes 和 isolatedDetailStore
- 所有管道通过 Promise.allSettled 并发执行
- 管道完成后按 SOURCE_ORDER 顺序合并结果（animeId 去重、detailStore 键去重）
- resultData 在管道 .then() 回调中填充，供 S2+ 季度扩展逻辑读取
- executeSourceHandlers 函数未做任何修改，源路由逻辑仍由其集中维护

预期收益：
消除阶段壁垒，各源 handleAnimes 不再等待最慢源搜索完成，
可减少约 max(handleAnimes) 的等待时间，同时实现管道级错误隔离

网络层容错增强（http-util.js）：
- 自适应重试退避：网络层物理阻断（ETIMEDOUT / ECONNRESET / AbortError） 采用 100ms 短退避快速重试；服务端业务错误保持原有指数退避逻辑， 在不影响服务端错误安全性的前提下加速 GFW 间歇性阻断场景的恢复
- 修复 linkSignal 事件监听器内存泄漏： finally 块中 removeEventListener 注销监听器，阻断跨请求引用累积

巴哈姆特源容错增强（bahamut.js）：
- HTTP 请求重试次数提升至 3（共 4 次尝试），配合自适应退避提高反代可达率
- tmdbSearchPromise 错误处理与 originalSearchPromise 保持一致： 网络失败返回 {success: false} 而非 throw，避免快速失败吞掉搜索结果
- handleAnimes 增加 epData 结构校验，防止 getEpisodes 返回空数组时 TypeError
- getEpisodes 日志仅输出 videoSn/animeSn/title/totalEpisode/episodes 关键字段， 避免全量输出 contentHtml/relatedGnn 等冗余数据

日志裁剪（kan360.js）：
- zongyi response 日志从全量 API 响应改为输出每页剧集条数
- search response 日志从全量 API 响应改为输出搜索结果数组