### PR TITLE
fix: 完善跨季匹配与平台过滤逻辑，修复备用匹配状态及集标题解析

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1206,7 +1206,8 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
 
     if (absoluteMatch) {
       if (platform && getPlatformMatchScore(extractEpisodeTitle(absoluteMatch.episodeTitle), platform) === 0) {
-          break;
+          currentSeason++;
+          continue;
       }
       log("info", `[system] [Spillover] 跨季溢出查找命中 (按绝对标题数字) -> 所在季：S${currentSeason} 集标题：${absoluteMatch.episodeTitle}`);
       bestRes = {
@@ -1220,7 +1221,8 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
     if (currentTargetEpisode <= allEps.length) {
       const targetEp = allEps[currentTargetEpisode - 1];
       if (platform && getPlatformMatchScore(extractEpisodeTitle(targetEp.episodeTitle), platform) === 0) {
-          break;
+          currentSeason++;
+          continue;
       }
       log("info", `[system] [Spillover] 跨季溢出查找命中 (按相对排位计算) -> 所在季：S${currentSeason} 集标题：${targetEp.episodeTitle}`);
       bestRes = {
@@ -1344,6 +1346,14 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
 
         // 匹配集数
         matchedEpisode = findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, platform);
+
+        // 当指定平台与候选动画源不匹配导致过滤后无匹配时，回退到不区分平台提取集数
+        if (!matchedEpisode && platform) {
+            const actualAnimePlatform = extractPlatformFromTitle(anime.animeTitle) || anime.source;
+            if (getPlatformMatchScore(actualAnimePlatform, platform) === 0) {
+                matchedEpisode = findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, null);
+            }
+        }
 
         // 如果当前是用户的优选偏好，但由于平台配置限制导致未命中目标平台，则放宽条件无视平台限制提取集数
         if (!matchedEpisode && isPreferredAnime) {

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -300,9 +300,9 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
     }
   }
 
-  // 指定平台均无匹配数据时判定为不满足，不阻塞跨季扩展
+  // 优先平台无匹配数据时回退到不区分平台重新检查全部可用数据
   if (!anyPlatformHadData && targetPlatform) {
-    return false;
+    return checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAnimeDetailsMap, null);
   }
 
   return allSatisfied;

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -239,6 +239,7 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
   }
 
   let allSatisfied = true;
+  let anyPlatformHadData = false;
 
   for (const tPlat of targetPlatforms) {
     let isEpisodeSatisfied = false;
@@ -283,8 +284,9 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
     }
 
     if (!platformHasData) {
-      continue; 
+      continue;
     }
+    anyPlatformHadData = true;
 
     if (!isEpisodeSatisfied) {
       let totalValidEpisodes = 0;
@@ -296,6 +298,11 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
         break;
       }
     }
+  }
+
+  // 指定平台均无匹配数据时判定为不满足，不阻塞跨季扩展
+  if (!anyPlatformHadData && targetPlatform) {
+    return false;
   }
 
   return allSatisfied;
