### PR TITLE
fix: iqiyi 搜索风控重试间隔从 1.5 秒延长至 3 秒，并优化年份提取

### DIFF
--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -74,8 +74,8 @@ export default class IqiyiSource extends BaseSource {
       let data = await doSearch();
       for (let attempt = 0; attempt < MAX_RETRIES && (!data || data.code === "-1"); attempt++) {
         const reason = !data ? "搜索响应为空" : `搜索接口风控 (code=${data.code})`;
-        log("info", `[iQiyi] ${reason}，等待 1.5 秒后重试 (${attempt + 1}/${MAX_RETRIES})`);
-        await new Promise(r => setTimeout(r, 1500));
+        log("info", `[iQiyi] ${reason}，等待 3 秒后重试 (${attempt + 1}/${MAX_RETRIES})`);
+        await new Promise(r => setTimeout(r, 3000));
         data = await doSearch();
       }
 

--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -196,13 +196,11 @@ export default class IqiyiSource extends BaseSource {
         return null;
       }
 
-      // 提取年份
+      // 提取年份（普通结果卡片在 year 字段，意图聚合卡片 template 112 无 year 字段，年份在 superscript 角标）
       let year = null;
-      if (album.year) {
-        const yearStr = album.year.value || album.year.name;
-        if (yearStr && typeof yearStr === 'string' && yearStr.length === 4 && /^\d{4}$/.test(yearStr)) {
-          year = parseInt(yearStr);
-        }
+      const yearStr = (album.year && (album.year.value || album.year.name)) || album.superscript;
+      if (yearStr && typeof yearStr === 'string' && /^\d{4}$/.test(yearStr)) {
+        year = parseInt(yearStr);
       }
 
       // 清理标题
@@ -234,13 +232,11 @@ export default class IqiyiSource extends BaseSource {
     }
     const linkId = linkIdMatch[1];
 
-    // 提取年份
+    // 提取年份（普通结果卡片在 year 字段，意图聚合卡片 template 112 无 year 字段，年份在 superscript 角标）
     let year = null;
-    if (album.year) {
-      const yearStr = album.year.value || album.year.name;
-      if (yearStr && typeof yearStr === 'string' && yearStr.length === 4 && /^\d{4}$/.test(yearStr)) {
-        year = parseInt(yearStr);
-      }
+    const yearStr = (album.year && (album.year.value || album.year.name)) || album.superscript;
+    if (yearStr && typeof yearStr === 'string' && /^\d{4}$/.test(yearStr)) {
+      year = parseInt(yearStr);
     }
 
     // 提取分集数


### PR DESCRIPTION
### 搜索风控重试间隔从 1.5 秒延长至 3 秒

- 用户反馈遇到风控时当前 1.5 秒间隔不足以通过，等待一会后又可正常访问。
推测爱奇艺风控冷却窗口约 3-5 秒，延长至 3 秒以覆盖更多场景。

### 搜索意图聚合卡片支持从 superscript 角标获取年份
- 搜索接口 homePageV3 返回的意图聚合卡片（template 112）不含 year 字段，
年份实际存放在角标字段 superscript（如 "1999"），导致航海王等内容年份恒为 null。
在原有 year.value || year.name 回退链末尾追加 superscript 兜底，使其在普通结果卡片