### PR TITLE
fix(bilibili): 搜索结果分集优先按 index_title 排序，无法提取时退回 ep_id

### DIFF
--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -5,7 +5,7 @@ import { httpGet, httpGetWithStreamCheck } from "../utils/http-util.js";
 import { parseDanmakuBase64, md5, convertToAsciiSum, decodeHtmlEntities } from "../utils/codec-util.js";
 import { generateValidStartDate } from "../utils/time-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
-import { titleMatches, getExplicitSeasonNumber, extractSeasonNumberFromAnimeTitle } from "../utils/common-util.js";
+import { titleMatches, getExplicitSeasonNumber, extractSeasonNumberFromAnimeTitle, extractEpisodeNumberFromTitle } from "../utils/common-util.js";
 import { SegmentListResponse } from '../models/dandan-model.js';
 import { simplized } from "../utils/zh-util.js";
 import { getTmdbJaOriginalTitle, smartTitleReplace } from "../utils/tmdb-util.js";
@@ -679,8 +679,14 @@ export default class BilibiliSource extends BaseSource {
                };
              });
 
-             // 依据底层数据主键 ep_id 进行时间序列升序排列
-             links.sort((a, b) => a._id - b._id);
+             // 优先从 index_title 提取集号排序，任一无法提取则退回到 ep_id 排序
+             const sortKeys = links.map(l => extractEpisodeNumberFromTitle(l.name));
+             if (sortKeys.every(k => k !== null)) {
+               links.forEach((l, i) => l._sortKey = sortKeys[i]);
+               links.sort((a, b) => a._sortKey - b._sortKey);
+             } else {
+               links.sort((a, b) => a._id - b._id);
+             }
 
              log("info", `[Bilibili] 直接使用搜索结果中的 ${links.length} 集分集`);
           } else {


### PR DESCRIPTION
部分番剧的 ep_id 为倒序排列，导致集号错乱。
改为优先从 index_title 提取集号升序排列，
任一集无法提取时整组退回 ep_id 排序。

同时解决
《游戏人生》id非规范导致倒序
《爱唱歌的大学生》集标题混乱导致倒叙

Related to #351 