@@ -1723,6 +1730,9 @@ export async function matchAnime(url, req, clientIp) {
         resAnime = __ret.resAnime;
         // 跨季集数顺延映射的结果不更新 lastSearch，防止无关番剧污染 lastSelectMap 偏好记录
         spilloverMatched = __ret.isSpillover;
+        if (resAnime) {
+          resData["isMatched"] = true;
+        }
       }
     }
 

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -314,8 +314,9 @@ export function titleMatches(title, query, parsedSeason = null) {
     const titleSeason = getExplicitSeasonNumber(titleText);
 
     if (querySeason > 1) {
-      // 搜索指定续作(>1)时，标题必须明确包含该季度标识
-      if ((titleSeason || 1) !== querySeason) return false;
+      // 搜索指定续作(>1)时，仅当源标题明确包含季号时才校验季号一致性
+      // 源标题无季号的不分季长剧不应被此规则拦截，交由上游源处理器决定
+      if (titleSeason !== null && titleSeason !== querySeason) return false;
     } else if (querySeason === 1) {
       // 搜索第1季时，拦截明确标明为其他季度(如第2季、第3季)的结果
       if (titleSeason !== null && titleSeason !== 1) return false;

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -446,8 +446,8 @@ export function extractSeasonNumberFromAnimeTitle(animeTitle) {
 export function extractEpisodeNumberFromTitle(episodeTitle) {
   if (!episodeTitle) return null;
 
-  // 匹配格式：第1集、第01集、第10集等
-  const chineseMatch = episodeTitle.match(/第(\d+)集/);
+  // 匹配格式：第1集、第01集、第1话、第1回等
+  const chineseMatch = episodeTitle.match(/第(\d+)[集话回]/);
   if (chineseMatch) {
     return parseInt(chineseMatch[1], 10);
   }


### PR DESCRIPTION
## Summary

完善 `match` 接口在多平台偏好、跨季扩展、集标题解析、季数守卫四个维度的匹配正确性：

1. **跨季扩展误判**：指定 `PLATFORM_ORDER` 但搜索结果无对应平台数据时，跨季扩展被错误触发或抑制。
2. **平台过滤过严**：`matchAniAndEp` 和 spillover 中平台不匹配时，分季数据被过滤殆尽而找不到匹配集。
3. **集标题解析缺陷**：`extractEpisodeNumberFromTitle` 只识别 `第X集`，dandan 等源使用的 `第X话` 格式被遗漏，导致分季条目被跳过。
4. **备用匹配状态遗漏**：`fallbackMatchAniAndEp` 成功后 `isMatched` 未正确置为 `true`。
5. **季数守卫过严**：`titleMatches` 对无季号的不分季长剧（如航海王）强制转为季号 1 并拦截 querySeason>1 的查询，导致 searchData 为空。

---

## 修复明细

### 1. checkEpisodeSatisfied — 优选平台无匹配时回退到不限平台重查

**问题**：`PLATFORM_ORDER` 指定的平台与搜索结果源不匹配时（如指定 `qiyi` 但搜到 `renren`），原有逻辑直接 `return false` 会错误触发跨季扩展（S5~S10）和 spillover，造成大量无意义 API 请求。

**修复**：`anyPlatformHadData=false` 时不再直接断言 true/false，而是以 `targetPlatform=null` 递归调用自身，回退到 `_any_` 模式重新查验全部可用数据，再依据集数是否满足决定是否触发扩展。

**实际案例**：

> 配置 `PLATFORM_ORDER=qiyi`，`SOURCE_ORDER=renren`（仅启用 renren 源确保搜索结果单一），查询 `老友记 S4E3`
>
> 搜索仅返回 renren 条目（`老友记 第四季 from renren`，含 24 集且第 3 集存在）。
> 修复前：`anyPlatformHadData=false` → 直接 `return false` → 跨季扩展触发 S5~S10 并行请求（6 次无谓搜索 + 详情）→ spillover 遍历 7 个条目 → 大量浪费后最终匹配成功。
> 修复后：回退 `_any_` 模式查验 renren 24 集含 E3 → `return true` → 跨季扩展和 spillover 均被正确抑制。
>
> 反面验证：同配置查询 `我推的孩子 S1E31`，renren 仅 11 集。回退 `_any_` 后总集数 11 < 31 → `return false` → 正确触发跨季扩展。

### 2. matchAniAndEp / spillover — 平台不匹配源时回退到无平台过滤

**问题**：`matchAniAndEp` 中 `findEpisodeByNumber(platform='renren')` 过滤掉全部 `iqiyi` 集后返回 null，`bestRes` 为空导致错误触发 spillover；spillover 本身也因平台不匹配而 `break` 退出。

**修复**：
- `matchAniAndEp`：`findEpisodeByNumber` 返回 null 后，检查候选源是否匹配目标平台，不匹配则以 `platform=null` 重试。
- `findCrossSeasonEpisodeMap`：平台不匹配时以 `currentSeason++; continue` 替代 `break`，允许跨季映射跳过不匹配季继续查找。

**实际案例**：

> 配置 `PLATFORM_ORDER=renren`，`SOURCE_ORDER=iqiyi`（仅启用 iqiyi 源确保搜索结果单一），查询 `老友记 S4E3`
>
> 搜索返回 iqiyi 条目（`老友记第四季(N/A)【电视剧】from iqiyi`），含 24 集且 E3 存在。
> 修复前：`findEpisodeByNumber(platform='renren')` 过滤掉全部 `【qiyi】` 集标题 → 返回 null → `bestRes` 为空 → 错误触发 spillover → spillover 也因平台不匹配 `break` → 浪费 2 次 bangumi 请求后 fallback 兜底成功。
> 修复后：`findEpisodeByNumber` 返回 null → 检测 `getPlatformMatchScore('iqiyi', 'renren') === 0` → 回退 `platform=null` 重试 → 直接命中 E3 → spillover 不再触发。

### 3. extractEpisodeNumberFromTitle — 支持 `第X话` 和 `第X回` 格式

**问题**：正则仅匹配 `/第(\d+)集/`，dandan 等动画源使用 `第31话` 格式，`findEpisodeByNumber` 无法提取集号。跨季扩展虽正确拉取了 S3 dandan 条目且含 E31（`第31话 决裂`），但集号提取失败 → 匹配被跳过 → 降级到 bahamut 不分季条目（用 `第31集`）。

**修复**：正则扩展为 `/第(\d+)[集话回]/`，同时覆盖：

| 格式 | 示例 | 场景 |
|------|------|------|
| 集 | `第31集` | 中文标准、bahamut、renren |
| 话 | `第31话` | 日式动画（dandan 等） |
| 回 | `第12回` | 老式分回结构 |
| 期/章/卷 | — | 刻意不匹配，避免综艺/漫画/OVA 误匹配 |

**实际案例**：

> 配置 `PLATFORM_ORDER=dandan&bahamut&animeko`，`SOURCE_ORDER=dandan,animeko,bahamut`，查询 `我推的孩子 S1E31`
>
> 跨季扩展正确拉取 S3 dandan 合并条目（`【我推的孩子】 第三季 from dandan&bahamut&animeko`），含 E31（`第31话 决裂`）。
> 修复前：`extractEpisodeNumberFromTitle('第31话 决裂')` 返回 `null` → `findEpisodeByNumber` 无法匹配 → 降级到 bahamut 不分季条目（`from bahamut&animeko&animeko&animeko`，用 `第31集`）→ 用户期望的 dandan S3 条目被跳过。
> 修复后：`第31话` 正确提取为 `31` → dandan S3 条目以更高平台匹配得分 (2997 vs 1996) 胜出 → 符合 PLATFORM_ORDER 中 dandan 优先的预期。

### 4. 备用匹配 isMatched 状态

**问题**：`matchAniAndEp` 在 AI 匹配和平台匹配均失败后调用 `fallbackMatchAniAndEp` 兜底，但成功后 `isMatched` 仍为 `false`，客户端收到正确的 `matches` 数组却视为未命中。

**修复**：`fallbackMatchAniAndEp` 成功且非 spillover 结果时将 `resData.isMatched` 置为 `true`。

**实际案例**：

> 常规刮削后传入 `航海王 S02E62`，`SOURCE_ORDER=iqiyi`，`PLATFORM_ORDER` 未指定
>
> `iqiyi` 返回不分季条目（`航海王(N/A)【动漫】from iqiyi`），`matchSeason("航海王", season=2)` 因 iqiyi 条目不区分季号而失败。进入 `fallbackMatchAniAndEp` 兜底 → `findEpisodeByNumber(episodes, 62)` 成功命中第 62 集。
>
> 修复前，客户端收到的响应：
> ```json
> {
>   "isMatched": false,
>   "matches": [{
>     "episodeTitle": "【qiyi】 航海王 第62集 第一道难关！巨大的鲸鱼出现！"
>   }]
> }
> ```
> 修复后，`isMatched` 正确置为 `true`，客户端可以正常消费匹配结果。

### 5. titleMatches — 对无季号标题放宽季数守卫

**问题**：`titleMatches` 在 `querySeason > 1` 时对源标题无季号的情况执行 `(titleSeason || 1) !== querySeason`，将 `null` 强制转为 `1` 并拦截。导致 iqiyi 搜索不分季长剧（如航海王、名侦探柯南）时，全部结果因标题中无季号被过滤，`searchData` 为空，整个匹配链路无数据可用。

**修复**：仅当源标题**明确含季号且与目标季不一致**时才拦截，无季号标题交由上游源处理器决定是否保留。

**实际案例**：

> 配置 `SOURCE_ORDER=iqiyi`，查询 `航海王 S02E62`
>
> iqiyi 搜索返回 16 个结果（均无季号）。修复前：`(null || 1) = 1 ≠ 2` → `titleMatches` 全部返回 `false` → `filteredAnimes` 为空 → 无详情请求 → `searchData` 为空 → spillover 空转。修复后：`titleSeason === null` → 跳过季数守卫 → 16 个结果通过 → iqiyi 正常获取分集 → 匹配链路完整。

---

## 影响范围

| 场景 | PLATFORM_ORDER | 行为变化 |
|------|:--:|------|
| 无 PLATFORM_ORDER | 空 | 不受影响 |
| 指定平台且命中 | 匹配 | 不受影响 |
| 指定平台但搜索结果无该源 | 不匹配 | **修复：回退到不限平台查验，避免误触发扩展** |
| 指定平台且集数跨季 | 匹配 | **修复：dandan 话格式可被正确识别，跨季分季条目胜出** |
| fallback 匹配成功 | 任意 | **修复：isMatched=true** |
| spillover 多季查找 | 不匹配 | **修复：跳过不匹配季继续而非 break 退出** |
| 不分季长剧 (querySeason>1) | 任意 | **修复：不再被 titleMatches 误拦截，searchData 正常填充** |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/apis/dandan-api.js` | checkEpisodeSatisfied 回退逻辑、matchAniAndEp 平台回退、spillover continue、isMatched 状态 |
| `danmu_api/utils/common-util.js` | extractEpisodeNumberFromTitle 正则扩展、titleMatches 季数守卫放宽 |
