### PR TITLE
fix: 合并合集探测分离 3D/2D 维度，防止误判断合并

### DIFF
--- a/danmu_api/utils/merge-util.js
+++ b/danmu_api/utils/merge-util.js
@@ -2145,14 +2145,19 @@ function detectCollectionCandidates(curAnimes) {
         if (!clean) return;
 
         const category = getContentCategory(anime.animeTitle, realAnime.typeDescription, realAnime.source);
-        const groupKey = `${clean}|${category}`;
+        // 3D/2D 维度分离：防止【3D动漫】与【动漫】在同一个合集探测组内被误合并
+        // 如 tencent 择天记(2020)【动漫】(2D) 与 iqiyi 择天记(2026)【3D动漫】(3D) 不应互成合集
+        const is3D = (realAnime.typeDescription || '').includes('3D') || /3[dD]/.test(anime.animeTitle || '');
+        const is2D = (realAnime.typeDescription || '').includes('2D') || /2[dD]/.test(anime.animeTitle || '');
+        const dim = is3D ? '3D' : (is2D ? '2D' : '-');
+        const groupKey = `${clean}|${category}|${dim}`;
         if (!groups.has(groupKey)) groups.set(groupKey, []);
         groups.get(groupKey).push(anime);
     });
 
     for (const [groupKey, list] of groups.entries()) {
         if (list.length < 2) continue;
-        const [baseTitle, category] = groupKey.split('|');
+        const [baseTitle, category, dim] = groupKey.split('|');
         const itemDetails = list.map(a => `   - [${a.source}] ${a.animeTitle}`).join('\n');
         log("info", `[Merge-Check] [合集探测] 正在检查分组: "${baseTitle}" [${category}] (包含 ${list.length} 个条目):\n${itemDetails}`);
 


### PR DESCRIPTION
getContentCategory 对 2D 动漫和 3D 动漫均返回 ANIME，
导致同 baseTitle 的 3D 番进入与 2D 番同一合集探测组。
如 tencent 择天记(2020)【动漫】(2D,61集) 与 iqiyi
择天记(2026)【3D动漫】(3D,26集) 被误分到同一组而产生错误合并。

合集探测分组 key 中加入维度标记(3D/2D/-)，使 3D 与 2D
番剧互不进入同一探测组，合集探测各查各的。

Closes #384 