### PR TITLE
fix(iqiyi): 优化分季URL请求数，分集异常时自动重试

### DIFF
--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -24,7 +24,7 @@ export default class IqiyiSource extends BaseSource {
    */
   async search(keyword) {
     try {
-      log("info", `[iQiyi] 开始搜索: ${keyword}`);
+      log("info", `[iqiyi] 开始搜索: ${keyword}`);
 
       // 使用桌面版 API 搜索
       const params = {
@@ -74,25 +74,25 @@ export default class IqiyiSource extends BaseSource {
       let data = await doSearch();
       for (let attempt = 0; attempt < MAX_RETRIES && (!data || data.code === "-1"); attempt++) {
         const reason = !data ? "搜索响应为空" : `搜索接口风控 (code=${data.code})`;
-        log("info", `[iQiyi] ${reason}，等待 3 秒后重试 (${attempt + 1}/${MAX_RETRIES})`);
+        log("info", `[iqiyi] ${reason}，等待 3 秒后重试 (${attempt + 1}/${MAX_RETRIES})`);
         await new Promise(r => setTimeout(r, 3000));
         data = await doSearch();
       }
 
       if (!data) {
-        log("info", "[iQiyi] 搜索响应为空");
+        log("info", "[iqiyi] 搜索响应为空");
         return [];
       }
 
       if (data.code === "-1") {
-        log("info", "[iQiyi] 搜索接口风控 (code=-1)，重试后仍失败");
-        log("info", `[iQiyi] 搜索原始数据: ${JSON.stringify(data)}`);
+        log("info", "[iqiyi] 搜索接口风控 (code=-1)，重试后仍失败");
+        log("info", `[iqiyi] 搜索原始数据: ${JSON.stringify(data)}`);
         return [];
       }
 
       if (!data.data || !data.data.templates) {
-        log("info", "[iQiyi] 搜索无结果");
-        log("info", `[iQiyi] 搜索原始数据: ${JSON.stringify(data)}`);
+        log("info", "[iqiyi] 搜索无结果");
+        log("info", `[iqiyi] 搜索原始数据: ${JSON.stringify(data)}`);
         return [];
       }
 
@@ -105,12 +105,12 @@ export default class IqiyiSource extends BaseSource {
 
         // 优先处理意图卡片 (template 112)
         if (template.template === 112 && template.intentAlbumInfos) {
-          log("info", `[iQiyi] 找到意图卡片 (template 112)，处理 ${template.intentAlbumInfos.length} 个结果`);
+          log("info", `[iqiyi] 找到意图卡片 (template 112)，处理 ${template.intentAlbumInfos.length} 个结果`);
           albumsToProcess = template.intentAlbumInfos;
         }
         // 然后处理普通结果卡片
         else if ([101, 102, 103].includes(template.template) && template.albumInfo) {
-          log("info", `[iQiyi] 找到普通结果卡片 (template ${template.template})`);
+          log("info", `[iqiyi] 找到普通结果卡片 (template ${template.template})`);
           albumsToProcess = [template.albumInfo];
         }
 
@@ -122,11 +122,11 @@ export default class IqiyiSource extends BaseSource {
         }
       }
 
-      log("info", `[iQiyi] 搜索找到 ${results.length} 个有效结果`);
+      log("info", `[iqiyi] 搜索找到 ${results.length} 个有效结果`);
       return results;
 
     } catch (error) {
-      log("error", "[iQiyi] 搜索出错:", error.message);
+      log("error", "[iqiyi] 搜索出错:", error.message);
       return [];
     }
   }
@@ -144,7 +144,7 @@ export default class IqiyiSource extends BaseSource {
 
     // 过滤外站付费播放
     if (album.btnText === '外站付费播放') {
-      log("info", `[iQiyi] 过滤掉外站付费播放内容: ${album.title}`);
+      log("info", `[iqiyi] 过滤掉外站付费播放内容: ${album.title}`);
       return null;
     }
 
@@ -192,7 +192,7 @@ export default class IqiyiSource extends BaseSource {
     if (mediaType.includes("电影")) {
       const qipuId = album.qipuId || album.playQipuId;
       if (!qipuId) {
-        log("info", `[iQiyi] 电影缺少 qipuId: ${album.title}`);
+        log("info", `[iqiyi] 电影缺少 qipuId: ${album.title}`);
         return null;
       }
 
@@ -221,13 +221,13 @@ export default class IqiyiSource extends BaseSource {
     // 非电影类型：从 pageUrl 提取 link_id
     const url = album.pageUrl;
     if (!url) {
-      log("info", `[iQiyi] 非电影内容缺少 pageUrl: ${album.title}`);
+      log("info", `[iqiyi] 非电影内容缺少 pageUrl: ${album.title}`);
       return null;
     }
 
     const linkIdMatch = url.match(/v_(\w+?)\.html/);
     if (!linkIdMatch) {
-      log("info", `[iQiyi] 无法从 pageUrl 提取 link_id: ${url}`);
+      log("info", `[iqiyi] 无法从 pageUrl 提取 link_id: ${url}`);
       return null;
     }
     const linkId = linkIdMatch[1];
@@ -273,25 +273,27 @@ export default class IqiyiSource extends BaseSource {
   /**
    * 获取分集列表
    * @param {string} id - 视频 ID (link_id 或 movie_qipuId)
+   * @param {number|null} querySeason - 目标季，指定时只获取该季分集
+   * @param {Map|null} seasonAlbumCache - 跨多次调用共享的分季数据缓存，避免同一 album 重复请求
    * @returns {Promise<Array>} 分集列表
    */
-  async getEpisodes(id) {
+  async getEpisodes(id, querySeason = null, seasonAlbumCache = null) {
     try {
-      log("info", `[iQiyi] 获取分集列表: media_id=${id}`);
+      log("info", `[iqiyi] 获取分集列表: media_id=${id}`);
 
       // 检查是否是电影类型（以 movie_ 开头）
       if (id.startsWith('movie_')) {
         const qipuId = id.substring(6); // 移除 "movie_" 前缀
-        log("info", `[iQiyi] 电影类型，调用 base_info API 获取视频ID: qipuId=${qipuId}`);
+        log("info", `[iqiyi] 电影类型，调用 base_info API 获取视频ID: qipuId=${qipuId}`);
 
         // 调用 base_info API 获取电影详情
         const videoId = await this._getMovieVideoId(qipuId);
         if (!videoId) {
-          log("error", `[iQiyi] 无法获取电影的视频ID: qipuId=${qipuId}`);
+          log("error", `[iqiyi] 无法获取电影的视频ID: qipuId=${qipuId}`);
           return [];
         }
 
-        log("info", `[iQiyi] 电影视频ID: ${videoId}`);
+        log("info", `[iqiyi] 电影视频ID: ${videoId}`);
         return [{
           id: videoId,
           title: "正片",
@@ -303,7 +305,7 @@ export default class IqiyiSource extends BaseSource {
       // 第一步：将 video_id 转换为 entity_id
       const entityId = /^\d+$/.test(id) ? id : this._videoIdToEntityId(id);
       if (!entityId) {
-        log("error", `[iQiyi] 无法将 media_id '${id}' 转换为 entity_id`);
+        log("error", `[iqiyi] 无法将 media_id '${id}' 转换为 entity_id`);
         return [];
       }
 
@@ -342,14 +344,14 @@ export default class IqiyiSource extends BaseSource {
       });
 
       if (!response || !response.data) {
-        log("error", "[iQiyi] 获取分集响应为空");
+        log("error", "[iqiyi] 获取分集响应为空");
         return [];
       }
 
       const data = typeof response.data === "string" ? JSON.parse(response.data) : response.data;
 
       if (data.status_code !== 0 || !data.data || !data.data.template) {
-        log("error", `[iQiyi] API 返回错误，status_code: ${data.status_code}`);
+        log("error", `[iqiyi] API 返回错误，status_code: ${data.status_code}`);
         return [];
       }
 
@@ -358,21 +360,22 @@ export default class IqiyiSource extends BaseSource {
       const tabs = data.data.template.tabs || [];
 
       if (tabs.length === 0) {
-        log("info", "[iQiyi] 未找到分集标签页");
+        log("info", "[iqiyi] 未找到分集标签页");
         return [];
       }
 
       const blocks = tabs[0].blocks || [];
       let foundEpisodes = false;
+      const fetchedSeasons = seasonAlbumCache || new Map();
 
       for (const block of blocks) {
         // 查找 video_list 类型的块（新版API）
         if (block.bk_type === "video_list" && block.data?.data) {
-          log("info", `[iQiyi] 找到 video_list 类型的分集数据块, bk_id: ${block.bk_id}`);
+          log("info", `[iqiyi] 找到 video_list 类型的分集数据块, bk_id: ${block.bk_id}`);
 
           // 检查是否是分集选择器块
           if (!block.tag || !block.tag.includes("episodes")) {
-            log("info", `[iQiyi] 跳过非分集块: ${block.bk_id}`);
+            log("info", `[iqiyi] 跳过非分集块: ${block.bk_id}`);
             continue;
           }
 
@@ -380,7 +383,7 @@ export default class IqiyiSource extends BaseSource {
 
           const dataGroups = block.data.data;
           if (!Array.isArray(dataGroups)) {
-            log("warn", "[iQiyi] data.data 不是数组，跳过此块");
+            log("warn", "[iqiyi] data.data 不是数组，跳过此块");
             continue;
           }
 
@@ -424,21 +427,40 @@ export default class IqiyiSource extends BaseSource {
         }
         // 兼容旧版 API 的 album_episodes 类型
         else if (block.bk_type === "album_episodes" && block.data?.data) {
-          log("info", "[iQiyi] 找到 album_episodes 类型的分集数据块");
+          log("info", "[iqiyi] 找到 album_episodes 类型的分集数据块");
           foundEpisodes = true;
 
           const episodeGroups = block.data.data;
           for (const group of episodeGroups) {
+            // 指定季时只处理目标季的分季组，避免拉取并合并无关季的分集
+            if (querySeason !== null && group.tab_name) {
+              const groupSeason = getExplicitSeasonNumber(group.tab_name);
+              if (groupSeason !== null && groupSeason !== querySeason) continue;
+            }
+
             let videosData = group.videos;
 
-            // 如果 videos 是 URL，需要额外请求
+            // 分季数据是 URL 时需额外请求；以 album_id 为键复用已获取或正在获取的请求，
+            // 避免同一次搜索内同一分季被并发或重复请求
             if (typeof videosData === 'string') {
-              log("info", `[iQiyi] 发现分季URL，正在获取: ${videosData}`);
+              const albumIdMatch = videosData.match(/album_id=(\d+)/);
+              const albumIdKey = albumIdMatch ? albumIdMatch[1] : videosData;
+              let seasonPromise = fetchedSeasons.get(albumIdKey);
+              if (!seasonPromise) {
+                seasonPromise = (async () => {
+                  log("info", `[iqiyi] 发现分季URL，正在获取: ${videosData}`);
+                  const seasonResponse = await httpGet(videosData);
+                  return typeof seasonResponse.data === "string" ? JSON.parse(seasonResponse.data) : seasonResponse.data;
+                })();
+                fetchedSeasons.set(albumIdKey, seasonPromise);
+              } else {
+                log("info", `[iqiyi] 分季URL已获取过，跳过重复请求: ${albumIdKey}`);
+              }
               try {
-                const seasonResponse = await httpGet(videosData);
-                videosData = typeof seasonResponse.data === "string" ? JSON.parse(seasonResponse.data) : seasonResponse.data;
+                videosData = await seasonPromise;
               } catch (error) {
-                log("error", `[iQiyi] 获取分季数据失败: ${error.message}`);
+                fetchedSeasons.delete(albumIdKey);
+                log("error", `[iqiyi] 获取分季数据失败: ${error.message}`);
                 continue;
               }
             }
@@ -480,7 +502,7 @@ export default class IqiyiSource extends BaseSource {
       }
 
       if (!foundEpisodes) {
-        log("info", "[iQiyi] 未找到分集数据块");
+        log("info", "[iqiyi] 未找到分集数据块");
         return [];
       }
 
@@ -490,11 +512,11 @@ export default class IqiyiSource extends BaseSource {
       );
       uniqueEpisodes.sort((a, b) => a.order - b.order);
 
-      log("info", `[iQiyi] 成功获取 ${uniqueEpisodes.length} 个分集`);
+      log("info", `[iqiyi] 成功获取 ${uniqueEpisodes.length} 个分集`);
       return uniqueEpisodes;
 
     } catch (error) {
-      log("error", "[iQiyi] 获取分集出错:", error.message);
+      log("error", "[iqiyi] 获取分集出错:", error.message);
       return [];
     }
   }
@@ -533,7 +555,7 @@ export default class IqiyiSource extends BaseSource {
       const queryString = buildQueryString(params);
       const url = `https://mesh.if.iqiyi.com/tvg/v2/lw/base_info?${queryString}`;
 
-      log("info", `[iQiyi] 请求电影详情: ${url}`);
+      log("info", `[iqiyi] 请求电影详情: ${url}`);
 
       const response = await httpGet(url, {
         headers: {
@@ -545,7 +567,7 @@ export default class IqiyiSource extends BaseSource {
       });
 
       if (!response || !response.data) {
-        log("error", "[iQiyi] base_info API 响应为空");
+        log("error", "[iqiyi] base_info API 响应为空");
         return null;
       }
 
@@ -560,7 +582,7 @@ export default class IqiyiSource extends BaseSource {
         if (baseData.share_url) {
           const match = baseData.share_url.match(/v_(\w+)\.html/);
           if (match) {
-            log("info", `[iQiyi] 从 share_url 提取视频ID: ${match[1]}`);
+            log("info", `[iqiyi] 从 share_url 提取视频ID: ${match[1]}`);
             return match[1];
           }
         }
@@ -569,19 +591,19 @@ export default class IqiyiSource extends BaseSource {
         if (baseData.page_url) {
           const match = baseData.page_url.match(/v_(\w+)\.html/);
           if (match) {
-            log("info", `[iQiyi] 从 page_url 提取视频ID: ${match[1]}`);
+            log("info", `[iqiyi] 从 page_url 提取视频ID: ${match[1]}`);
             return match[1];
           }
         }
       }
 
       // 所有尝试均失败，使用 qipuId（entity_id）作为视频ID
-      log("info", `[iQiyi] 响应中未找到 v_xxx 格式视频ID，使用 entity_id: ${qipuId}`);
-      log("info", `[iQiyi] 响应数据结构: ${JSON.stringify(data).substring(0, 1000)}...`);
+      log("info", `[iqiyi] 响应中未找到 v_xxx 格式视频ID，使用 entity_id: ${qipuId}`);
+      log("info", `[iqiyi] 响应数据结构: ${JSON.stringify(data).substring(0, 1000)}...`);
       return qipuId;
 
     } catch (error) {
-      log("error", `[iQiyi] 获取电影视频ID时出错: ${error.message}`);
+      log("error", `[iqiyi] 获取电影视频ID时出错: ${error.message}`);
       return null;
     }
   }
@@ -598,7 +620,7 @@ export default class IqiyiSource extends BaseSource {
       const finalResult = xorResult < 900000 ? 100 * (xorResult + 900000) : xorResult;
       return String(finalResult);
     } catch (error) {
-      log("error", `[iQiyi] 将 video_id '${videoId}' 转换为 entity_id 时出错: ${error.message}`);
+      log("error", `[iqiyi] 将 video_id '${videoId}' 转换为 entity_id 时出错: ${error.message}`);
       return null;
     }
   }
@@ -670,7 +692,7 @@ export default class IqiyiSource extends BaseSource {
 
     // 添加错误处理，确保sourceAnimes是数组
     if (!sourceAnimes || !Array.isArray(sourceAnimes)) {
-      log("error", "[iQiyi] sourceAnimes is not a valid array");
+      log("error", "[iqiyi] sourceAnimes is not a valid array");
       return [];
     }
 
@@ -689,13 +711,15 @@ export default class IqiyiSource extends BaseSource {
       // 如果已命中目标，减少详情请求量
       if (seasonFiltered.length > 0) {
         filteredAnimes = seasonFiltered;
-        log("info", `[iQiyi] 结果已命中目标季(第${resolvedQuerySeason}季)，跳过非目标季相关请求`);
+        log("info", `[iqiyi] 结果已命中目标季(第${resolvedQuerySeason}季)，跳过非目标季相关请求`);
       }
     }
 
+    // 跨多个搜索结果共享分季数据缓存，避免同一 album 的分季URL被重复请求
+    const seasonAlbumCache = new Map();
     const processIqiyiAnimes = await Promise.all(filteredAnimes.map(async (anime) => {
         try {
-          const eps = await this.getEpisodes(anime.mediaId);
+          const eps = await this.getEpisodes(anime.mediaId, resolvedQuerySeason, seasonAlbumCache);
 
           // 格式化分集列表
           const links = [];
@@ -732,7 +756,7 @@ export default class IqiyiSource extends BaseSource {
             }
           }
         } catch (error) {
-          log("error", `[iQiyi] Error processing anime: ${error.message}`);
+          log("error", `[iqiyi] Error processing anime: ${error.message}`);
         }
       })
     );
@@ -742,7 +766,7 @@ export default class IqiyiSource extends BaseSource {
   }
 
   async getEpisodeDanmu(id) {
-    log("info", "[iQiyi] 开始从本地请求爱奇艺弹幕...", id);
+    log("info", "[iqiyi] 开始从本地请求爱奇艺弹幕...", id);
 
     // 获取页面标题
     let res;
@@ -754,14 +778,14 @@ export default class IqiyiSource extends BaseSource {
         },
       });
     } catch (error) {
-      log("error", "[iQiyi] 请求页面失败:", error);
+      log("error", "[iqiyi] 请求页面失败:", error);
       return [];
     }
 
     // 使用正则表达式提取 <title> 标签内容
     const titleMatch = res.data.match(/<title[^>]*>(.*?)<\/title>/i);
     const title = titleMatch ? titleMatch[1].split("_")[0] : "未知标题";
-    log("info", `[iQiyi] 标题: ${title}`);
+    log("info", `[iqiyi] 标题: ${title}`);
 
     // 获取弹幕分段数据
     const segmentResult = await this.getEpisodeDanmuSegments(id);
@@ -770,7 +794,7 @@ export default class IqiyiSource extends BaseSource {
     }
 
     const segmentList = segmentResult.segmentList;
-    log("info", `[iQiyi] 弹幕分段数量: ${segmentList.length}`);
+    log("info", `[iqiyi] 弹幕分段数量: ${segmentList.length}`);
 
     // 创建请求Promise数组
     const promises = [];
@@ -791,7 +815,7 @@ export default class IqiyiSource extends BaseSource {
         contents.push(...data);
       });
     } catch (error) {
-      log("error", "[iQiyi] 解析弹幕数据失败:", error);
+      log("error", "[iqiyi] 解析弹幕数据失败:", error);
       return [];
     }
 
@@ -801,7 +825,7 @@ export default class IqiyiSource extends BaseSource {
   }
 
   async getEpisodeDanmuSegments(id) {
-    log("info", "[iQiyi] 获取爱奇艺视频弹幕分段列表...", id);
+    log("info", "[iqiyi] 获取爱奇艺视频弹幕分段列表...", id);
 
     // 弹幕 API 基础地址
     const api_decode_base = "https://pcw-api.iq.com/api/decode/";
@@ -812,14 +836,14 @@ export default class IqiyiSource extends BaseSource {
     try {
       const idMatch = id.match(/v_(\w+)/);
       if (!idMatch) {
-        log("error", "[iQiyi] 无法从 URL 中提取 tvid");
+        log("error", "[iqiyi] 无法从 URL 中提取 tvid");
         return new SegmentListResponse({
           "type": "qiyi",
           "segmentList": []
         });
       }
       tvid = idMatch[1];
-      log("info", `[iQiyi] tvid: ${tvid}`);
+      log("info", `[iqiyi] tvid: ${tvid}`);
       originalTvid = tvid; // 保存原始 tvid，用于解码失败回退
 
       // 获取 tvid 的解码信息
@@ -832,9 +856,9 @@ export default class IqiyiSource extends BaseSource {
       });
       const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
       tvid = data.data.toString();
-      log("info", `[iQiyi] 解码后 tvid: ${tvid}`);
+      log("info", `[iqiyi] 解码后 tvid: ${tvid}`);
     } catch (error) {
-      log("error", "[iQiyi] 请求解码信息失败:", error);
+      log("error", "[iqiyi] 请求解码信息失败:", error);
       return new SegmentListResponse({
         "type": "qiyi",
         "segmentList": []
@@ -855,21 +879,21 @@ export default class IqiyiSource extends BaseSource {
       const videoInfo = data.data;
       duration = Number(videoInfo.durationSec) || 0;
       if (videoInfo.displayBarrage === false) {
-        log("info", "[iQiyi] 爱奇艺视频未开启弹幕");
+        log("info", "[iqiyi] 爱奇艺视频未开启弹幕");
         return new SegmentListResponse({
           "type": "qiyi",
           "duration": duration,
           "segmentList": []
         });
       }
-      log("info", `[iQiyi] 时长: ${duration}`);
+      log("info", `[iqiyi] 时长: ${duration}`);
     } catch (error) {
-      log("error", "[iQiyi] 请求视频基础信息失败:", error);
+      log("error", "[iqiyi] 请求视频基础信息失败:", error);
     }
 
     // decode API 输出的 tvid 无效时（duration=0 或请求失败），用原始 tvid 重试
     if (!duration && originalTvid && originalTvid !== tvid) {
-      log("info", `[iQiyi] decode 后 tvid 无效，用原始 tvid 重试: ${originalTvid}`);
+      log("info", `[iqiyi] decode 后 tvid 无效，用原始 tvid 重试: ${originalTvid}`);
       try {
         const retryUrl = `${api_video_info}${originalTvid}`;
         const retryRes = await httpGet(retryUrl, {
@@ -883,10 +907,10 @@ export default class IqiyiSource extends BaseSource {
         if (retryDuration > 0) {
           tvid = originalTvid;
           duration = retryDuration;
-          log("info", `[iQiyi] 原始 tvid 有效，时长: ${duration}`);
+          log("info", `[iqiyi] 原始 tvid 有效，时长: ${duration}`);
         }
       } catch (retryError) {
-        log("error", "[iQiyi] 原始 tvid 重试也失败:", retryError);
+        log("error", "[iqiyi] 原始 tvid 重试也失败:", retryError);
       }
     }
     if (!duration) {
@@ -899,7 +923,7 @@ export default class IqiyiSource extends BaseSource {
     // 当前爱奇艺弹幕分片按 60 秒切片，并使用 md5 后缀校验。
     const segmentDuration = 60;
     const page = Math.ceil(duration / segmentDuration);
-    log("info", `[iQiyi] 弹幕分段数量: ${page}`);
+    log("info", `[iqiyi] 弹幕分段数量: ${page}`);
 
     // 构建分段列表
     const segmentList = [];
@@ -950,7 +974,7 @@ export default class IqiyiSource extends BaseSource {
 
       return this._parseIqiyiProtoDanmu(payload);
     } catch (error) {
-      log("error", "[iQiyi] 请求分片弹幕失败:", error);
+      log("error", "[iqiyi] 请求分片弹幕失败:", error);
       return []; // 返回空数组而不是抛出错误，保持与getEpisodeDanmu一致的行为
     }
   }

--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -277,7 +277,7 @@ export default class IqiyiSource extends BaseSource {
    * @param {Map|null} seasonAlbumCache - 跨多次调用共享的分季数据缓存，避免同一 album 重复请求
    * @returns {Promise<Array>} 分集列表
    */
-  async getEpisodes(id, querySeason = null, seasonAlbumCache = null) {
+  async getEpisodes(id, querySeason = null, seasonAlbumCache = null, inlinedAlbumIds = null, baseInfoCache = null) {
     try {
       log("info", `[iqiyi] 获取分集列表: media_id=${id}`);
 
@@ -302,67 +302,21 @@ export default class IqiyiSource extends BaseSource {
         }];
       }
 
-      // 第一步：将 video_id 转换为 entity_id
+      // 将 video_id 转换为 entity_id
       const entityId = /^\d+$/.test(id) ? id : this._videoIdToEntityId(id);
       if (!entityId) {
         log("error", `[iqiyi] 无法将 media_id '${id}' 转换为 entity_id`);
         return [];
       }
 
-      // 第二步：构建 API 请求参数
-      const params = {
-        entity_id: entityId,
-        device_id: 'qd5fwuaj4hunxxdgzwkcqmefeb3ww5hx',
-        auth_cookie: '',
-        user_id: '0',
-        vip_type: '-1',
-        vip_status: '0',
-        conduit_id: '',
-        pcv: '13.082.22866',
-        app_version: '13.082.22866',
-        ext: '',
-        app_mode: 'standard',
-        scale: '100',
-        timestamp: String(Date.now()),
-        src: 'pca_tvg',
-        os: '',
-        ad_ext: '{"r":"2.2.0-ares6-pure"}'
-      };
-
-      // 生成签名
-      params.sign = this._createSign(params);
-
-      // 第三步：请求 API
-      const queryString = buildQueryString(params);
-      const url = `https://www.iqiyi.com/prelw/tvg/v2/lw/base_info?${queryString}`;
-
-      // base_info 接口可能返回空响应或结构残缺的响应，此处最多重试两次再放弃
-      const MAX_EPISODE_RETRIES = 2;
-      const fetchEpisodeData = async () => {
-        try {
-          const resp = await httpGet(url, {
-            headers: {
-              'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-              'Referer': 'https://www.iqiyi.com/'
-            }
-          });
-          if (!resp || !resp.data) return null;
-          return typeof resp.data === "string" ? JSON.parse(resp.data) : resp.data;
-        } catch (error) {
-          log("error", `[iqiyi] 获取分集列表请求失败: ${error.message}`);
-          return null;
-        }
-      };
-
-      let data = await fetchEpisodeData();
-      for (let attempt = 0; attempt < MAX_EPISODE_RETRIES && (!data || data.status_code !== 0 || !data.data || !data.data.template); attempt++) {
-        log("info", `[iqiyi] 分集接口返回异常${data ? ` (status_code: ${data.status_code})` : " (响应为空或解析失败)"}，等待 3 秒后重试 (${attempt + 1}/${MAX_EPISODE_RETRIES})`);
-        await new Promise(r => setTimeout(r, 3000));
-        data = await fetchEpisodeData();
+      // 分集列表数据；本次搜索已在 handleAnimes 中统一拉取时直接复用，避免重复请求
+      let data;
+      if (baseInfoCache && baseInfoCache.has(id)) {
+        data = baseInfoCache.get(id);
+      } else {
+        data = await this._fetchBaseInfoData(entityId);
       }
-
       if (!data || data.status_code !== 0 || !data.data || !data.data.template) {
-        log("error", `[iqiyi] 获取分集列表失败: ${data ? `status_code: ${data.status_code}` : "响应为空或解析失败"}`);
         return [];
       }
 
@@ -454,8 +408,13 @@ export default class IqiyiSource extends BaseSource {
             // 分季数据是 URL 时需额外请求；以 album_id 为键复用已获取或正在获取的请求，
             // 避免同一次搜索内同一分季被并发或重复请求
             if (typeof videosData === 'string') {
-              const albumIdMatch = videosData.match(/album_id=(\d+)/);
-              const albumIdKey = albumIdMatch ? albumIdMatch[1] : videosData;
+              // 该季的 album_id 已通过其它结果的 album_episodes 内联数据获取时，无需再请求分季URL
+              const groupAlbumId = group.entity_id ? String(group.entity_id) : (videosData.match(/album_id=(\d+)/)?.[1] || videosData);
+              if (inlinedAlbumIds && inlinedAlbumIds.has(groupAlbumId)) {
+                log("info", `[iqiyi] 该季分集已通过内联数据获取，跳过分季URL: ${groupAlbumId}`);
+                continue;
+              }
+              const albumIdKey = groupAlbumId;
               let seasonPromise = fetchedSeasons.get(albumIdKey);
               if (!seasonPromise) {
                 seasonPromise = (async () => {
@@ -530,6 +489,98 @@ export default class IqiyiSource extends BaseSource {
       log("error", "[iqiyi] 获取分集出错:", error.message);
       return [];
     }
+  }
+
+  /**
+   * 请求分集列表接口并解析响应，接口返回空响应或结构残缺时最多重试两次
+   * @param {string} entityId - 实体 id
+   * @returns {Promise<Object|null>} 解析后的响应数据，失败返回 null
+   */
+  async _fetchBaseInfoData(entityId) {
+    const params = {
+      entity_id: entityId,
+      device_id: 'qd5fwuaj4hunxxdgzwkcqmefeb3ww5hx',
+      auth_cookie: '',
+      user_id: '0',
+      vip_type: '-1',
+      vip_status: '0',
+      conduit_id: '',
+      pcv: '13.082.22866',
+      app_version: '13.082.22866',
+      ext: '',
+      app_mode: 'standard',
+      scale: '100',
+      timestamp: String(Date.now()),
+      src: 'pca_tvg',
+      os: '',
+      ad_ext: '{"r":"2.2.0-ares6-pure"}'
+    };
+    params.sign = this._createSign(params);
+
+    const queryString = buildQueryString(params);
+    const url = `https://www.iqiyi.com/prelw/tvg/v2/lw/base_info?${queryString}`;
+
+    // base_info 接口可能返回空响应或结构残缺的响应，此处最多重试两次再放弃
+    const MAX_EPISODE_RETRIES = 2;
+    const fetchEpisodeData = async () => {
+      try {
+        const resp = await httpGet(url, {
+          headers: {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+            'Referer': 'https://www.iqiyi.com/'
+          }
+        });
+        if (!resp || !resp.data) return null;
+        return typeof resp.data === "string" ? JSON.parse(resp.data) : resp.data;
+      } catch (error) {
+        log("error", `[iqiyi] 获取分集列表请求失败: ${error.message}`);
+        return null;
+      }
+    };
+
+    let data = await fetchEpisodeData();
+    for (let attempt = 0; attempt < MAX_EPISODE_RETRIES && (!data || data.status_code !== 0 || !data.data || !data.data.template); attempt++) {
+      log("info", `[iqiyi] 分集接口返回异常${data ? ` (status_code: ${data.status_code})` : " (响应为空或解析失败)"}，等待 3 秒后重试 (${attempt + 1}/${MAX_EPISODE_RETRIES})`);
+      await new Promise(r => setTimeout(r, 3000));
+      data = await fetchEpisodeData();
+    }
+
+    if (!data || data.status_code !== 0 || !data.data || !data.data.template) {
+      log("error", `[iqiyi] 获取分集列表失败: ${data ? `status_code: ${data.status_code}` : "响应为空或解析失败"}`);
+      return null;
+    }
+    return data;
+  }
+
+  /**
+   * 全季搜索时统一拉取各结果的分集列表，收集其中以内联方式返回的季 album_id；
+   * 这些季无需再经分季URL获取，供 getEpisodes 判断跳过对应请求
+   * @param {Array} animes - 搜索结果数组
+   * @param {Map} baseInfoCache - 复用已拉取的分集列表数据，避免重复请求
+   * @returns {Promise<Set<string>>} 已被内联的季 album_id 集合
+   */
+  async _collectInlinedAlbumIds(animes, baseInfoCache) {
+    const inlined = new Set();
+    await Promise.all(animes.map(async (anime) => {
+      if (anime.mediaId.startsWith('movie_')) return;
+      const entityId = /^\d+$/.test(anime.mediaId) ? anime.mediaId : this._videoIdToEntityId(anime.mediaId);
+      if (!entityId) return;
+      const data = await this._fetchBaseInfoData(entityId);
+      baseInfoCache.set(anime.mediaId, data);
+      if (!data || !data.data || !data.data.template) return;
+      const tabs = data.data.template.tabs || [];
+      if (tabs.length === 0) return;
+      for (const block of (tabs[0].blocks || [])) {
+        if (block.bk_type === 'album_episodes' && block.data?.data) {
+          for (const group of block.data.data) {
+            if (group.videos && typeof group.videos === 'object' && group.videos.feature_paged && group.entity_id) {
+              inlined.add(String(group.entity_id));
+            }
+          }
+        }
+      }
+    }));
+    return inlined;
   }
 
   /**
@@ -728,9 +779,18 @@ export default class IqiyiSource extends BaseSource {
 
     // 跨多个搜索结果共享分季数据缓存，避免同一 album 的分季URL被重复请求
     const seasonAlbumCache = new Map();
+
+    // 全季搜索时先统一拉取各结果的分集列表，收集已被内联的季 album_id；
+    // 这些季无需再经分季URL获取，后续处理各结果时据此跳过对应请求
+    let inlinedAlbumIds = null;
+    const baseInfoCache = new Map();
+    if (resolvedQuerySeason === null) {
+      inlinedAlbumIds = await this._collectInlinedAlbumIds(filteredAnimes, baseInfoCache);
+    }
+
     const processIqiyiAnimes = await Promise.all(filteredAnimes.map(async (anime) => {
         try {
-          const eps = await this.getEpisodes(anime.mediaId, resolvedQuerySeason, seasonAlbumCache);
+          const eps = await this.getEpisodes(anime.mediaId, resolvedQuerySeason, seasonAlbumCache, inlinedAlbumIds, baseInfoCache);
 
           // 格式化分集列表
           const links = [];

--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -336,22 +336,33 @@ export default class IqiyiSource extends BaseSource {
       const queryString = buildQueryString(params);
       const url = `https://www.iqiyi.com/prelw/tvg/v2/lw/base_info?${queryString}`;
 
-      const response = await httpGet(url, {
-        headers: {
-          'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-          'Referer': 'https://www.iqiyi.com/'
+      // base_info 接口可能返回空响应或结构残缺的响应，此处最多重试两次再放弃
+      const MAX_EPISODE_RETRIES = 2;
+      const fetchEpisodeData = async () => {
+        try {
+          const resp = await httpGet(url, {
+            headers: {
+              'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+              'Referer': 'https://www.iqiyi.com/'
+            }
+          });
+          if (!resp || !resp.data) return null;
+          return typeof resp.data === "string" ? JSON.parse(resp.data) : resp.data;
+        } catch (error) {
+          log("error", `[iqiyi] 获取分集列表请求失败: ${error.message}`);
+          return null;
         }
-      });
+      };
 
-      if (!response || !response.data) {
-        log("error", "[iqiyi] 获取分集响应为空");
-        return [];
+      let data = await fetchEpisodeData();
+      for (let attempt = 0; attempt < MAX_EPISODE_RETRIES && (!data || data.status_code !== 0 || !data.data || !data.data.template); attempt++) {
+        log("info", `[iqiyi] 分集接口返回异常${data ? ` (status_code: ${data.status_code})` : " (响应为空或解析失败)"}，等待 3 秒后重试 (${attempt + 1}/${MAX_EPISODE_RETRIES})`);
+        await new Promise(r => setTimeout(r, 3000));
+        data = await fetchEpisodeData();
       }
 
-      const data = typeof response.data === "string" ? JSON.parse(response.data) : response.data;
-
-      if (data.status_code !== 0 || !data.data || !data.data.template) {
-        log("error", `[iqiyi] API 返回错误，status_code: ${data.status_code}`);
+      if (!data || data.status_code !== 0 || !data.data || !data.data.template) {
+        log("error", `[iqiyi] 获取分集列表失败: ${data ? `status_code: ${data.status_code}` : "响应为空或解析失败"}`);
         return [];
       }
 


### PR DESCRIPTION
## Summary

调整 iqiyi 源 `getEpisodes` 对分季数据的获取策略，覆盖四个维度：

1. **分季范围**：指定季时，`album_episodes` 分支仅处理目标季的分季组，不再拉取并合并无关季。
2. **请求去重**：以 `album_id` 为键在一次搜索内对分季URL请求去重，覆盖单次调用、跨多次调用及并发（`Promise.all`）场景。
3. **接口韧性**：`base_info` 请求在响应为空、解析失败、状态码异常或结构残缺时自动重试，避免单次网络抖动令整季被静默丢弃。
4. **减少冗余请求**：全季搜索且搜索已把每一季作为独立结果返回时，跳过已被其它结果内联覆盖的季的分季URL（selector）请求，集数结果不变，仅减少重复请求。

---

## 改动明细

### 1. album_episodes 分支按目标季过滤

**上游原版行为**：`album_episodes` 分支对每个分季组的 `videos` URL 无差别地发起请求并合并到同一结果。即使搜索层已锁定目标季，该分支仍会拉取并合并所有无关季的分集。

**改动后行为**：`getEpisodes` 新增 `querySeason` 参数，由 `handleAnimes` 透传（解析自搜索词中的季号或显式指定季）。`album_episodes` 分支按每个分季组 `tab_name`（`第一季`/`第三季`…）用 `getExplicitSeasonNumber` 解析季号，指定季时跳过非目标季组。`video_list` 内联分支不受影响。

**实际观察**：

> 搜索 `老友记 第三季`，上游原版在已锁定第 3 季的情况下，仍对每个分季组逐个发起请求并合并全部季分集；改动后仅第 3 季分季组被处理。

### 2. 分季URL 按 album_id 请求去重（跨调用与并发）

**上游原版行为**：搜索返回的多个结果各自触发一次 `getEpisodes`（`handleAnimes` 以 `Promise.all` 并发）。当不同结果指向同一 `album` 时，其分季URL的 `album_id` 在各次调用间重复出现，会各自发起独立请求。同一 `album_id` 在一次搜索内可能被请求多次。

**改动后行为**：`handleAnimes` 每次搜索创建一个 `Map` 缓存并透传给全部 `getEpisodes`；以 `album_id` 为键缓存分季请求本身（首次遇到某 `album_id` 时立即记录 Promise，不等响应返回），并发或后续调用直接复用同一请求，确保同一分季在一次搜索内最多请求一次。命中时复用已获取的分季数据继续处理（而非跳过），各结果仍能拿到对应分集；请求失败则清除占位以允许重试。不指定季时结果集与上游一致，仅减少冗余请求。

**实际观察**：

> 搜索 `老友记` 返回 11 个结果，多个结果指向同一 `album_id=3935124836735401`。上游原版在一次搜索内对该分季URL请求 7~9 次；改动后无论串行、跨调用还是并发，同一 `album_id` 最多请求一次。

### 3. base_info 请求异常重试

**上游原版行为**：`getEpisodes` 对 `base_info` 接口仅请求一次。当响应为空、JSON 解析失败、`status_code` 非 0 或结构残缺（缺失 `data.template`，常见于网络抖动）时直接 `return []`。由于 `handleAnimes` 仅在分集非空时才收录该结果，一次瞬断会令整个季被静默丢弃，需重跑才能恢复。

**改动后行为**：将 `base_info` 的 `httpGet` 与解析封装为 `_fetchBaseInfoData`，对空响应、解析失败、`status_code` 非 0、结构残缺最多重试两次（每次间隔 3 秒），耗尽才返回 `null` 并由 `getEpisodes` 转 `[]`。首请求即成功时循环条件不满足，行为与上游完全一致。`_fetchBaseInfoData` 同时被全季搜索的预拉取阶段复用，避免重复请求同一 `base_info`。

**实际观察**：

> 实跑 `老友记`，某次运行中 `base_info` 返回 `status_code: 0` 但缺失 `data.template`（响应残缺），上游原版直接丢弃该季（`搜索找到 11` 但 `Cached 10 animes`）；重跑即恢复。改动后该次瞬断会被重试吸收，季不再丢失。

### 4. 全季搜索跳过已被内联覆盖的季的分季URL

**上游原版行为**：全季搜索（不指定季）时，`handleAnimes` 对每个搜索结果并发调用 `getEpisodes`。每个 `getEpisodes` 独立请求 `base_info`，而 `base_info` 的 `album_episodes` 块仅内联"当前季"、其余季以分季URL（selector）桩形式存在。因此当搜索已把每一季作为独立结果返回、每季各自内联自己的分集时，某一季的分集既从其所属结果的 `base_info` 内联拿到，又被其它结果里指向该季的桩再次 `selector` 请求——重复搬运同一批数据。上游原版缺乏跨结果的"该季已内联"感知，无法避免这次重复请求。

**改动后行为**：全季搜索时，`handleAnimes` 先统一拉取各结果的 `base_info`（收集为 `inlinedAlbumIds` 集合，记录每季 `album_episodes` 中以内联 `feature_paged` 形式存在、且带有 `entity_id` 的季），并缓存供后续复用以避免重复请求；随后处理各结果时，若某分季组是 URL 桩且其 `entity_id` 已出现在 `inlinedAlbumIds`，说明该季分集已在别的結果内联获取，跳过其 `selector` 请求。指定季时该预拉取阶段不执行、集合为空，桩季照常请求（确保用户指定的季一定返回）。跳过判定以季的 `entity_id` 为键，与按标题分组无关，不会误吞速看/二创等衍生内容，也不会因无关关键词命中而错删数据。

**实际观察**：

> 搜索 `老友记`（全季），上游原版对 10 个分季URL 桩各发起一次 selector；改动后这些季均已通过各季独立结果的 `base_info` 内联覆盖，selector 请求归零，集数完整。对于只返回单个主专辑、各季皆桩、未独立返回的剧，桩季 `entity_id` 不在 `inlinedAlbumIds` 中，仍照常发起 `selector`，不丢季。

---

## 影响范围

| 场景 | 行为变化 |
|------|:--:|
| 指定季查询 | **仅获取目标季分集，不再拉取无关季；预拉取阶段不执行，桩季照常请求** |
| 多结果指向同一 album | **同一分季URL 一次搜索内最多请求一次（含并发）** |
| base_info 单次瞬断 | **自动重试，整季不再因单次失败被静默丢弃** |
| 全季搜索、各季已独立返回 | **已被内联覆盖的季跳过分季URL 请求，集数不变，仅减少冗余请求** |
| 全季搜索、仅返回主专辑（各季皆桩） | **桩季仍发起分季URL 请求，不丢季** |
| video_list 内联分支 | 不受影响 |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/sources/iqiyi.js` | getEpisodes 增加 querySeason / seasonAlbumCache 参数并按 tab_name 季过滤；分季URL 按 album_id 缓存请求 Promise 去重（跨调用与并发）；base_info 请求异常重试两次（封装为 _fetchBaseInfoData 复用）；新增 inlinedAlbumIds / baseInfoCache 参数，全季搜索时由 handleAnimes 先统一拉取 base_info 收集已内联季集合并缓存，处理各结果时跳过已内联覆盖季的分季URL 请求 |
