### PR TITLE
fix: 严格匹配支持剧名杂音清理，改用正则补全数字与英中季号允许关键词

### DIFF
--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -223,16 +223,22 @@ export function normalizeSpaces(str) {
 export function strictTitleMatch(title, query) {
   if (!title || !query) return false;
 
-  const t = normalizeSpaces(title);
-  const q = normalizeSpaces(query);
+  // 剧名杂音清理：移除画质/配音/版本等杂音词，避免阻塞匹配
+  const tagFilter = globals.titleNoiseFilter || null;
+  const cleanTitle = tagFilter ? title.replace(tagFilter, '').trim() : title;
+  const cleanQuery = tagFilter ? query.replace(tagFilter, '').trim() : query;
+
+  const t = normalizeSpaces(cleanTitle);
+  const q = normalizeSpaces(cleanQuery);
 
   // 完全匹配
   if (t === q) return true;
 
-  // 标题以搜索词开头，且后面跟着空格、括号等分隔符
-  const separators = [' ', '(', '（', ':', '：', '-', '—', '·', '第', 'S', 's', '年番', '合集'];
-  for (const sep of separators) {
-    if (t.startsWith(q + sep)) return true;
+  // 标题以搜索词开头，且后面为季号或有效关键词时，允许严格匹配通过
+  if (t.startsWith(q) && t.length > q.length) {
+    const suffix = t.substring(q.length);
+    const seasonPattern = /^(?:[\dⅡⅢⅣⅤⅥⅦⅧⅨⅩ]|[sS]\d+|Season\s*\d+|Part\s*\d+|第\d+|[第]?\s*[零一二三四五六七八九十]+\s*[季期部]|年番|合集|部(?!分)|部分|篇|剧场|完结|最终)/;
+    if (seasonPattern.test(suffix)) return true;
   }
 
   return false;


### PR DESCRIPTION
strictTitleMatch 入口处先执行 titleNoiseFilter 再 normalizeSpaces，
标题与查询词双端清理后比较，与宽松模式行为一致。
移除 normalizeSpaces 已剥离的无用符号分隔词（空格、括号、冒号等）。

允许关键词检测改用正则 seasonPattern，覆盖阿拉伯数字（新闻女王2）、
罗马数字（无职转生Ⅱ）、英文季号（S1/Season1/Part1）、
中文季号（第一季/第三部）及关键词（年番/合集/部/篇/部分/剧场/完结/最终）。
裸 S/第/Season 无数字后缀不再匹配，部(?!分) 防止裸"部"吞掉"部分"。