### PR TITLE
fix(bilibili): 修复集数倒序问题并规范化HTML实体解码

### DIFF
--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -2,7 +2,7 @@ import BaseSource from './base.js';
 import { globals } from '../configs/globals.js';
 import { log } from "../utils/log-util.js";
 import { httpGet, httpGetWithStreamCheck } from "../utils/http-util.js";
-import { parseDanmakuBase64, md5, convertToAsciiSum } from "../utils/codec-util.js";
+import { parseDanmakuBase64, md5, convertToAsciiSum, decodeHtmlEntities } from "../utils/codec-util.js";
 import { generateValidStartDate } from "../utils/time-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
 import { titleMatches, getExplicitSeasonNumber, extractSeasonNumberFromAnimeTitle } from "../utils/common-util.js";
@@ -197,23 +197,13 @@ export default class BilibiliSource extends BaseSource {
           // 忽略年份解析错误
         }
 
-        // 清理标题
-        const cleanedTitle = (item.title || "")
-          .replace(/<[^>]+>/g, '')  // 移除 HTML 标签
-          .replace(/&[^;]+;/g, match => {  // 解码 HTML 实体
-            const entities = { '&lt;': '<', '&gt;': '>', '&amp;': '&', '&quot;': '"', '&#39;': "'" };
-            return entities[match] || match;
-          })
+        // 清理标题，移除 HTML 标签并解码 HTML 实体
+        const cleanedTitle = decodeHtmlEntities((item.title || "").replace(/<[^>]+>/g, ''))
           .replace(/:/g, '：')
           .trim();
 
-		// 清洗原标题
-        const cleanedOrgTitle = (item.org_title || "")
-          .replace(/<[^>]+>/g, '')
-          .replace(/&[^;]+;/g, match => {
-            const entities = { '&lt;': '<', '&gt;': '>', '&amp;': '&', '&quot;': '"', '&#39;': "'" };
-            return entities[match] || match;
-          })
+        // 清洗原标题，移除 HTML 标签并解码 HTML 实体
+        const cleanedOrgTitle = decodeHtmlEntities((item.org_title || "").replace(/<[^>]+>/g, ''))
           .trim();
 
         const resultItem = {
@@ -684,17 +674,13 @@ export default class BilibiliSource extends BaseSource {
                return {
                  name: realVal,
                  url: linkUrl,
-                 title: `【bilibili1】 ${displayTitle.trim()}`
+                 title: `【bilibili1】 ${displayTitle.trim()}`,
+                 _id: parseInt(epId, 10) || 0
                };
              });
 
-             // 按照提取出的 name (真实集号) 进行升序排列
-             links.sort((a, b) => {
-                  const numA = parseFloat(a.name);
-                  const numB = parseFloat(b.name);
-                  if (!isNaN(numA) && !isNaN(numB)) return numA - numB;
-                  return 0;
-             });
+             // 依据底层数据主键 ep_id 进行时间序列升序排列
+             links.sort((a, b) => a._id - b._id);
 
              log("info", `[Bilibili] 直接使用搜索结果中的 ${links.length} 集分集`);
           } else {
@@ -712,9 +698,13 @@ export default class BilibiliSource extends BaseSource {
                 return {
                     name: `${index + 1}`,
                     url: linkUrl,
-                    title: `【bilibili1】 ${ep.title}`
+                    title: `【bilibili1】 ${ep.title}`,
+                    _id: parseInt(ep.id, 10) || 0
                 };
              });
+
+             // 依据底层数据主键 ep_id 进行时间序列升序排列
+             links.sort((a, b) => a._id - b._id);
           }
 
           if (links.length === 0) return;
@@ -1198,8 +1188,8 @@ export default class BilibiliSource extends BaseSource {
                     .map(i => ({
                         provider: "bilibili",
                         mediaId: i.season_id ? `ss${i.season_id}` : (i.uri.match(/season\/(\d+)/)?.[1] ? `ss${i.uri.match(/season\/(\d+)/)[1]}` : ""),
-                        title: (i.title||"").replace(/<[^>]+>/g,'').trim(),
-                        org_title: (i.org_title||"").replace(/<[^>]+>/g,'').trim(),
+                        title: decodeHtmlEntities((i.title||"").replace(/<[^>]+>/g,'')).trim(),
+                        org_title: decodeHtmlEntities((i.org_title||"").replace(/<[^>]+>/g,'')).trim(),
                         type: this._extractMediaType(i.season_type_name),
                         year: i.ptime ? new Date(i.ptime*1000).getFullYear() : null,
                         imageUrl: i.cover||i.pic||"",
@@ -1243,11 +1233,11 @@ export default class BilibiliSource extends BaseSource {
                 provider: "bilibili", 
                 mediaId: i.season_id ? `ss${i.season_id}` : "", 
                 mdId: i.media_id ? `md${i.media_id}` : null,
-                title: (i.title||"").replace(/<[^>]+>/g,'').trim(),
-                org_title: (i.org_title || "").replace(/<[^>]+>/g,'').replace(/&[^;]+;/g, match => { const entities = { '&lt;': '<', '&gt;': '>', '&amp;': '&', '&quot;': '"', '&#39;': "'" }; return entities[match] || match; }).trim(),
+                title: decodeHtmlEntities((i.title||"").replace(/<[^>]+>/g,'')).trim(),
+                org_title: decodeHtmlEntities((i.org_title || "").replace(/<[^>]+>/g,'')).trim(),
                 type: this._extractMediaType(i.season_type_name),
-				year: i.pubtime?new Date(i.pubtime*1000).getFullYear():null,
-				imageUrl: i.cover||null,
+                year: i.pubtime?new Date(i.pubtime*1000).getFullYear():null,
+                imageUrl: i.cover||null,
                 episodeCount: i.ep_size||0,
 				_eps: i.eps,
 				isOversea: true

--- a/danmu_api/utils/codec-util.js
+++ b/danmu_api/utils/codec-util.js
@@ -744,8 +744,15 @@ function fromCodePoint(codePoint) {
    * @returns {string} 转换后的字符串
    */
 export function decodeHtmlEntities(str) {
+  if (!str) return str;
+  const namedEntities = { '&lt;': '<', '&gt;': '>', '&amp;': '&', '&quot;': '"', '&apos;': "'" };
+
+  // 处理命名HTML实体
+  return str.replace(/&[a-zA-Z]+;/g, match => {
+    return namedEntities[match] || match;
+  })
   // 处理十进制HTML实体 &#12345;
-  return str.replace(/&#(\d+);/g, (match, num) => {
+  .replace(/&#(\d+);/g, (match, num) => {
     return fromCodePoint(parseInt(num, 10));
   })
   // 处理十六进制HTML实体 &#x123A;


### PR DESCRIPTION
- 修复：将集数排序基准从易受干扰的标题文本切换为B站底层数据主键(ep.id/cid)，进行绝对数值升序排列，彻底解决因不规则标题(如精华版)破坏排序算法导致的集数倒序问题。
- 重构：移除各处零散的内联HTML实体解码字典，将命名实体解码逻辑统一收敛下沉至公共工具类 `codec-util.js`，提升代码规范度与复用性。