### PR TITLE
fix: 修复集连播场景可能导致集偏移记录错误

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -2304,11 +2304,17 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
 
     if (clientIp) {
       const lastSearch = getLastSearch(clientIp);
+      // lastSearch 仅在 Match/Search 时更新，顺播下一集时不刷新。
+      // 加 3 分钟 TTL 防止过期 episode 值导致错误偏移（如 E21 时搜的，
+      // 20 分钟后顺播到 E24 时仍以 E21 为基准记录）。
+      // 3 分钟与默认搜索结果缓存时间一致，给用户留出手动纠正的窗口。
       if (lastSearch && lastSearch.title && lastSearch.season && lastSearch.episode && episodeTitle) {
-        lastTitle = lastSearch.title;
-        lastSeason = lastSearch.season;
-        offset = `${lastSearch.episode}:${episodeTitle}`;
-        log("info", `[system] [LogVar-API] Calculated episode offset for IP ${clientIp}: Query E${lastSearch.episode}, Selected ${episodeTitle} -> Offset ${offset} (Season ${lastSeason})`);
+        if (Date.now() - lastSearch.timestamp < 180000) {
+          lastTitle = lastSearch.title;
+          lastSeason = lastSearch.season;
+          offset = `${lastSearch.episode}:${episodeTitle}`;
+          log("info", `[system] [LogVar-API] Calculated episode offset for IP ${clientIp}: Query E${lastSearch.episode}, Selected ${episodeTitle} -> Offset ${offset} (Season ${lastSeason})`);
+        }
       }
     }
 

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -2304,10 +2304,8 @@ export async function getComment(path, queryFormat, segmentFlag, clientIp, inclu
 
     if (clientIp) {
       const lastSearch = getLastSearch(clientIp);
-      // lastSearch 仅在 Match/Search 时更新，顺播下一集时不刷新。
-      // 加 3 分钟 TTL 防止过期 episode 值导致错误偏移（如 E21 时搜的，
-      // 20 分钟后顺播到 E24 时仍以 E21 为基准记录）。
-      // 3 分钟与默认搜索结果缓存时间一致，给用户留出手动纠正的窗口。
+      // lastSearch 仅在 Match/Search 时更新，小幻顺播下一集时不刷新。
+      // 加 3 分钟 TTL 防止过期 episode 值导致错误偏移（如 E21 时搜的，20 分钟后顺播到 E24 时仍以 E21 为基准记录）。
       if (lastSearch && lastSearch.title && lastSearch.season && lastSearch.episode && episodeTitle) {
         if (Date.now() - lastSearch.timestamp < 180000) {
           lastTitle = lastSearch.title;


### PR DESCRIPTION
## 📝 PR 描述

总算搞清楚了这个问题本质，大概只有小幻客户端会遇到。

虽然搞清楚了但是其实不知道怎么精准修复，当前的方案加时间限制可以防止绝大多数场景，但是假设用户快速切集或者放的是三分钟之内的短视频还是可能遇到，问题在于无法精准区分调用 Comment 时用户是不是想记录偏移值，小幻只调用一次 Match，后续顺播多集仅通过 Comment API 获取弹幕导致了这个问题

### 变更类型
🐛 Bug 修复 (bug)

### 变更内容

**集偏移记录加 3 分钟 TTL 防止 lastSearch.episode 过期导致错误偏移**

#### 问题

`lastSearch` 仅在 Match/Search 时更新。部分客户端（如小幻影视）只调用一次 Match，后续顺播多集仅通过 Comment API 获取弹幕。此时 Comment 中读取的 `lastSearch.episode` 仍是上一集的旧值，导致记录错误偏移。

触发条件（三缺一不可）：
1. 客户端对后续集不调 Match API
2. `lastSearch.episode` 与实际播放的集号不一致
3. 两次 Comment 间隔超过正常纠正窗口

**具体复现**：

```
干净状态: lastSelectMap 中"老友记"无 offsets

1. 用户打开 S3E21 → Match API → setLastSearch(episode=21) → 返回 E21 ✓
2. 用户看完 E21，顺播 E22 → 无 Match，只有 Comment
   Comment: lastSearch.episode=21, episodeTitle=第22集
   → offset = "21:第22集" ← 第一个错误记录
3. 用户下次搜 S3E22 → offset "21:第22集" → delta=1 → 偏移到 E23 ✗
```

#### 修复

`dandan-api.js` 第 2311 行：对偏移记录加 3 分钟时间窗口检查。

```javascript
if (Date.now() - lastSearch.timestamp < 180000) {
    offset = `${lastSearch.episode}:${episodeTitle}`;
}
```

效果：
- 手动纠正（Match 后 3 分钟内纠正）：正常记录 ✓
- 顺播过期（Match 后超过 3 分钟）：自动跳过 ✓
- 3 分钟与默认 `SEARCH_CACHE_MINUTES` 一致，给用户留出纠正窗口

#### 历史

`lastSearch` 偏移记录设计由来已久：
- PR [#231](https://github.com/huangxd-/danmu_api/pull/231) 引入偏移功能，Comment 中用 `lastSearch.episode` 记录
- PR [#255](https://github.com/huangxd-/danmu_api/pull/255) 加 `episodeId===commentId` 防快速切集竞态，但过严导致所有纠正都被拦截
- Commit `871db79` 移除该检查以恢复纠正功能，但同时暴露了顺播过期问题
- 本次加 TTL：保留纠正功能，同时防止过期数据污染

### 测试
- [x] 1 文件，+6/-4 行
- [x] `dandan-api.js` 正常加载
- [x] 手动纠正：Match 后立即纠正，TTL 内生效
- [x] 顺播过期：超过 3 分钟自动跳过
- [x] 不破坏 `computeTargetEpisode` 的 delta 传播逻辑