### PR TITLE
fix(hongguo): 修改红果 API 主机名

### DIFF
--- a/danmu_api/sources/hongguo.js
+++ b/danmu_api/sources/hongguo.js
@@ -19,7 +19,7 @@ import { titleMatches } from "../utils/common-util.js";
 import { SegmentListResponse } from "../models/dandan-model.js";
 
 const CLIENT_CONFIG = {
-  apiHost: "api5-normal-sinfonlineb.fqnovel.com",
+  apiHost: "api5-normal-sinfonlinea.fqnovel.com",
   baseQuery: {
     iid: "4439167111854618",
     device_id: "4439167111850522",


### PR DESCRIPTION
api5-normal-sinfonlineb.fqnovel.com 不处理红果 (aid=8662)的请求，改为 api5-normal-sinfonlinea.fqnovel.com