### PR TITLE
feat(renren): 搜索接口收集 original_name 到别名列表

### DIFF
--- a/danmu_api/sources/renren.js
+++ b/danmu_api/sources/renren.js
@@ -398,8 +398,16 @@ export default class RenrenSource extends BaseSource {
 
       return list.map((item) => {
         let aliases = [];
-        if (item.highlights && item.highlights.alias) {
-          aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+        if (item.highlights) {
+          if (item.highlights.alias) {
+            aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+          }
+          if (item.highlights.original_name) {
+            const originalName = item.highlights.original_name.replace(/<[^>]+>/g, "").trim();
+            if (originalName && !aliases.includes(originalName)) {
+              aliases.push(originalName);
+            }
+          }
         }
         return {
           provider: "renren",
@@ -442,8 +450,16 @@ export default class RenrenSource extends BaseSource {
 
       return list.map(item => {
         let aliases = [];
-        if (item.highlights && item.highlights.alias) {
-          aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+        if (item.highlights) {
+          if (item.highlights.alias) {
+            aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+          }
+          if (item.highlights.original_name) {
+            const originalName = item.highlights.original_name.replace(/<[^>]+>/g, "").trim();
+            if (originalName && !aliases.includes(originalName)) {
+              aliases.push(originalName);
+            }
+          }
         }
         return {
           provider: "renren",
@@ -492,8 +508,16 @@ export default class RenrenSource extends BaseSource {
       // 数据模型装载器
       const processItem = (item) => {
         let aliases = [];
-        if (item.highlights && item.highlights.alias) {
-          aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+        if (item.highlights) {
+          if (item.highlights.alias) {
+            aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+          }
+          if (item.highlights.original_name) {
+            const originalName = item.highlights.original_name.replace(/<[^>]+>/g, "").trim();
+            if (originalName && !aliases.includes(originalName)) {
+              aliases.push(originalName);
+            }
+          }
         }
         return {
           provider: "renren",
@@ -565,8 +589,16 @@ export default class RenrenSource extends BaseSource {
 
       return list.map((item) => {
         let aliases = [];
-        if (item.highlights && item.highlights.alias) {
-          aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+        if (item.highlights) {
+          if (item.highlights.alias) {
+            aliases = item.highlights.alias.split(',').map(s => s.trim().replace(/<[^>]+>/g, "")).filter(Boolean);
+          }
+          if (item.highlights.original_name) {
+            const originalName = item.highlights.original_name.replace(/<[^>]+>/g, "").trim();
+            if (originalName && !aliases.includes(originalName)) {
+              aliases.push(originalName);
+            }
+          }
         }
         return {
           provider: "renren",


### PR DESCRIPTION
将各端搜索接口的 highlights 字段采集统一到同一条件块内，
alias 与 original_name 作为 highlights 的同级子字段处理。
original_name 去除 HTML 标签后加入别名列表，
解决搜索原名无法匹配的问题。
original_name 可能为空或 null，与 alias 处理一致。