### PR TITLE
fix(offset): 记住选择偏移基准从 lastSearch.episode 改为当前剧集实际集数

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -2090,8 +2090,11 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
       if (lastSearch && lastSearch.title && lastSearch.season && lastSearch.episode && episodeTitle) {
         lastTitle = lastSearch.title;
         lastSeason = lastSearch.season;
-        offset = `${lastSearch.episode}:${episodeTitle}`;
-        log("info", `[system] [LogVar-API] Calculated episode offset for IP ${clientIp}: Query E${lastSearch.episode}, Selected ${episodeTitle} -> Offset ${offset} (Season ${lastSeason})`);
+        // 从当前观看的剧集标题提取真实集数，避免 lastSearch.episode 因手动选择而过期
+        const currentEpisode = extractEpisodeNumberFromTitle(episodeTitle);
+        const baseEpisode = currentEpisode !== null ? currentEpisode : lastSearch.episode;
+        offset = `${baseEpisode}:${episodeTitle}`;
+        log("info", `[system] [LogVar-API] Calculated episode offset for IP ${clientIp}: Query E${lastSearch.episode}, Current E${baseEpisode}, Selected ${episodeTitle} -> Offset ${offset} (Season ${lastSeason})`);
       }
     }
 


### PR DESCRIPTION
## 问题

match S2E12 返回 bilibili1 的结果，用户手动从搜索结果选择 renren S2E12（同一集，只换源）。之后 match S2E17 时虽然选中了 renren，但命中了第 20 集而非第 17 集。

## 根因

`getComment` 中写入偏移时，集数基准取自 `lastSearch.episode`：

```js
offset = `${lastSearch.episode}:${episodeTitle}`;
```

但 `lastSearch` 仅在 `matchAnime` 时更新。用户从搜索列表手动选择不会触发更新，`lastSearch.episode` 保留的是上一次 match 的值。

例如上次 match 的是 S2E9，用户手动选 S2E12（同一集换源）：

- offset 错误记录为 `"9:E12"`
- 后续 match S2E17 时 `computeTargetEpisode` 算出 `targetEpisode = 20`

计算过程：`offsetEpisode=9, offset=8, offsetIndex=11, target=11+8+1=20`

## 历史追溯

这一漏洞的形成经历了多次提交演变：

**PR #231** (c5b7221) — 引入「记住集偏移」功能。设计意图：当源的集编号与文件命名不一致时（如源 SP01 对应文件 E22），让系统记住映射关系，下次自动 match 时修正。

**PR #255** (df96965) — 修复快速切集时的竞态问题。给 `getComment` 增加了防护：

```js
if (lastSearch && lastSearch.episodeId === commentId && ...)
```

确保只有 lastSearch 的 episodeId 与当前正在请求弹幕的 commentId 一致时，才写入偏移。

**`871db79`** — "优化自动匹配和记住集episode偏移功能"。**删除了 `episodeId === commentId` 校验**，意图是允许跨集场景记录偏移，但同时去掉了陈旧值防护。

**PR #340** (dc41b91) — 给 `getComment` 增加了别名匹配 (`animeAliases`)，使更多剧集通过标题校验触发偏移写入，将漏洞暴露面扩大。

## 修复

偏移基准由 `lastSearch.episode` 改为从当前观看剧集的标题提取实际集数：

```js
const currentEpisode = extractEpisodeNumberFromTitle(episodeTitle);
const baseEpisode = currentEpisode !== null ? currentEpisode : lastSearch.episode;
offset = `${baseEpisode}:${episodeTitle}`;
```

效果：

- 用户选同一集不同源 → baseEpisode 从标题提取为 12，offset 为 0 → 只更新源偏好，不产生错误偏移
- 用户选不同集（源编号 ≠ 文件编号） → baseEpisode 为源的实际编号 → 偏移正确记录
- 标题提取失败 → 退回到 `lastSearch.episode`，向后兼容

## 改动

- `danmu_api/apis/dandan-api.js` — `getComment` 偏移计算逻辑
- 1 file changed, 5 insertions(+), 2 deletions(-)
