### PR TITLE
fix(server): prevent SSRF in proxy server (CWE-918)

### DIFF
--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -5,6 +5,8 @@ import { fileURLToPath } from 'url';
 import http from 'http';
 import https from 'https';
 import zlib from 'zlib';
+import dns from 'dns';
+import net from 'net';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import dotenv from 'dotenv';
 import { Request as NodeFetchRequest } from 'node-fetch';
@@ -364,11 +366,125 @@ function createServer() {
 }
 
 /**
+ * 判断给定 IP 字符串是否属于不允许通过本地代理转发的内网/保留范围 (SSRF 防护)。
+ * 覆盖：环回、链路本地、RFC1918、CGNAT、广播/多播、未指定地址，以及对应的 IPv6 范围
+ * (含 IPv4 映射 ::ffff:0:0/96 与 IPv4 兼容 ::/96)。
+ * @param {string} ip 已解析的 IP 字符串 (IPv4 或 IPv6)
+ * @returns {boolean}
+ */
+function isDisallowedProxyTargetIp(ip) {
+  if (!ip || typeof ip !== 'string') return true;
+  const family = net.isIP(ip);
+  if (family === 0) return true;
+
+  if (family === 4) {
+    const parts = ip.split('.').map(Number);
+    if (parts.length !== 4 || parts.some(p => !Number.isInteger(p) || p < 0 || p > 255)) return true;
+    const [a, b] = parts;
+    if (a === 0) return true;                               // 0.0.0.0/8 (含未指定地址)
+    if (a === 10) return true;                              // 10.0.0.0/8
+    if (a === 127) return true;                             // 127.0.0.0/8 环回
+    if (a === 169 && b === 254) return true;               // 169.254.0.0/16 链路本地 (含 cloud metadata 169.254.169.254)
+    if (a === 172 && b >= 16 && b <= 31) return true;      // 172.16.0.0/12
+    if (a === 192 && b === 168) return true;                // 192.168.0.0/16
+    if (a === 100 && b >= 64 && b <= 127) return true;     // 100.64.0.0/10 CGNAT
+    if (a === 192 && b === 0 && parts[2] === 0) return true; // 192.0.0.0/24 IETF 协议保留
+    if (a === 198 && (b === 18 || b === 19)) return true;  // 198.18.0.0/15 基准测试
+    if (a >= 224 && a <= 239) return true;                 // 224.0.0.0/4 多播
+    if (a >= 240) return true;                             // 240.0.0.0/4 保留 + 255.255.255.255 广播
+    return false;
+  }
+
+  // IPv6 - 先做范围规则；再处理 IPv4 映射/兼容并复用上面的判定
+  const lower = ip.toLowerCase();
+  if (lower === '::' || lower === '::1') return true;       // 未指定 / 环回
+  if (lower.startsWith('fe80:') || lower.startsWith('fe80::')) return true; // 链路本地 fe80::/10
+  if (/^f[cd][0-9a-f]{2}:/.test(lower)) return true;        // 唯一本地 fc00::/7
+  if (/^ff[0-9a-f]{2}:/.test(lower)) return true;            // 多播 ff00::/8
+
+  // ::ffff:a.b.c.d 或 ::ffff:HHHH:HHHH 形式的 IPv4 映射地址
+  const mappedMatch = lower.match(/^::ffff:([0-9a-f.:]+)$/);
+  if (mappedMatch) {
+    let inner = mappedMatch[1];
+    if (!inner.includes('.')) {
+      // ::ffff:HHHH:HHHH → 拼出点分十进制
+      const groups = inner.split(':');
+      if (groups.length === 2 && groups.every(g => /^[0-9a-f]{1,4}$/.test(g))) {
+        const hi = parseInt(groups[0], 16);
+        const lo = parseInt(groups[1], 16);
+        inner = `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+      }
+    }
+    if (net.isIP(inner) === 4) return isDisallowedProxyTargetIp(inner);
+    return true;
+  }
+
+  // ::a.b.c.d (deprecated IPv4-compatible)
+  if (lower.startsWith('::') && lower.includes('.')) {
+    const inner = lower.slice(2);
+    if (net.isIP(inner) === 4) return isDisallowedProxyTargetIp(inner);
+  }
+
+  return false;
+}
+
+/**
+ * 校验代理目标 URL：协议必须是 http(s)，并将主机名解析为 IP，拒绝任何指向
+ * 本机/内网/链路本地/云元数据等不安全范围的目标 (SSRF 防护)。
+ * 返回 `{ ok: true, ip, family }` 或 `{ ok: false, status, reason }`。
+ * @param {URL} urlObj 目标 URL 对象
+ */
+async function validateProxyTarget(urlObj) {
+  const protocol = urlObj.protocol;
+  if (protocol !== 'http:' && protocol !== 'https:') {
+    return { ok: false, status: 400, reason: `Unsupported protocol: ${protocol}` };
+  }
+
+  // 去掉 IPv6 字面量的方括号
+  const hostname = urlObj.hostname.replace(/^\[|\]$/g, '');
+  if (!hostname) {
+    return { ok: false, status: 400, reason: 'Empty hostname' };
+  }
+
+  // 如果用户直接写了 IP，则不走 DNS
+  if (net.isIP(hostname)) {
+    if (isDisallowedProxyTargetIp(hostname)) {
+      return { ok: false, status: 403, reason: `Target IP not allowed: ${hostname}` };
+    }
+    return { ok: true, ip: hostname, family: net.isIP(hostname) };
+  }
+
+  // 主机名 → DNS 解析所有 A/AAAA，任意一条命中保留范围即拒绝
+  let addresses;
+  try {
+    addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
+  } catch (err) {
+    return { ok: false, status: 502, reason: `DNS lookup failed: ${err.message}` };
+  }
+  if (!addresses || addresses.length === 0) {
+    return { ok: false, status: 502, reason: 'No DNS records resolved' };
+  }
+  for (const addr of addresses) {
+    if (isDisallowedProxyTargetIp(addr.address)) {
+      return {
+        ok: false,
+        status: 403,
+        reason: `Target host ${hostname} resolves to disallowed address ${addr.address}`
+      };
+    }
+  }
+
+  // 用解析出的首个地址直连，避免后续 protocol.request 再次 DNS (防 TOCTOU/DNS rebinding)
+  const first = addresses[0];
+  return { ok: true, ip: first.address, family: first.family };
+}
+
+/**
  * 创建代理服务器 (端口 5321)
  * 处理通用代理请求，支持配置正向代理和请求熔断
  */
 function createProxyServer() {
-  return http.createServer((req, res) => {
+  return http.createServer(async (req, res) => {
     // 使用 new URL 解析参数，逻辑与 url.parse 保持一致
     const reqUrlObj = new URL(req.url, `http://${req.headers.host}`);
     const queryObject = Object.fromEntries(reqUrlObj.searchParams);
@@ -396,19 +512,58 @@ function createProxyServer() {
       }
       const targetUrl = queryObject.url;
       console.log('[Proxy Server] Target URL:', targetUrl);
-      
-      const originalUrlObj = new URL(targetUrl);
+
+      let originalUrlObj;
+      try {
+        originalUrlObj = new URL(targetUrl);
+      } catch (e) {
+        res.statusCode = 400;
+        res.end('Bad Request: Invalid url parameter');
+        return;
+      }
+
+      // SSRF 防护：只允许 http/https，且目标主机不得指向本机/内网/链路本地
+      // 注意：仅在直连模式下校验。若用户显式配置了 PROXY_URL 正向代理，则由
+      // 外部代理负责出站连接，本机不会直接访问目标 IP。
+      let resolvedIp = null;
+      let resolvedFamily = null;
+      if (!forwardProxy) {
+        const check = await validateProxyTarget(originalUrlObj);
+        if (!check.ok) {
+          console.warn('[Proxy Server] Refused SSRF target:', check.reason);
+          res.statusCode = check.status;
+          res.end(`Proxy target not allowed: ${check.reason}`);
+          return;
+        }
+        resolvedIp = check.ip;
+        resolvedFamily = check.family;
+      }
+
       let options = {
-        hostname: originalUrlObj.hostname,
+        hostname: resolvedIp || originalUrlObj.hostname,
         port: originalUrlObj.port || (originalUrlObj.protocol === 'https:' ? 443 : 80),
         path: originalUrlObj.pathname + originalUrlObj.search,
         method: 'GET',
         headers: { ...req.headers } // 传递原始请求头
       };
-      
-      // Host 头必须被移除，以便 protocol.request 根据 options.hostname 设置正确的值
-      delete options.headers.host; 
-      
+
+      // 使用已解析的 IP 直连时，仍需把原始主机名带入 Host 头与 TLS SNI，
+      // 否则虚拟主机站点 / HTTPS 校验会失败。
+      if (resolvedIp && resolvedIp !== originalUrlObj.hostname) {
+        options.headers.host = originalUrlObj.host;
+        if (originalUrlObj.protocol === 'https:') {
+          options.servername = originalUrlObj.hostname;
+        }
+        if (resolvedFamily === 6) {
+          options.family = 6;
+        } else if (resolvedFamily === 4) {
+          options.family = 4;
+        }
+      } else {
+        // Host 头必须被移除，以便 protocol.request 根据 options.hostname 设置正确的值
+        delete options.headers.host;
+      }
+
       let protocol = originalUrlObj.protocol === 'https:' ? https : http;
 
       // 处理正向代理逻辑
@@ -485,10 +640,14 @@ async function startServer() {
     console.log(`Server running on http://0.0.0.0:${mainPort}`);
   });
 
-  // 启动5321端口的代理服务
+  // 启动 5321 端口的内部代理服务
+  // 该代理仅供本进程通过 127.0.0.1:5321 调用（见 configs/globals.js makeProxyUrl），
+  // 默认绑定环回地址以避免被外部探测/滥用为开放 SSRF 中继。
+  // 如需在其它接口监听，可通过 PROXY_SERVER_HOST 覆盖（不建议公网暴露）。
   proxyServer = createProxyServer();
-  proxyServer.listen(5321, '0.0.0.0', () => {
-    console.log('Proxy server running on http://0.0.0.0:5321');
+  const proxyHost = process.env.PROXY_SERVER_HOST || '127.0.0.1';
+  proxyServer.listen(5321, proxyHost, () => {
+    console.log(`Proxy server running on http://${proxyHost}:5321`);
 
     // 异步初始化 Bangumi Data 缓存
     setTimeout(() => initBangumiData('node', true).catch(console.error), 1000);

--- a/danmu_api/ssrf.test.js
+++ b/danmu_api/ssrf.test.js
@@ -1,0 +1,284 @@
+// SSRF fix regression test for the 5321 proxy server.
+//
+// Re-implements the private isDisallowedProxyTargetIp / validateProxyTarget
+// logic by re-loading server.js source and vm.runInNewContext is overkill —
+// instead we boot the actual proxy server (createProxyServer) via the same
+// http module path but expose it by patching server.js dynamically? Too
+// invasive. Use the easier route: copy the helpers' behaviour test via the
+// real proxy server by literally launching it on an ephemeral port.
+
+import test from 'node:test';
+import assert from 'node:assert';
+import http from 'http';
+import { fileURLToPath } from 'url';
+import path from 'path';
+import fs from 'fs';
+import vm from 'vm';
+
+// Pull the two helper functions out of server.js without booting the whole
+// app. They are pure functions w.r.t. the imported `net` module, so we
+// evaluate them inside a sandbox that supplies a real `net` and `dns`.
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const serverSrc = fs.readFileSync(path.join(__dirname, 'server.js'), 'utf8');
+
+function extractFn(src, name) {
+  // Find the function declaration with its body. We rely on the file using
+  // 1 blank line between top-level declarations.
+  const re = new RegExp(`(async\\s+)?function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`);
+  const m = src.match(re);
+  if (!m) throw new Error(`Could not locate function ${name}`);
+  const start = m.index;
+  // Walk braces.
+  let depth = 0;
+  let i = src.indexOf('{', start);
+  for (; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) {
+        return src.slice(start, i + 1);
+      }
+    }
+  }
+  throw new Error(`Unterminated function ${name}`);
+}
+
+const helperSrc =
+  extractFn(serverSrc, 'isDisallowedProxyTargetIp') + '\n' +
+  extractFn(serverSrc, 'validateProxyTarget') + '\n' +
+  'globalThis.__isDisallowedProxyTargetIp = isDisallowedProxyTargetIp;\n' +
+  'globalThis.__validateProxyTarget = validateProxyTarget;\n';
+
+const net = await import('node:net');
+const dns = await import('node:dns');
+const sandbox = {
+  net: net.default ?? net,
+  dns: dns.default ?? dns,
+  console,
+  globalThis: {},
+};
+sandbox.globalThis = sandbox;
+vm.createContext(sandbox);
+vm.runInContext(helperSrc, sandbox);
+const isDisallowedProxyTargetIp = sandbox.__isDisallowedProxyTargetIp;
+const validateProxyTarget = sandbox.__validateProxyTarget;
+
+test('isDisallowedProxyTargetIp - IPv4 reserved ranges', () => {
+  // Loopback
+  assert.equal(isDisallowedProxyTargetIp('127.0.0.1'), true, '127.0.0.1');
+  assert.equal(isDisallowedProxyTargetIp('127.255.255.254'), true, '127.255.x.x');
+  // Unspecified
+  assert.equal(isDisallowedProxyTargetIp('0.0.0.0'), true, '0.0.0.0');
+  // RFC1918
+  assert.equal(isDisallowedProxyTargetIp('10.1.2.3'), true, '10/8');
+  assert.equal(isDisallowedProxyTargetIp('172.16.0.1'), true, '172.16/12 low');
+  assert.equal(isDisallowedProxyTargetIp('172.31.255.254'), true, '172.16/12 high');
+  assert.equal(isDisallowedProxyTargetIp('192.168.1.1'), true, '192.168/16');
+  // Link-local / cloud metadata
+  assert.equal(isDisallowedProxyTargetIp('169.254.169.254'), true, 'AWS metadata');
+  assert.equal(isDisallowedProxyTargetIp('169.254.0.1'), true, 'link-local');
+  // CGNAT
+  assert.equal(isDisallowedProxyTargetIp('100.64.0.1'), true, 'CGNAT low');
+  assert.equal(isDisallowedProxyTargetIp('100.127.255.254'), true, 'CGNAT high');
+  // Multicast / broadcast / reserved
+  assert.equal(isDisallowedProxyTargetIp('224.0.0.1'), true, 'multicast');
+  assert.equal(isDisallowedProxyTargetIp('239.255.255.255'), true, 'multicast high');
+  assert.equal(isDisallowedProxyTargetIp('240.0.0.1'), true, 'reserved');
+  assert.equal(isDisallowedProxyTargetIp('255.255.255.255'), true, 'broadcast');
+  // Benchmarking
+  assert.equal(isDisallowedProxyTargetIp('198.18.0.1'), true, 'benchmarking');
+  assert.equal(isDisallowedProxyTargetIp('198.19.255.254'), true, 'benchmarking');
+});
+
+test('isDisallowedProxyTargetIp - public IPv4 allowed', () => {
+  // Cloudflare / Google DNS, GitHub
+  assert.equal(isDisallowedProxyTargetIp('1.1.1.1'), false);
+  assert.equal(isDisallowedProxyTargetIp('8.8.8.8'), false);
+  assert.equal(isDisallowedProxyTargetIp('140.82.121.4'), false);
+  // Public-ish boundaries near reserved ranges
+  assert.equal(isDisallowedProxyTargetIp('172.15.255.254'), false, 'just below RFC1918');
+  assert.equal(isDisallowedProxyTargetIp('172.32.0.1'), false, 'just above RFC1918');
+  assert.equal(isDisallowedProxyTargetIp('100.63.255.254'), false, 'just below CGNAT');
+  assert.equal(isDisallowedProxyTargetIp('100.128.0.1'), false, 'just above CGNAT');
+  assert.equal(isDisallowedProxyTargetIp('169.253.255.254'), false, 'just below link-local');
+  assert.equal(isDisallowedProxyTargetIp('169.255.0.1'), false, 'just above link-local');
+});
+
+test('isDisallowedProxyTargetIp - IPv6 reserved', () => {
+  assert.equal(isDisallowedProxyTargetIp('::1'), true, 'IPv6 loopback');
+  assert.equal(isDisallowedProxyTargetIp('::'), true, 'unspecified');
+  assert.equal(isDisallowedProxyTargetIp('fe80::1'), true, 'link-local');
+  assert.equal(isDisallowedProxyTargetIp('fc00::1'), true, 'ULA');
+  assert.equal(isDisallowedProxyTargetIp('fd00::1'), true, 'ULA');
+  assert.equal(isDisallowedProxyTargetIp('ff02::1'), true, 'multicast');
+  // IPv4-mapped IPv6
+  assert.equal(isDisallowedProxyTargetIp('::ffff:127.0.0.1'), true, 'mapped loopback');
+  assert.equal(isDisallowedProxyTargetIp('::ffff:169.254.169.254'), true, 'mapped metadata');
+  assert.equal(isDisallowedProxyTargetIp('::ffff:7f00:1'), true, 'mapped loopback hex');
+  assert.equal(isDisallowedProxyTargetIp('::ffff:a9fe:a9fe'), true, 'mapped metadata hex');
+  // IPv4-compatible (deprecated)
+  assert.equal(isDisallowedProxyTargetIp('::127.0.0.1'), true, 'compat loopback');
+});
+
+test('isDisallowedProxyTargetIp - public IPv6 allowed', () => {
+  assert.equal(isDisallowedProxyTargetIp('2606:4700:4700::1111'), false, 'Cloudflare');
+  assert.equal(isDisallowedProxyTargetIp('2001:4860:4860::8888'), false, 'Google');
+});
+
+test('isDisallowedProxyTargetIp - invalid input handled safely', () => {
+  assert.equal(isDisallowedProxyTargetIp(''), true);
+  assert.equal(isDisallowedProxyTargetIp(null), true);
+  assert.equal(isDisallowedProxyTargetIp(undefined), true);
+  assert.equal(isDisallowedProxyTargetIp('not-an-ip'), true);
+  assert.equal(isDisallowedProxyTargetIp('999.999.999.999'), true);
+});
+
+test('validateProxyTarget - rejects non-http(s) protocols', async () => {
+  for (const proto of ['file:', 'gopher:', 'dict:', 'ftp:', 'data:']) {
+    const url = new URL(`${proto}//example.com/`);
+    const r = await validateProxyTarget(url);
+    assert.equal(r.ok, false, `${proto} should be rejected`);
+    assert.equal(r.status, 400, `${proto} → 400`);
+  }
+});
+
+test('validateProxyTarget - rejects literal internal IPs without DNS', async () => {
+  for (const addr of ['127.0.0.1', '10.0.0.1', '169.254.169.254', '[::1]']) {
+    const url = new URL(`http://${addr}/`);
+    const r = await validateProxyTarget(url);
+    assert.equal(r.ok, false, `${addr} should be rejected`);
+    assert.equal(r.status, 403, `${addr} → 403`);
+  }
+});
+
+test('validateProxyTarget - accepts literal public IPs', async () => {
+  const url = new URL('http://1.1.1.1/');
+  const r = await validateProxyTarget(url);
+  assert.equal(r.ok, true, '1.1.1.1 should be accepted');
+  assert.equal(r.ip, '1.1.1.1');
+});
+
+// End-to-end test against the real createProxyServer. We test that
+// requests for SSRF-y URLs are refused with the documented status codes
+// and that a public-looking hostname (no DNS required, we pass an IP) is
+// rejected only when internal.
+test('proxy server end-to-end - SSRF probes blocked', async (t) => {
+  // Boot the proxy server. We need the real createProxyServer, but
+  // importing server.js also starts the main app on port 9321 and
+  // schedules background tasks. To avoid this, we re-evaluate just
+  // createProxyServer here too.
+  const createSrc = extractFn(serverSrc, 'createProxyServer');
+  // createProxyServer references: http, https, HttpsProxyAgent, console,
+  // process, URL, validateProxyTarget, isDisallowedProxyTargetIp, net.
+  const https = await import('node:https');
+  const url = await import('node:url');
+  const { HttpsProxyAgent } = await import('https-proxy-agent');
+  const ctx = {
+    net: net.default ?? net,
+    dns: dns.default ?? dns,
+    http,
+    https: https.default ?? https,
+    URL,
+    HttpsProxyAgent,
+    process,
+    console,
+    isDisallowedProxyTargetIp,
+    validateProxyTarget,
+  };
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(createSrc + '\nglobalThis.__createProxyServer = createProxyServer;\n', ctx);
+  const server = ctx.__createProxyServer();
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = server.address().port;
+  t.after(() => new Promise((r) => server.close(r)));
+
+  const probe = (q) =>
+    new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          host: '127.0.0.1',
+          port,
+          path: `/?url=${encodeURIComponent(q)}`,
+          method: 'GET',
+        },
+        (res) => {
+          const chunks = [];
+          res.on('data', (c) => chunks.push(c));
+          res.on('end', () =>
+            resolve({ status: res.statusCode, body: Buffer.concat(chunks).toString('utf8') })
+          );
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+
+  // Each of these should be rejected (status 400 or 403).
+  const ssrfProbes = [
+    'http://127.0.0.1/',
+    'http://localhost/', // resolves to loopback
+    'http://169.254.169.254/latest/meta-data/',
+    'http://[::1]/',
+    'http://10.0.0.1/',
+    'http://192.168.1.1/',
+    'http://172.16.0.1/',
+    'http://100.64.0.1/',
+    'http://0.0.0.0/',
+    'http://255.255.255.255/',
+    'http://[::ffff:127.0.0.1]/',
+    'http://[::ffff:7f00:1]/', // mapped hex loopback
+    'http://[::ffff:a9fe:a9fe]/', // mapped hex metadata
+    'file:///etc/passwd',
+    'gopher://127.0.0.1:6379/_x',
+    'dict://127.0.0.1:11211/stats',
+    'ftp://127.0.0.1/',
+  ];
+  for (const p of ssrfProbes) {
+    const r = await probe(p);
+    assert.ok(
+      r.status === 400 || r.status === 403 || r.status === 502,
+      `${p} should be blocked (got ${r.status}: ${r.body})`
+    );
+  }
+});
+
+test('proxy server end-to-end - bad URL → 400', async (t) => {
+  const createSrc = extractFn(serverSrc, 'createProxyServer');
+  const https = await import('node:https');
+  const { HttpsProxyAgent } = await import('https-proxy-agent');
+  const ctx = {
+    net: net.default ?? net,
+    dns: dns.default ?? dns,
+    http,
+    https: https.default ?? https,
+    URL,
+    HttpsProxyAgent,
+    process,
+    console,
+    isDisallowedProxyTargetIp,
+    validateProxyTarget,
+  };
+  ctx.globalThis = ctx;
+  vm.createContext(ctx);
+  vm.runInContext(createSrc + '\nglobalThis.__createProxyServer = createProxyServer;\n', ctx);
+  const server = ctx.__createProxyServer();
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  t.after(() => new Promise((r) => server.close(r)));
+
+  const req = http.request(
+    { host: '127.0.0.1', port, path: '/?url=not-a-url', method: 'GET' }
+  );
+  const status = await new Promise((resolve, reject) => {
+    req.on('response', (res) => {
+      res.resume();
+      resolve(res.statusCode);
+    });
+    req.on('error', reject);
+    req.end();
+  });
+  assert.equal(status, 400);
+});


### PR DESCRIPTION
## Summary

The internal proxy server on port 5321 (`createProxyServer` in `danmu_api/server.js`) accepts an arbitrary `?url=` query parameter and forwards an outbound HTTP/HTTPS request without validating the destination host. In the default Node deploy described in the README (`node ./danmu_api/server.js` or `npm start`), this listener also binds to `0.0.0.0`, so any host that can reach port 5321 — i.e. anyone on the same LAN, or anyone on the public internet when the host is publicly addressable — can use the service as an unauthenticated SSRF relay.

- **CWE-918** — Server-Side Request Forgery
- **Affected file**: `danmu_api/server.js`
- **Affected function**: `createProxyServer()` and its `startServer()` listen call
- **Severity**: High (unauthenticated, no `TOKEN` gate, full response body returned to the attacker)

## Data flow

1. `proxyServer.listen(5321, '0.0.0.0', …)` exposes the proxy on every interface.
2. `createProxyServer` reads `queryObject.url` from the request and constructs `new URL(targetUrl)`.
3. `options.hostname` is set to `originalUrlObj.hostname` with no allow-list and no IP check.
4. `protocol.request(options, …)` issues the request and pipes the response (status + headers + body) straight back to the caller via `proxyRes.pipe(res, { end: true })`.

There is no authentication on this listener (the `TOKEN` middleware lives on the 9321 API, not on 5321) and no scheme/host restriction, so an attacker can target:

- `http://127.0.0.1/` and `http://localhost/` — loopback services on the host
- `http://169.254.169.254/latest/meta-data/` — cloud metadata (AWS IMDSv1, also reachable on GCP/Azure/AliCloud) ⇒ IAM credential theft
- `http://10.x/`, `http://192.168.x/`, `http://172.16-31.x/` — RFC1918 internal networks
- `http://100.64-127.x/` — CGNAT ranges
- IPv6 forms including `[::1]`, `[fe80::…]`, IPv4-mapped (`[::ffff:127.0.0.1]`), IPv4-compatible (`[::127.0.0.1]`)

Node's `URL` parser also normalises decimal/octal/hex/short-form IPs (`http://0177.0.0.1/`, `http://2130706433/`, `http://127.1/`) into canonical dotted-quad, so those payloads all funnel into the same code path.

## Proof of concept

Reproducing against a stock install (Node ≥ 18, `npm install`):

```bash
git clone https://github.com/huangxd-/danmu_api.git
cd danmu_api
npm install
cp config/.env.example config/.env
npm start
# Server running on http://0.0.0.0:9321
# Proxy server running on http://0.0.0.0:5321      <-- the unauthenticated SSRF surface
```

In another shell — note that no `TOKEN` is required and we hit port **5321**, not the API port 9321:

```bash
# 1) Loopback probe — would return data from a service bound only to 127.0.0.1
curl -i "http://<host>:5321/proxy?url=http://127.0.0.1:9321/api/logs"

# 2) AWS / GCP / Azure / AliCloud metadata — works whenever the host is in a cloud VPC
curl -i "http://<host>:5321/proxy?url=http://169.254.169.254/latest/meta-data/iam/security-credentials/"

# 3) Internal RFC1918 sweep
curl -i "http://<host>:5321/proxy?url=http://192.168.1.1/"

# 4) IPv4-mapped IPv6 bypass of naive string filters
curl -i "http://<host>:5321/proxy?url=http://[::ffff:127.0.0.1]/"

# 5) Numeric / short-form IP — Node URL normalises this to 127.0.0.1
curl -i "http://<host>:5321/proxy?url=http://2130706433/"
```

Pre-fix, each of these proxies the response back to the attacker. Post-fix, the request is rejected with either `403 Proxy target not allowed: …` (host resolves to a reserved range) or `400 Bad Request: Invalid url parameter` / `400 Unsupported protocol: …` (non-HTTP scheme).

## The fix

Two independent, defence-in-depth layers, both in `danmu_api/server.js`:

1. **Default bind to loopback.** The proxy is documented in `configs/globals.js` as an *internal* hop reached only via `http://127.0.0.1:5321/proxy?url=…`, so binding it to `0.0.0.0` was unnecessary. The listener now binds to `127.0.0.1` by default and exposes a `PROXY_SERVER_HOST` escape hatch for operators who really need a different interface. This alone removes external reachability for the default Node deploy and Docker deployments that don't publish 5321.

2. **Allow-list at connect time.** A new `validateProxyTarget(urlObj)` runs before any outbound request when the proxy is in direct-connect mode. It:
   - Rejects any scheme other than `http:` or `https:` (closes `file:`, `gopher:`, `dict:`, `ftp:`, `data:`).
   - If the URL is a literal IP, checks `isDisallowedProxyTargetIp` directly.
   - Otherwise resolves the hostname via `dns.promises.lookup(host, { all: true, verbatim: true })` and rejects if *any* returned A/AAAA record falls in a reserved range. This blocks DNS records that point at internal IPs.
   - Returns the resolved IP. The outbound request is then issued **against that IP** (with the original hostname preserved in the `Host` header and TLS SNI), eliminating the TOCTOU / DNS-rebinding window between the lookup and the actual TCP connect.

   `isDisallowedProxyTargetIp` covers IPv4 reserved space — `0.0.0.0/8`, `10.0.0.0/8`, `127.0.0.0/8`, `169.254.0.0/16` (incl. `169.254.169.254`), `172.16.0.0/12`, `192.168.0.0/16`, `100.64.0.0/10` CGNAT, `192.0.0.0/24`, `198.18.0.0/15`, `224.0.0.0/4` multicast, `240.0.0.0/4` reserved + `255.255.255.255` — and the IPv6 equivalents (`::`, `::1`, `fe80::/10`, `fc00::/7`, `ff00::/8`) including IPv4-mapped (`::ffff:a.b.c.d` and `::ffff:HHHH:HHHH`) and IPv4-compatible (`::a.b.c.d`) forms.

When `PROXY_URL` is configured (i.e. the operator has explicitly set an outbound forward proxy), the validation is skipped because the outbound connection is handed off to that proxy — the local process never directly dials the target IP, so the local SSRF threat model doesn't apply.

## Test results

A new test file `danmu_api/ssrf.test.js` covers both helpers and the live proxy server:

```bash
node --test danmu_api/ssrf.test.js
# ✔ isDisallowedProxyTargetIp - IPv4 reserved ranges
# ✔ isDisallowedProxyTargetIp - public IPv4 allowed
# ✔ isDisallowedProxyTargetIp - IPv6 reserved
# ✔ isDisallowedProxyTargetIp - public IPv6 allowed
# ✔ isDisallowedProxyTargetIp - invalid input handled safely
# ✔ validateProxyTarget - rejects non-http(s) protocols
# ✔ validateProxyTarget - rejects literal internal IPs without DNS
# ✔ validateProxyTarget - accepts literal public IPs
# ✔ proxy server end-to-end - SSRF probes blocked
# ✔ proxy server end-to-end - bad URL → 400
# ℹ tests 10  pass 10  fail 0
```

The end-to-end case boots the real `createProxyServer()` on an ephemeral port and verifies that every payload class from the PoC above is rejected (`127.0.0.1`, `localhost`, `169.254.169.254`, `[::1]`, `10.0.0.1`, `192.168.1.1`, `172.16.0.1`, `100.64.0.1`, `0.0.0.0`, `255.255.255.255`, IPv4-mapped IPv6, `file://`, `gopher://`, `dict://`, `ftp://`, malformed URLs). Public IPs (`1.1.1.1`, `8.8.8.8`, Cloudflare/Google IPv6) are explicitly verified to still be accepted, so the fix doesn't regress legitimate use.

## Adversarial review

Before submitting, we tried to disprove this: is the 5321 listener really exposed in real deployments? The Dockerfile only `EXPOSE 9321`, so containerised deploys aren't automatically exposing 5321 — but the README's first-class install path is plain `node ./danmu_api/server.js` / `npm start`, and pre-fix that listener bound to `0.0.0.0`, so anyone running the project directly (or in a host-networked container) was exposing it. We also checked whether the 9321 API path has a parallel SSRF: it routes by hostname into per-source modules, and the only fallback (`otherSource`) prefixes a globally-configured danmu server rather than dispatching an arbitrary URL — so this fix is the right and only place. Finally, we considered whether `TOKEN` somehow protected port 5321: it doesn't — token validation is on the 9321 router only.