### PR TITLE
fix: 修复跨季集数匹配中多候选毒化、同号集膨胀、季容量虚高与无关源污染

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -818,14 +818,10 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
         }
       }
 
-      // 即使 maxSeason 不大于 querySeason，也至少尝试一次跨季扩展。某些源（如
-      // dandan）的高季条目经 handleAnimes 内的关联作品发现机制获取，原始搜索结果
-      // 中无直接季号标记，需执行跨季调用才能触发发现
-      const effectiveMaxSeason = Math.max(maxSeason, querySeason + 1);
-      if (effectiveMaxSeason > querySeason) {
-        log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${effectiveMaxSeason}...`);
+      if (maxSeason > querySeason) {
+        log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${maxSeason}...`);
         const expandPromises = [];
-        for (let s = querySeason + 1; s <= effectiveMaxSeason; s++) {
+        for (let s = querySeason + 1; s <= maxSeason; s++) {
           expandPromises.push((async () => {
             const seasonAnimes = [];
             await executeSourceHandlers(resultData, queryTitle, seasonAnimes, requestAnimeDetailsMap, s, preferAnimeId, preferSource);

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -818,10 +818,14 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
         }
       }
 
-      if (maxSeason > querySeason) {
-        log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${maxSeason}...`);
+      // 即使 maxSeason 不大于 querySeason，也至少尝试一次跨季扩展。某些源（如
+      // dandan）的高季条目经 handleAnimes 内的关联作品发现机制获取，原始搜索结果
+      // 中无直接季号标记，需执行跨季调用才能触发发现
+      const effectiveMaxSeason = Math.max(maxSeason, querySeason + 1);
+      if (effectiveMaxSeason > querySeason) {
+        log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${effectiveMaxSeason}...`);
         const expandPromises = [];
-        for (let s = querySeason + 1; s <= maxSeason; s++) {
+        for (let s = querySeason + 1; s <= effectiveMaxSeason; s++) {
           expandPromises.push((async () => {
             const seasonAnimes = [];
             await executeSourceHandlers(resultData, queryTitle, seasonAnimes, requestAnimeDetailsMap, s, preferAnimeId, preferSource);

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -808,7 +808,10 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
             const list = (item && Array.isArray(item.list)) ? item.list : [item];
             for (const a of list) {
               if (!a) continue;
-              const s = extractSeasonNumberFromAnimeTitle(a.animeTitle || a.title || "").season;
+              // 仅从与查询相关的条目中提取季号，避免无关源的搜索结果污染 maxSeason
+              const testTitle = a.animeTitle || a.title || a.name || a.name_cn || "";
+              if (testTitle && !titleMatches(testTitle, queryTitle)) continue;
+              const s = extractSeasonNumberFromAnimeTitle(testTitle).season;
               if (s !== null && s > maxSeason) maxSeason = s;
             }
           }

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -923,7 +923,16 @@ export function filterSameEpisodeTitle(filteredTmpEpisodes) {
             return prevEpisode.episodeTitle === episode.episodeTitle;
         });
     });
-    return filteredEpisodes;
+    // 对聚合采集源（如360）中来自不同平台的同名集号做二次去重
+    // 同一集号保留首次出现（最早平台）的条目
+    const seenNumbers = new Set();
+    return filteredEpisodes.filter(ep => {
+        const num = extractEpisodeNumberFromTitle(ep.episodeTitle);
+        if (num === null) return true;
+        if (seenNumbers.has(num)) return false;
+        seenNumbers.add(num);
+        return true;
+    });
 }
 
 /**

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -810,7 +810,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
               if (!a) continue;
               // 仅从与查询相关的条目中提取季号，避免无关源的搜索结果污染 maxSeason
               const testTitle = a.animeTitle || a.title || a.name || a.name_cn || "";
-              if (testTitle && !titleMatches(testTitle, queryTitle)) continue;
+              if (testTitle && !titleMatches(testTitle, queryTitle, null, true)) continue;
               const s = extractSeasonNumberFromAnimeTitle(testTitle).season;
               if (s !== null && s > maxSeason) maxSeason = s;
             }

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1191,13 +1191,15 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
     }
     if (sNum === null) sNum = 1;
 
-    if (!seasonMap.has(sNum)) {
-      const bangumiData = getBangumiDataForMatch(anime, detailStore);
-      if (bangumiData?.success && bangumiData?.bangumi?.episodes) {
-        const filteredTmpEpisodes = bangumiData.bangumi.episodes.filter(ep => !globals.episodeTitleFilter.test(ep.episodeTitle));
-        const filteredEpisodes = filterSameEpisodeTitle(filteredTmpEpisodes);
+    const bangumiData = getBangumiDataForMatch(anime, detailStore);
+    if (bangumiData?.success && bangumiData?.bangumi?.episodes) {
+      const filteredTmpEpisodes = bangumiData.bangumi.episodes.filter(ep => !globals.episodeTitleFilter.test(ep.episodeTitle));
+      const filteredEpisodes = filterSameEpisodeTitle(filteredTmpEpisodes);
 
-        if (filteredEpisodes.length > 0) {
+      if (filteredEpisodes.length > 0) {
+        const existing = seasonMap.get(sNum);
+        // 同一季号存在多个候选时，保留集数更多的条目（如 TV 系列覆盖剧场版/特别篇）
+        if (!existing || filteredEpisodes.length > existing.episodes.length) {
           seasonMap.set(sNum, {
             anime: anime,
             episodes: filteredEpisodes,

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -303,8 +303,11 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
 
     if (!isEpisodeSatisfied) {
       let totalValidEpisodes = 0;
-      for (const capacity of seasonCapacities.values()) {
-        totalValidEpisodes += capacity;
+      for (const [sNum, capacity] of seasonCapacities) {
+        // 仅累加不超过查询季号的容量，防止跳跃季（如别名指示S3但S2缺失）导致虚高
+        if (sNum <= querySeason) {
+          totalValidEpisodes += capacity;
+        }
       }
       if (totalValidEpisodes < queryEpisode) {
         allSatisfied = false;


### PR DESCRIPTION
## Summary

完善 `match` 接口在跨季集数映射（spillover）、聚合源集数去重、容量求和、maxSeason 污染四个维度的匹配正确性：

1. **跨季映射 seasonMap 被剧场版毒化**：同季号存在多个候选条目时，先到先得导致剧场版（1集）占据 TV 系列（24集）的季号位置，整条跨季映射链路实效。
2. **聚合源多平台同号集膨胀**：360 等聚合采集源将多个平台的同名集合并到单个条目中（如 imgo/youku/qiyi/bilibili 各 24 集 → 96 links），`filterSameEpisodeTitle` 仅按标题去重无法过滤，导致集数虚高。
3. **跨季容量求和包含跳跃季**：`seasonCapacities` 无条件累加所有季号的容量，当别名含 `Season 3` 映射为 sNum=3 后，S3 的 12 集被计入 S1 的容量，使 `totalValidEpisodes = 36 ≥ 26` 误判满足，跨季扩展被抑制。
4. **maxSeason 被无关源的搜索结果污染**：`maxSeason` 计算遍历所有源的原始搜索结果提取季号，某源返回的与查询无关的条目（如 renren 搜"师兄啊师兄"返回的"绝世武神 第8季"）被计入，异常推高 maxSeason 触发大量无效跨季扩展调用。

---

## 修复明细

### 1. findCrossSeasonEpisodeMap — seasonMap 按集数比较防止剧场版毒化

**问题**：`seasonMap` 原先使用 `!seasonMap.has(sNum)` 先到先得。当同一季号存在多个候选条目时（如剧情复杂的动画同时有剧场版、特别篇、TV 系列），searchData 中集数极少的剧场版排在前面，占据了本该属于 TV 系列的季号位置。

**修复**：移除 `has()` 守卫，改为 `seasonMap.get(sNum)` 比较集数，集数更多的候选自动覆盖较少的。

**实际案例**：

> 配置 `SOURCE_ORDER=dandan`，查询 `咒术回战 S1E26`
>
> dandan 搜索返回 6 个与咒术回战相关的条目，其中 `死灭回游(sNum=1, 已过滤后 1 集)`、`怀玉玉折(sNum=1, 1 集)`、`剧场版 0(sNum=1, 1 集)` 排在前面，真正的 TV 系列条目 `咒术回战(2020)(sNum=1, 24 集)` 被 `!seasonMap.has(1)` 跳过。
>
> 修复前：`seasonMap S1 = 1 集`（剧场版占据）→ S1 容量 1 < 26 → spillover 正确触发 → 但映射到 S2 时无数据可用 → 整个跨季匹配链路实效。
> 修复后：TV 系列 24 集自然覆盖剧场版 1 集 → `seasonMap S1 = 24 集` → spillover 的 S2 映射 24 + 23 = 47 ≥ 26 → 跨季映射正常执行。

### 2. filterSameEpisodeTitle — 增加按集号二次去重

**问题**：360 等聚合采集源将多平台同一集合并到单个 bangumi 条目中（如 imgo/youku/qiyi/bilibili 各播 24 集，共 96 links），`filterSameEpisodeTitle` 仅按 `episodeTitle` 字符串完全相同去重——不同平台前缀不同故全部保留。

**修复**：同名去重后增加按 `extractEpisodeNumberFromTitle` 的二次去重：同一集号（数字）仅保留首次出现的平台条目。`extractEpisodeNumberFromTitle` 提取不到数字的标题（综艺 `第X期`、电影 `剧场版`）不受影响。

**去重判断依据**：不是比字符串，而是比 `extractEpisodeNumberFromTitle` 提取出的**数字集号**。`第(\d+)[集话回]` 同时匹配"集""话""回"：

| 标题 | 提取数字 |
|------|:--:|
| `【imgo】 第1集` | `1` |
| `【youku】 第1集` | `1` → 与上一条同号 → 丢弃 |
| `【dandan】 第1话` | `1` → 同号丢弃 |
| `【dandan】 第2话` | `2` → 保留 |
| `第8期 宋亚轩…` | `null`（期 ∉ [集话回]）→ 保留 |
| `剧场版` | `null` → 保留 |

**实际案例**：

> 配置 `SOURCE_ORDER=360`，查询 `咒术回战 S01E49`
>
> 360 返回不分季条目 `【咒术回战】(2020)【TV动画】from 360`，内含 4 平台 × 24 集 = 96 links。修复前：`filterSameEpisodeTitle` 保留全部 96 条 → `checkEpisodeSatisfied` 判定 S1 含 96 集 ≥ 49 → 跳过跨季扩展 → `findEpisodeByNumber(eps, 49)` 在 96 项数组中索引到错误条目 → 匹配失败。
> 修复后：按集号去重为 24 条 → `checkEpisodeSatisfied` 判定 24 < 49 → 触发跨季扩展 → 正确匹配。

### 3. checkEpisodeSatisfied — 跨季容量求和仅累加不超过查询季号的季

**问题**：`seasonCapacities` 的求和判断原为 `for (const capacity of seasonCapacities.values())` 无条件累加**所有季号**。当别名被提取为非预期的大季号（如 `"Jujutsu Kaisen Season 3"` → `sNum=3`）时，S3 的容量被独立计入，形成 `totalValidEpisodes = 24 + 12 = 36 ≥ 26` 的虚高误判。

**修复**：`for (const [sNum, capacity] of seasonCapacities)` 增加 `if (sNum <= querySeason)` 守卫，仅累加不超过查询季号的容量。跳跃的后继季（如 S3 在 S2 缺失时）不独立计入总量。

**实际案例**：

> 配置 `SOURCE_ORDER=dandan`，查询 `咒术回战 S1E26`
>
> searchData 中 `咒术回战(2020)` 条目别名含 `"Jujutsu Kaisen Season 1"` → 映射为 `sNum=1`，24 集。`死灭回游(2026)` 条目别名含 `"Jujutsu Kaisen Season 3"` → 映射为 `sNum=3`，12 集。
>
> 修复前：`seasonCapacities = {1: 24, 3: 12}` → 无条件求和 `24 + 12 = 36 ≥ 26` → `allSatisfied = true` → 跨季扩展被抑制 → spillover 虽触发但依赖跨季扩展的前置数据，实际匹配残缺。
> 修复后：`sNum ≤ 1` → 仅累加 `24` → `24 < 26` → `allSatisfied = false` → 跨季扩展正确触发。

### 4. maxSeason 计算 — 用 titleMatches 过滤无关搜索结果

**问题**：`maxSeason` 遍历所有源的原始搜索结果，使用 `a.animeTitle || a.title` 提取季号。animeko 的搜索结果字段为 `name/name_cn`（不含 `animeTitle`/`title`），单独使用时提取不到季号，`maxSeason` 保持 1 不触发跨季。但当 renren 同时启用时，其搜索返回与查询无关的条目（如搜"师兄啊师兄"返回"绝世武神 第8季"），被 `a.title` 捕获并将 `maxSeason` 推高至 8，触发 S2~S8 共 7 次完全无效的跨季扩展调用，导致每个源在这些调用中被重复处理。

**修复**：字段覆盖 `a.animeTitle || a.title || a.name || a.name_cn`，使用 `titleMatches(testTitle, queryTitle)` 过滤，仅从与查询相关的条目中提取季号。`titleMatches` 不传 `parsedSeason` 时跳过季号校验（`queryText` 无季号则 `querySeason=null`，第319行 `if` 跳过），允许所有季通过。

**实际案例**：

> 配置 `SOURCE_ORDER=renren,animeko`，查询 `师兄啊师兄 S01E120`
>
> renren 搜索返回 15 条结果但 0 条 `titleMatches` 有效匹配，其中标题含"第8季"的无关条目被提取 `extractSeasonNumberFromAnimeTitle` 得到 `s=8`。
>
> 修复前：`maxSeason=8` → S2~S8 全部触发 → 7 次无效跨季调用，animeko 的 428130/516416 各被请求 7 次，renren 的 handleAnimes 被重复调用 7 次。
> 修复后：`titleMatches("绝世武神 第8季", "师兄啊师兄") === false` → 跳过 → `maxSeason` 不包含该无关条目 → 仅相关条目影响 maxSeason。

---

## 影响范围

| 场景 | 触发条件 | 行为变化 |
|------|------|------|
| seasonMap 同季号多候选 | 搜到剧场版+TV系列 | **修复：TV系列覆盖剧场版，不再被毒化** |
| 360 聚合源搜索 | SOURCE_ORDER 包含 360 | **修复：96→24 集，跨季映射正常** |
| 跳跃季容量误判 | 别名含大季号（如 Season 3） | **修复：跳跃季不独立计入，正确触发扩展** |
| 正常单源搜索 | dandan/bahamut 等 | 不受影响（每个集号唯一，零过滤） |
| 综艺 `第X期` | `期 ∉ [集话回]` | 不受影响（`null` → 全部保留） |
| 电影 `剧场版` | `extractEpisodeNumberFromTitle` 返回 null | 不受影响 |
| FongMi 客户端 | filterSameEpisodeTitle 去重 | 同号集去重，每条集唯一，正常 |
| 多源启用且某源返回无关条目 | renren + animeko 等组合 | **修复：无关条目不推高 maxSeason，无效跨季扩展被消除** |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/apis/dandan-api.js` | findCrossSeasonEpisodeMap seasonMap 集数比较、filterSameEpisodeTitle 集号去重、checkEpisodeSatisfied 容��求和季号过滤、maxSeason 用 titleMatches 过滤无关条目 |
