### PR TITLE
fix(animeko): 更新内置镜像站域名

### DIFF
--- a/danmu_api/sources/animeko.js
+++ b/danmu_api/sources/animeko.js
@@ -82,7 +82,7 @@ export default class AnimekoSource extends BaseSource {
    */
   _getSubjectServerPriority() {
     const officialBase = "https://api.bgm.tv";
-    const mirrorBase = "https://api.bangumi.one";
+    const mirrorBase = "https://api.bangumi.lol";
     // 获取可能被代理的官方 URL
     const proxyOfficialBase = this._applyProxyForSearch(officialBase);
 
@@ -351,7 +351,7 @@ export default class AnimekoSource extends BaseSource {
       while (true) {
         const searchPath = `/v0/search/subjects?limit=${limit}&offset=${offset}`;
         const officialUrl = `https://api.bgm.tv${searchPath}`;
-        const mirrorUrl = `https://api.bangumi.one${searchPath}`;
+        const mirrorUrl = `https://api.bangumi.lol${searchPath}`;
         
         // 获取可能被代理的官方 URL
         const proxySearchUrl = this._applyProxyForSearch(officialUrl);


### PR DESCRIPTION
原镜像站域名遭遇 TLS 阻断导致请求失败，更换为新域名。
bangumi.one → bangumi.lol
详见：https://bgm.tv/group/topic/462456