### PR TITLE
feat: 为ForwardWidget构建添加运行时兼容插件，并重构解压工具函数

### DIFF
--- a/build-forward-widget.js
+++ b/build-forward-widget.js
@@ -1,5 +1,6 @@
 import * as esbuild from 'esbuild';
 import fs from 'fs';
+import path from 'node:path';
 
 // 动态获取版本号
 import { Globals } from './danmu_api/configs/globals.js';
@@ -38,6 +39,50 @@ const uiModules = [
 
 let customPolyfillContent = fs.readFileSync('forward/custom-polyfill.js', 'utf8');
 
+// ForwardWidget runs in a browser-like JS runtime, so Node built-ins must not
+// leak into the bundle. The server still imports the native implementations.
+const forwardRuntimeCompatPlugin = {
+  name: 'forward-runtime-compat',
+  setup(build) {
+    build.onResolve({ filter: /^node:async_hooks$/ }, () => ({
+      path: 'async-hooks',
+      namespace: 'forward-node-builtins'
+    }));
+
+    // brotli ships a compressed dictionary specifically for browser bundles.
+    build.onResolve({ filter: /^\.\/dictionary-data$/ }, (args) => {
+      if (/[\\/]node_modules[\\/]brotli[\\/]dec[\\/]dictionary\.js$/.test(args.importer)) {
+        return { path: path.resolve('node_modules/brotli/dec/dictionary-browser.js') };
+      }
+    });
+
+    build.onLoad({ filter: /^async-hooks$/, namespace: 'forward-node-builtins' }, () => ({
+      loader: 'js',
+      contents: `
+        export class AsyncLocalStorage {
+          constructor() {
+            this.store = undefined;
+          }
+
+          getStore() {
+            return this.store;
+          }
+
+          run(store, callback, ...args) {
+            const previousStore = this.store;
+            this.store = store;
+            try {
+              return callback(...args);
+            } finally {
+              this.store = previousStore;
+            }
+          }
+        }
+      `
+    }));
+  }
+};
+
 (async () => {
   try {
     await esbuild.build({
@@ -51,6 +96,7 @@ let customPolyfillContent = fs.readFileSync('forward/custom-polyfill.js', 'utf8'
       format: 'esm', // 保持ES模块格式
       external: ['redis', 'fs', 'path', 'stream/promises', 'node-fetch'],
       plugins: [
+        forwardRuntimeCompatPlugin,
         // 插件：排除UI相关模块
         {
           name: 'exclude-ui-modules',

--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -2,7 +2,7 @@ import BaseSource from './base.js';
 import { log } from "../utils/log-util.js";
 import { buildQueryString, httpGet} from "../utils/http-util.js";
 import { printFirst200Chars, titleMatches, getExplicitSeasonNumber, extractSeasonNumberFromAnimeTitle } from "../utils/common-util.js";
-import { md5, convertToAsciiSum, decodeHtmlEntities, base64ToBytes } from "../utils/codec-util.js";
+import { md5, convertToAsciiSum, decodeHtmlEntities, base64ToBytes, decompressBrotli, utf8BytesToString } from "../utils/codec-util.js";
 import { generateValidStartDate } from "../utils/time-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
 import { globals } from '../configs/globals.js';
@@ -949,7 +949,7 @@ export default class IqiyiSource extends BaseSource {
       const payload = await this._decompressBrotli(compressed);
 
       if (payload[0] === 60) {
-        return this._parseIqiyiXmlDanmu(new TextDecoder("utf-8").decode(payload));
+        return this._parseIqiyiXmlDanmu(utf8BytesToString(payload));
       }
 
       return this._parseIqiyiProtoDanmu(payload);
@@ -960,17 +960,7 @@ export default class IqiyiSource extends BaseSource {
   }
 
   async _decompressBrotli(bytes) {
-    if (typeof DecompressionStream !== "undefined") {
-      try {
-        const stream = new Blob([bytes]).stream().pipeThrough(new DecompressionStream("brotli"));
-        return new Uint8Array(await new Response(stream).arrayBuffer());
-      } catch {
-        log("info", "[iQiyi] DecompressionStream Brotli 解压失败，尝试 Node zlib");
-      }
-    }
-
-    const { brotliDecompressSync } = await import("node:zlib");
-    return new Uint8Array(brotliDecompressSync(bytes));
+    return decompressBrotli(bytes);
   }
 
   _parseIqiyiXmlDanmu(xml) {
@@ -1024,7 +1014,6 @@ export default class IqiyiSource extends BaseSource {
   _parseIqiyiProtoFields(bytes) {
     const fields = [];
     let offset = 0;
-    const decoder = new TextDecoder("utf-8");
 
     while (offset < bytes.length) {
       const keyResult = this._readIqiyiVarint(bytes, offset);
@@ -1050,7 +1039,7 @@ export default class IqiyiSource extends BaseSource {
         if (end > bytes.length) break;
 
         const raw = bytes.subarray(offset, end);
-        fields.push({ number, wireType, bytes: raw, value: decoder.decode(raw) });
+        fields.push({ number, wireType, bytes: raw, value: utf8BytesToString(raw) });
         offset = end;
       } else if (wireType === 5) {
         fields.push({ number, wireType });

--- a/danmu_api/utils/codec-util.js
+++ b/danmu_api/utils/codec-util.js
@@ -1,4 +1,5 @@
 import { log } from "./log-util.js";
+import brotliDecompress from "brotli/decompress.js";
 
 // =====================
 // 通用编码/解码工具
@@ -449,6 +450,21 @@ export function base64ToBytes(b64) {
     bytes[i] = binaryString.charCodeAt(i);
   }
   return bytes;
+}
+
+// 纯 JavaScript Brotli 解压，兼容不提供原生解压 API 的沙箱。
+export function decompressBrotli(bytes) {
+  if (bytes == null) {
+    throw new TypeError("Brotli 输入不能为空");
+  }
+
+  const input = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+  const output = brotliDecompress(input);
+  if (!output) {
+    throw new Error("Brotli 解压失败");
+  }
+
+  return output instanceof Uint8Array ? output : new Uint8Array(output);
 }
 
 // 自定义 Base64 解码函数

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "brotli": "^1.3.3",
     "chokidar": "^4.0.3",
     "dotenv": "^16.4.7",
     "esbuild": "^0.25.10",


### PR DESCRIPTION
- 新增 forwardRuntimeCompatPlugin 插件，处理 node:async_hooks 的浏览器兼容实现，并重定向 brotli 字典文件至浏览器版本，确保 ForwardWidget 在浏览器类运行时环境中正常运行
- 将 iQiyi 源中的 Brotli 解压逻辑迁移至 codec-util 的 decompressBrotli 通用函数，统一使用 utf8BytesToString 替代 TextDecoder，提升代码复用性和可维护性
- 此举旨在减少构建产物中的 Node.js 内置模块依赖，并集中管理解码工具，便于后续扩展