### PR TITLE
fix: 修复 Bangumi-Data 检索子串混淆与尾部数字误识别为季号，使高达00正确匹配而非高达0079

### DIFF
--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -431,8 +431,13 @@ export function extractSeasonNumberFromAnimeTitle(animeTitle) {
   // 4) 尾部阿拉伯数字（如"某某 2" 或 "某某2"，但不超过2位）
   const trailingNumber = titleWithoutYear.match(/(?:^|\s|[^\d])(\d{1,2})$/);
   if (trailingNumber) {
+    const season = parseInt(trailingNumber[1], 10);
+    // 尾部"00"等不合法的季号不视为季数标识（如"机动战士高达00"）
+    if (season === 0) {
+      return { season: null, baseTitle: titleWithoutYear };
+    }
     return {
-      season: parseInt(trailingNumber[1], 10),
+      season,
       baseTitle: titleWithoutYear.slice(0, titleWithoutYear.lastIndexOf(trailingNumber[1])).trim(),
     };
   }

--- a/danmu_api/utils/tmdb-util.js
+++ b/danmu_api/utils/tmdb-util.js
@@ -216,6 +216,16 @@ export async function getTmdbJaOriginalTitle(title, signal = null, sourceLabel =
   if (globals.useBangumiData) {
     const localMatches = await searchBangumiData(cleanTitle, ['tmdb', 'bangumi', 'anidb']);
     if (localMatches && localMatches.length > 0) {
+      // 按精确度排序：将正好匹配检索词的条目排在前面，避免子串混淆（如 "机动战士高达00" 匹配到 "机动战士高达0079"）
+      if (localMatches.length > 1) {
+        localMatches.sort((a, b) => {
+          const aExact = a.titles.some(t => t === cleanTitle);
+          const bExact = b.titles.some(t => t === cleanTitle);
+          if (aExact && !bExact) return -1;
+          if (!aExact && bExact) return 1;
+          return 0;
+        });
+      }
       const m = localMatches[0]; // 取第一个最佳匹配
       const displayTitle = m.titles.find(t => t && t.includes(cleanTitle)) || m.titles[1] || m.title;
       const jaOriginalTitle = m.title; // Bangumi Data 的主标题就是原名


### PR DESCRIPTION
## Summary

完善 `match` 接口在 Bangumi-Data 本地加速检索与季号提取两个维度的匹配正确性：

1. **Bangumi-Data 检索子串混淆**：`getTmdbJaOriginalTitle` 取首个结果时未按精确度排序，检索词被较长别名子串包含时错误选中（如 `"机动战士高达00"` 匹配到 `"机动战士高达0079"`）。
2. **尾部数字误识别为季号**：`extractSeasonNumberFromAnimeTitle` 规则4（尾部阿拉伯数字）将 `"00"` 解析为 `season=0`，导致标题含 `"00"` 的条目（如 `"机动战士高达00"`）被季号过滤器误过滤。

---

## 修复明细

### 1. getTmdbJaOriginalTitle — 对 Bangumi-Data 结果按精确度排序

**问题**：`searchBangumiData` 按数据文件原始顺序返回结果。`getTmdbJaOriginalTitle` 取 `localMatches[0]` 作为最佳匹配，但当检索词恰好是某个较长别名的子串时（如 `"机动战士高达0079"` 包含 `"机动战士高达00"`），错误选中子串包含条目而非精确匹配条目。

**修复**：取首个结果前，将 `titles` 中恰好等于检索词的条目排在最前。无精确匹配时维持原始顺序。

**实际案例**：

> 配置 `USE_BANGUMI_DATA=true`，查询 `机动战士高达00 S01E025`
>
> Bangumi-Data 中同时存在：
> - `機動戦士ガンダム` (1979)，别名含 `"机动战士高达0079"`
> - `機動戦士ガンダム00` (2007)，别名含 `"机动战士高达00"`
>
> 修复前：0079 条目在数据文件中排在 00 之前 → `localMatches[0]` 选中 0079 → 日语原名错误提取为 `機動戦士ガンダム`(非00) → bahamut 使用错误日语名搜索 → 大量 0079 结果污染匹配列表。
> 修复后：`"机动战士高达00"` 与 00 条目的别名精确相等 → 排序到第一位 → 日语原名正确提取为 `機動戦士ガンダム00`。

### 2. extractSeasonNumberFromAnimeTitle — 尾部 "00" 等不合法季号不视为季数

**问题**：规则4（尾部阿拉伯数字 `/^(?:^|\s|[^\d])(\d{1,2})$/`）对 `"机动战士高达00"` 匹配到 `"达00"` 中的 `"00"`，`parseInt("00")=0` 返回 `season=0`。在 `handleAnimes` 季号过滤中，`s=0 ≠ 1` 且 `s ≠ null`，条目被错误丢弃。

**修复**：尾部数字解析为 0 时返回 `{season: null}`，因为动画领域不存在"第 0 季"。不影响合法季号（`1`~`99`）的正常提取。

**实际案例**：

> 配置 `USE_BANGUMI_DATA=true`，查询 `机动战士高达00 S01E025`
>
> dandan 的 Bangumi-Data 搜索返回 8 条结果，其中 animeId=5252（`机动战士高达00` TV 系列）的 `animeTitle="机动战士高达00"`。
>
> 修复前：`extractSeasonNumberFromAnimeTitle("机动战士高达00")` → `season=0` → 季号过滤 `0≠1` → 5252 被丢弃 → 匹配链路中仅有 0079 等条目 → 最终匹配到 0079 的 E25。
> 修复后：`season=null` → 季号过滤 `null` 对 `querySeason=1` 通过 → 5252 正常参与匹配 → `matchAniAndEp` 评分选择正确条目。

---

## 影响范围

| 场景 | 触发条件 | 行为变化 |
|------|------|------|
| 标题尾部含 "00" | `机动战士高达00`、`代号00` 等 | **修复：season 返回 null 而非 0，不被季号过滤误丢弃** |
| 标题尾部合法数字 | `某某 2`、`第三季` | 不受影响（`2`~`99` 正常解析） |
| Bangumi-Data 子串混淆 | 检索词是较长时间别名的子串 | **修复：精确匹配条目优先于子串包含条目** |
| 无精确匹配 | 任意检索词无完全匹配的条目 | 不受影响（维持原始数据顺序） |
| 合法 Season 0 | 不存在 | 不受影响 |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/utils/tmdb-util.js` | getTmdbJaOriginalTitle 精确度排序 |
| `danmu_api/utils/common-util.js` | extractSeasonNumberFromAnimeTitle 尾部 "00" 不视为季号 |
