### PR TITLE
fix(match): improve release filename episode matching

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -854,8 +854,8 @@ function extractPlatformFromTitle(title) {
     return match ? match[1] : null;
 }
 
-// 根据集数匹配episode（优先使用集标题中的集数，其次使用episodeNumber，最后使用数组索引）
-function findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, platform = null) {
+// 根据集数匹配episode（优先使用结构化episodeNumber，其次使用集标题中的集数，最后使用数组索引）
+export function findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, platform = null) {
   if (!filteredEpisodes || filteredEpisodes.length === 0) {
     return null;
   }
@@ -873,31 +873,41 @@ function findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, platform 
   if (platformEpisodes.length === 0) {
     return null;
   }
+
+  const target = parseInt(targetEpisode, 10);
+  let hasStructuredEpisodeNumber = false;
+  let hasTitleEpisodeNumber = false;
   
-  // 策略1：从集标题中提取集数进行匹配
+  // 策略1：使用episodeNumber字段匹配
+  for (const ep of platformEpisodes) {
+    if (ep.episodeNumber !== undefined && ep.episodeNumber !== null && ep.episodeNumber !== '') {
+      hasStructuredEpisodeNumber = true;
+      if (parseInt(ep.episodeNumber, 10) === target) {
+        log("info", `Found episode by episodeNumber: ${ep.episodeTitle} (episodeNumber: ${ep.episodeNumber})`);
+        return ep;
+      }
+    }
+  }
+
+  // 策略2：从集标题中提取集数进行匹配
   for (const ep of platformEpisodes) {
     const extractedNumber = extractEpisodeNumberFromTitle(ep.episodeTitle);
-    if (episode === targetEpisode && extractedNumber === targetEpisode) {
+    if (extractedNumber !== null) {
+      hasTitleEpisodeNumber = true;
+    }
+    if (extractedNumber === target) {
       log("info", `Found episode by title number: ${ep.episodeTitle} (extracted: ${extractedNumber})`);
       return ep;
     }
   }
 
-  // 策略2：使用数组索引
-  if (platformEpisodes.length >= targetEpisode) {
-    const fallbackEp = platformEpisodes[targetEpisode - 1];
+  // 策略3：仅在没有任何结构化集数时使用数组索引兜底
+  if (!hasStructuredEpisodeNumber && !hasTitleEpisodeNumber && platformEpisodes.length >= target) {
+    const fallbackEp = platformEpisodes[target - 1];
     log("info", `Using fallback array index for episode ${targetEpisode}: ${fallbackEp.episodeTitle}`);
     return fallbackEp;
   }
-  
-  // 策略3：使用episodeNumber字段匹配
-  for (const ep of platformEpisodes) {
-    if (ep.episodeNumber && parseInt(ep.episodeNumber, 10) === targetEpisode) {
-      log("info", `Found episode by episodeNumber: ${ep.episodeTitle} (episodeNumber: ${ep.episodeNumber})`);
-      return ep;
-    }
-  }
-  
+
   return null;
 }
 
@@ -1390,6 +1400,47 @@ async function fallbackMatchAniAndEp(searchData, req, season, episode, year, tit
   return {resEpisode, resAnime, isSpillover};
 }
 
+function cleanReleaseTitle(title) {
+  return String(title || '')
+    .replace(/^(?:\[[^\]]+\]\s*)+/, '')
+    .replace(/[._]+/g, ' ')
+    .replace(/\s*[\[(（]?(?:19|20)\d{2}[\])）]?\s*$/i, '')
+    .replace(/[-_\s.]+$/g, '')
+    .trim();
+}
+
+function parseReleaseEpisodeName(cleanFileName) {
+  const noExt = String(cleanFileName || '')
+    .trim()
+    .replace(/\.(?:mkv|mp4|avi|mov|wmv|flv|webm|ts|m2ts)$/i, '');
+
+  const yearMatch = noExt.match(/(?:\.|\s|\(|（)((?:19|20)\d{2})(?:\)|）|\.|\s|$)/);
+  const patterns = [
+    /^(.+?)\s*-\s*(\d{1,3})(?:v\d+)?(?=\s*(?:$|[\[(（]))/i,
+    /^(.+?)\s*\[(\d{1,3})(?:v\d+)?\](?=\s*(?:$|\[))/i,
+    /^(.+?)\s+第\s*(\d{1,3})\s*[集话話]/,
+    /^(.+?)\s+(?:[Ee][Pp]?|#)\s*(\d{1,3})(?:v\d+)?(?=\s*(?:$|[\[(（]))/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = noExt.match(pattern);
+    if (!match) continue;
+
+    const title = cleanReleaseTitle(match[1]);
+    const episode = parseInt(match[2], 10);
+    if (!title || Number.isNaN(episode)) continue;
+
+    return {
+      title,
+      season: 1,
+      episode,
+      year: yearMatch ? parseInt(yearMatch[1], 10) : undefined,
+    };
+  }
+
+  return null;
+}
+
 export async function extractTitleSeasonEpisode(cleanFileName) {
   const regex = /^(.+?)[.\s]+S(\d+)E(\d+)/i;
   const match = cleanFileName.match(regex);
@@ -1439,7 +1490,12 @@ export async function extractTitleSeasonEpisode(cleanFileName) {
 
     // 最后再保险清理一次常见的年份尾巴（防止漏网）
     title = title.replace(/\.\d{4}$/i, '').trim();
+    title = cleanReleaseTitle(title);
   } else {
+    const releaseMatch = parseReleaseEpisodeName(cleanFileName);
+    if (releaseMatch) {
+      ({ title, season, episode, year } = releaseMatch);
+    } else {
     // 没有 S##E## 格式，尝试提取第一个片段作为标题
     // 匹配第一个中文/英文标题部分（在年份、分辨率等技术信息之前）
     const titleRegex = /^([^.\s]+(?:[.\s][^.\s]+)*?)(?:[.\s](?:\d{4}|(?:19|20)\d{2}|\d{3,4}p|S\d+|E\d+|WEB|BluRay|Blu-ray|HDTV|DVDRip|BDRip|x264|x265|H\.?264|H\.?265|AAC|AC3|DDP|TrueHD|DTS|10bit|HDR|60FPS))/i;
@@ -1453,6 +1509,7 @@ export async function extractTitleSeasonEpisode(cleanFileName) {
     const yearMatch = cleanFileName.match(/(?:\.|\(|（)((?:19|20)\d{2})(?:\)|）|\.|$)/);
     if (yearMatch) {
       year = parseInt(yearMatch[1], 10);
+    }
     }
   }
 

--- a/danmu_api/match-rule.test.js
+++ b/danmu_api/match-rule.test.js
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { extractTitleSeasonEpisode, findEpisodeByNumber } from './apis/dandan-api.js';
+import { extractEpisodeNumberFromTitle } from './utils/common-util.js';
+
+test('extractTitleSeasonEpisode parses common release episode names', async () => {
+  let parsed = await extractTitleSeasonEpisode('[ANi] 葬送的芙莉莲 - 10 [1080P][Baha][WEB-DL][AAC AVC][CHT].mkv');
+  assert.equal(parsed.title, '葬送的芙莉莲');
+  assert.equal(parsed.season, 1);
+  assert.equal(parsed.episode, 10);
+
+  parsed = await extractTitleSeasonEpisode('葬送的芙莉莲 [10][1080p].mkv');
+  assert.equal(parsed.title, '葬送的芙莉莲');
+  assert.equal(parsed.season, 1);
+  assert.equal(parsed.episode, 10);
+
+  parsed = await extractTitleSeasonEpisode('Kusuriya no Hitorigoto - 10 [1080p].mkv');
+  assert.equal(parsed.title, 'Kusuriya no Hitorigoto');
+  assert.equal(parsed.season, 1);
+  assert.equal(parsed.episode, 10);
+
+  parsed = await extractTitleSeasonEpisode('Title 第01話.mkv');
+  assert.equal(parsed.title, 'Title');
+  assert.equal(parsed.season, 1);
+  assert.equal(parsed.episode, 1);
+});
+
+test('extractTitleSeasonEpisode keeps existing SxxEyy parsing', async () => {
+  assert.deepEqual(
+    await extractTitleSeasonEpisode('爱情公寓.ipartment.2009.S02E08.H.265.25fps.mkv'),
+    { title: '爱情公寓', season: 2, episode: 8, year: 2009 }
+  );
+
+  const parsed = await extractTitleSeasonEpisode('[Lilith-Raws] Kusuriya.no.Hitorigoto.S01E04.1080p.WEB-DL.mkv');
+  assert.equal(parsed.title, 'Kusuriya no Hitorigoto');
+  assert.equal(parsed.season, 1);
+  assert.equal(parsed.episode, 4);
+});
+
+test('extractEpisodeNumberFromTitle supports hua and release suffixes', () => {
+  assert.equal(extractEpisodeNumberFromTitle('第01話'), 1);
+  assert.equal(extractEpisodeNumberFromTitle('[bilibili] 第10话'), 10);
+  assert.equal(extractEpisodeNumberFromTitle('#03'), 3);
+  assert.equal(extractEpisodeNumberFromTitle('01v2'), 1);
+});
+
+test('findEpisodeByNumber prefers structured episodeNumber over array index', () => {
+  const episodes = [
+    { episodeTitle: 'OP', episodeNumber: '1' },
+    { episodeTitle: '番外', episodeNumber: '99' },
+    { episodeTitle: '正片', episodeNumber: '2' },
+  ];
+
+  assert.equal(findEpisodeByNumber(episodes, 2, 2), episodes[2]);
+});
+
+test('findEpisodeByNumber avoids index fallback when structured numbers disagree', () => {
+  const episodes = [
+    { episodeTitle: '正片', episodeNumber: '1' },
+    { episodeTitle: '番外', episodeNumber: '99' },
+  ];
+
+  assert.equal(findEpisodeByNumber(episodes, 2, 2), null);
+});
+
+test('findEpisodeByNumber still uses index fallback for unnumbered lists', () => {
+  const episodes = [
+    { episodeTitle: '上' },
+    { episodeTitle: '下' },
+  ];
+
+  assert.equal(findEpisodeByNumber(episodes, 2, 2), episodes[1]);
+});

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -396,24 +396,24 @@ export function extractSeasonNumberFromAnimeTitle(animeTitle) {
   return { season: null, baseTitle: titleWithoutYear };
 }
 
-// 从集标题中提取集数（支持多种格式：第1集、第01集、EP01、E01等）
+// 从集标题中提取集数（支持多种格式：第1集、第01话、EP01、E01等）
 export function extractEpisodeNumberFromTitle(episodeTitle) {
   if (!episodeTitle) return null;
 
-  // 匹配格式：第1集、第01集、第10集等
-  const chineseMatch = episodeTitle.match(/第(\d+)集/);
+  // 匹配格式：第1集、第01话、第10話等
+  const chineseMatch = episodeTitle.match(/第\s*(\d+)\s*[集话話]/);
   if (chineseMatch) {
     return parseInt(chineseMatch[1], 10);
   }
 
-  // 匹配格式：EP01、EP1、E01、E1等
-  const epMatch = episodeTitle.match(/[Ee][Pp]?(\d+)/);
+  // 匹配格式：EP01、EP1、E01、E1、#01等
+  const epMatch = episodeTitle.match(/(?:[Ee][Pp]?|#)\s*(\d+)/);
   if (epMatch) {
     return parseInt(epMatch[1], 10);
   }
 
-  // 匹配格式：01、1（纯数字，通常在标题开头或结尾）
-  const numberMatch = episodeTitle.match(/(?:^|\s)(\d+)(?:\s|$)/);
+  // 匹配格式：01、01v2、Title - 01（纯数字，通常在标题开头或结尾）
+  const numberMatch = episodeTitle.match(/(?:^|[\s\-_])(\d+)(?:v\d+)?(?:\s|$)/i);
   if (numberMatch) {
     return parseInt(numberMatch[1], 10);
   }


### PR DESCRIPTION
## Summary

- prefer structured `episodeNumber` before array-index fallback when selecting episodes
- parse common release filenames such as `[Group] Title - 10 [1080p]`, `Title [10]`, and `第01話`
- add focused node tests for release parsing and guarded episode fallback behavior

## Why

The previous fallback order could select by array position before checking structured episode numbers. That makes mixed episode lists, extras, or filtered lists easier to mis-match. Release-style filenames also often failed before source search because title and episode were not cleaned consistently.

## Validation

- `node --test danmu_api/match-rule.test.js`
- `node --test danmu_api/worker.test.js`
- `git diff --check`
- staged secret-marker scan