### PR TITLE
fix: searchCache/commentCache 写入时清扫过期条目并限制大小上限

### DIFF
--- a/danmu_api/configs/globals.js
+++ b/danmu_api/configs/globals.js
@@ -152,12 +152,14 @@ export const Globals = {
    */
   /**
    * 获取全局配置对象（单例，可修改）
+   * 使用 Proxy 保持接口兼容性，实例懒初始化后缓存复用避免每次新建
    * @returns {Object} 全局配置对象本身
    */
   getConfig() {
-    // 使用 Proxy 保持接口兼容性
+    if (this._configProxy) return this._configProxy;
+
     const self = this;
-    return new Proxy({}, {
+    this._configProxy = new Proxy({}, {
       get(target, prop) {
         // 优先返回 envs 中的属性（保持原有的平铺效果）
         if (prop in self.envs) {
@@ -186,6 +188,8 @@ export const Globals = {
         return true;
       }
     });
+
+    return this._configProxy;
   },
 };
 

--- a/danmu_api/utils/cache-util.js
+++ b/danmu_api/utils/cache-util.js
@@ -104,6 +104,25 @@ function getActiveSearchCacheEntries() {
     return activeEntries;
 }
 
+// 清除 Map 中所有已超过 TTL 的过期条目
+// 使用 Map 自身的迭代器遍历并删除，不依赖 getActiveSearchCacheEntries 的返回值
+function sweepExpiredCache(cacheMap, cacheMinutes, cacheName) {
+    const now = Date.now();
+    let sweptCount = 0;
+
+    for (const [key, entry] of cacheMap.entries()) {
+        const ageMinutes = (now - entry.timestamp) / (1000 * 60);
+        if (ageMinutes > cacheMinutes) {
+            cacheMap.delete(key);
+            sweptCount++;
+        }
+    }
+
+    if (sweptCount > 0) {
+        log("info", `[Cache] ${cacheName} TTL 扫描完毕，已移除 ${sweptCount} 个过期条目，剩余 ${cacheMap.size} 个`);
+    }
+}
+
 function matchesAnimeId(anime, idStr) {
     return String(anime?.animeId) === idStr || String(anime?.bangumiId) === idStr;
 }
@@ -279,11 +298,21 @@ export function getSearchCache(keyword, detailsMap = null) {
 export function setSearchCache(keyword, results, detailsMap = null) {
     const details = collectUniqueAnimeDetails(detailsMap);
 
+    // 写入前先清理所有过期条目
+    sweepExpiredCache(globals.searchCache, globals.searchCacheMinutes, 'searchCache');
+
     globals.searchCache.set(keyword, {
         results: results,
         details: details,
         timestamp: Date.now()
     });
+
+    // TTL 清理后仍未降回上限，则按插入顺序移除最早条目作为安全兜底
+    if (globals.searchCache.size > 500) {
+        const oldestKey = globals.searchCache.keys().next().value;
+        globals.searchCache.delete(oldestKey);
+        log("info", `[Cache] searchCache TTL清理后仍达上限，已移除最早条目: ${oldestKey}`);
+    }
 
     log("info", `[Cache] Cached search results for "${keyword}" (${results.length} animes)`);
 }
@@ -319,10 +348,20 @@ export function getCommentCache(videoUrl) {
 
 // 设置弹幕缓存
 export function setCommentCache(videoUrl, comments) {
+    // 写入前先清理所有过期条目
+    sweepExpiredCache(globals.commentCache, globals.commentCacheMinutes, 'commentCache');
+
     globals.commentCache.set(videoUrl, {
         comments: comments,
         timestamp: Date.now()
     });
+
+    // TTL 清理后仍未降回上限，则按插入顺序移除最早条目作为安全兜底
+    if (globals.commentCache.size > 500) {
+        const oldestKey = globals.commentCache.keys().next().value;
+        globals.commentCache.delete(oldestKey);
+        log("info", `[Cache] commentCache TTL清理后仍达上限，已移除最早条目: ${oldestKey}`);
+    }
 
     log("info", `[Cache] Cached comments for "${videoUrl}" (${comments.length} comments)`);
 }

--- a/danmu_api/utils/cookie-util.js
+++ b/danmu_api/utils/cookie-util.js
@@ -327,9 +327,10 @@ function extractLoginCookieFromResponse(response) {
  * 检查二维码扫描状态
  */
 export async function handleQRCheck(request) {
+  let qrcodeKey = null;
   try {
     const body = await request.json();
-    const qrcodeKey = body.qrcodeKey || body.qrcode_key;
+    qrcodeKey = body.qrcodeKey || body.qrcode_key;
 
     if (!qrcodeKey) {
       return jsonResponse({ success: false, message: '缺少qrcodeKey参数' }, 400);
@@ -389,6 +390,11 @@ export async function handleQRCheck(request) {
     return jsonResponse(result);
   } catch (error) {
     return jsonResponse({ success: false, message: error.message }, 500);
+  } finally {
+    // 检查完成后清理会话记录，防止长期运行后内存累积
+    if (qrcodeKey) {
+      qrLoginSessions.delete(qrcodeKey);
+    }
   }
 }
 


### PR DESCRIPTION
## 问题

### 1. `searchCache` / `commentCache` 无主动过期清理且无大小上限

旧版中两个 Map 的过期清理均为被动触发：

- `searchCache`：仅在 `isSearchCacheValid()`（读取时按单 key 检查）或 `getActiveSearchCacheEntries()`（被 `resolveAnimeById` / `resolveEpisodeContextById` 间接调用时扫描全表）中清理。未被读取的过期条目会一直残留在内存中。
- `commentCache`：仅有 `isCommentCacheValid()` 的单 key 惰性检查，无任何全表扫描机制。写完后再无人请求的 URL 对应的弹幕数据永远不会被清除。

在 Docker 长期运行的 Node.js 进程中，这意味着：
- 每被搜索过一次的关键词，其结果永久滞留（直到偶发的 `resolveAnimeById` 扫描）
- 每被请求过弹幕的视频 URL，其弹幕数组永久滞留（没有任何主动清扫路径）

当 `SEARCH_CACHE_MINUTES` / `COMMENT_CACHE_MINUTES` 设为默认的 3 分钟时，过期条目残留不释放；设为 0 时，两个 Map 更是完全无清理。以 `commentCache` 为例，热门番剧一集弹幕可达 2.5 MB，2000 个 URL 全部堆积即占用约 5 GB。

### 2. `Globals.getConfig()` 每次调用新建 Proxy

`globals.someProperty` 的每次属性访问（读/写/has/ownKeys/getOwnPropertyDescriptor 5 个 trap）都会触发 `new Proxy({}, {...})`，该 Proxy 对象在本次访问结束后立即成为垃圾。高并发下产生大量短命对象，增加 GC 频率。

### 3. `qrLoginSessions` 无清理

`handleQRGenerate` 在生成二维码时写入会话记录，但 `handleQRCheck` 检查完成后未删除。长期运行的进程会累积所有扫码会话。

---

## 修复

### cache-util.js

- 新增 `sweepExpiredCache(cacheMap, cacheMinutes, cacheName)` 通用函数：遍历 Map 全表，删除 `(Date.now() - timestamp) > TTL` 的过期条目
- `setSearchCache` 写入前调用 `sweepExpiredCache` 清扫过期条目，写入后检查 `size > 500` 则以 FIFO 移除最早条目（TTL 清扫后的安全兜底）
- `setCommentCache` 同样处理，上限 500

写入前的 TTL 清扫直接对齐用户配置的 `SEARCH_CACHE_MINUTES` / `COMMENT_CACHE_MINUTES`，正常情况下 TTL 合理时缓存自然保持小巧，上限仅在 TTL 过长或设为 0 时作为安全兜底生效。

### globals.js

- `getConfig()` 首次调用时将 Proxy 实例存储到 `this._configProxy`，后续调用直接返回缓存实例
- 缓存 Proxy 的 `get` 陷阱通过 `self.envs[prop]` 动态读取，`reInit` 重载 envs 后无需额外处理

### cookie-util.js

- `handleQRCheck` 增加 `finally` 块，检查完成后删除 `qrLoginSessions` 对应条目
- 将 `qrcodeKey` 从 `const` 改为函数级 `let`，使 `finally` 可正确访问

---

## 改动范围

| 文件 | 新增 | 删除 |
|------|------|------|
| `danmu_api/utils/cache-util.js` | +39 | 0 |
| `danmu_api/configs/globals.js` | +8 | -2 |
| `danmu_api/utils/cookie-util.js` | +7 | -1 |
