### PR TITLE
fix(merge): 零偏移奖励门槛从 4 对降为 1 对，修复新番"炒翻天"合并错误

### DIFF
--- a/danmu_api/utils/merge-util.js
+++ b/danmu_api/utils/merge-util.js
@@ -1420,13 +1420,11 @@ function findBestAlignmentOffset(
             }
             // 匹配数量规模奖励（对齐对越多越可信）
             finalScore += Math.min(matchCount * 0.15, 1.5);
-            // 零偏移奖励：偏移为 0 说明主副源集数完全对齐，是最理想情况
+            // 零偏移奖励：主副源出现任意零差对集即表明集号一致，给予强信号
             const zeroDiffCount = numericDiffs.get('0.0000') || 0;
-            if (zeroDiffCount > 3) {
+            if (zeroDiffCount > 0) {
                 finalScore += MergeWeights.EP_ALIGN.ZERO_DIFF_BONUS_BASE;
                 finalScore += zeroDiffCount * MergeWeights.EP_ALIGN.ZERO_DIFF_BONUS_PER_HIT;
-            } else if (zeroDiffCount > 0) {
-                finalScore += zeroDiffCount * 2.0;
             }
             if (finalScore > maxScore) { maxScore = finalScore; bestOffset = offset; }
         }


### PR DESCRIPTION
ZERO_DIFF_BONUS 原需 >3 对零差才能触发 100 分奖励，
导致单集断层场景仅 E1 一对零差无法拿到加成，
被无断层惩罚的批量偏移对以数量优势压制，选错偏移方向。

任意零差对集出现即表明集号一致，门槛降为 >0。