### PR TITLE
fix: 跨季扩展按平台满足度过滤源并修复恶性重复请求问题

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -258,6 +258,7 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
     let isEpisodeSatisfied = false;
     const seasonCapacities = new Map();
     let platformHasData = false;
+    const providedSources = new Set();
 
     for (const anime of animesList) {
       // 候选平台由番剧身份标签(标题 from 段或 source)与所挂集标签共同决定，使身份名(如tencent)与优选平台名(如qq)不一致但集上挂有目标标签的源也能被正确识别为该平台有数据
@@ -278,6 +279,7 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
       }
 
       platformHasData = true;
+      providedSources.add(anime.source);
 
       if (bData?.success && bData.bangumi?.episodes) {
         const validEps = bData.bangumi.episodes.filter(ep => !globals.episodeTitleFilter.test(ep.episodeTitle));
@@ -321,7 +323,9 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
       }
       if (totalValidEpisodes < queryEpisode) {
         allSatisfied = false;
-        if (unsatisfiedOut) unsatisfiedOut.add(tPlat);
+        if (unsatisfiedOut) {
+          for (const s of providedSources) unsatisfiedOut.add(s);
+        }
       }
     }
   }

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -260,7 +260,18 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
     let platformHasData = false;
 
     for (const anime of animesList) {
-      const actualPlatform = extractPlatformFromTitle(anime.animeTitle) || anime.source;
+      // 候选平台由番剧身份标签(标题 from 段或 source)与所挂集标签共同决定，使身份名(如tencent)与优选平台名(如qq)不一致但集上挂有目标标签的源也能被正确识别为该平台有数据
+      const identityPlatform = extractPlatformFromTitle(anime.animeTitle) || anime.source;
+      const bData = getBangumiDataForMatch(anime, requestAnimeDetailsMap);
+      const epPlatforms = new Set();
+      if (bData?.success && bData.bangumi?.episodes) {
+        for (const ep of bData.bangumi.episodes) {
+          const epPlat = extractEpisodeTitle(ep.episodeTitle);
+          if (epPlat) epPlatforms.add(epPlat);
+        }
+      }
+      const actualPlatform = [...new Set([identityPlatform, ...epPlatforms].filter(Boolean)
+          .flatMap(p => p.split(/[&＆]/).map(s => s.trim().toLowerCase())).filter(s => s))].join('&');
 
       if (tPlat !== '_any_' && getPlatformMatchScore(actualPlatform, tPlat) === 0) {
         continue;
@@ -268,7 +279,6 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
 
       platformHasData = true;
 
-      const bData = getBangumiDataForMatch(anime, requestAnimeDetailsMap);
       if (bData?.success && bData.bangumi?.episodes) {
         const validEps = bData.bangumi.episodes.filter(ep => !globals.episodeTitleFilter.test(ep.episodeTitle));
         const filtered = filterSameEpisodeTitle(validEps);
@@ -1464,10 +1474,15 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
   if (!bestRes.episode && season && episode) {
     const spilloverRes = findCrossSeasonEpisodeMap(searchData, title, year, season, episode, platform, detailStore);
     if (spilloverRes.resEpisode) {
+      // 候选平台由番剧身份标签与命中集所挂平台标签共同决定，与 matchAniAndEp 评分口径保持一致
+      const spillIdentity = extractPlatformFromTitle(spilloverRes.resAnime.animeTitle) || spilloverRes.resAnime.source;
+      const spillEpPlatform = spilloverRes.resEpisode ? extractEpisodeTitle(spilloverRes.resEpisode.episodeTitle) : null;
+      const spillCandidate = [...new Set([spillIdentity, spillEpPlatform].filter(Boolean)
+          .flatMap(p => p.split(/[&＆]/).map(s => s.trim().toLowerCase())).filter(s => s))].join('&');
       bestRes = {
         episode: spilloverRes.resEpisode,
         anime: spilloverRes.resAnime,
-        score: platform ? getPlatformMatchScore(extractPlatformFromTitle(spilloverRes.resAnime.animeTitle) || spilloverRes.resAnime.source, platform) : 1
+        score: platform ? getPlatformMatchScore(spillCandidate, platform) : 1
       };
     }
   }

--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -239,7 +239,7 @@ export function matchSeason(anime, queryTitle, season) {
  * @param {string|null} targetPlatform 期望优先验证的目标平台
  * @returns {boolean} 是否满足需求
  */
-function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAnimeDetailsMap, targetPlatform) {
+function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAnimeDetailsMap, targetPlatform, unsatisfiedOut = null) {
   if (queryEpisode === null || querySeason === null) return true;
 
   let targetPlatforms = [];
@@ -311,7 +311,7 @@ function checkEpisodeSatisfied(animesList, querySeason, queryEpisode, requestAni
       }
       if (totalValidEpisodes < queryEpisode) {
         allSatisfied = false;
-        break;
+        if (unsatisfiedOut) unsatisfiedOut.add(tPlat);
       }
     }
   }
@@ -796,9 +796,10 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
     }
 
     // 判断当前获取的季度是否已包含用户指定的集数
-    const isEpisodeSatisfied = checkEpisodeSatisfied(curAnimes, querySeason, queryEpisode, requestAnimeDetailsMap, targetPlatform);
+    const unsatisfiedPlatforms = new Set();
+    const isEpisodeSatisfied = checkEpisodeSatisfied(curAnimes, querySeason, queryEpisode, requestAnimeDetailsMap, targetPlatform, unsatisfiedPlatforms);
 
-    // 若未包含且用户指定了季度，推导最大季并并行映射 S2、S3 等结果，合并同一次搜索下的后续季以辅助跨季匹配
+    // 若未包含且用户指定了季度，推导最大季并扩展至后续季以辅助跨季匹配
     if (!isEpisodeSatisfied && querySeason !== null) {
       let maxSeason = querySeason;
       for (const source of globals.sourceOrderArr) {
@@ -808,9 +809,9 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
             const list = (item && Array.isArray(item.list)) ? item.list : [item];
             for (const a of list) {
               if (!a) continue;
-              // 仅从与查询相关的条目中提取季号，避免无关源的搜索结果污染 maxSeason
+              // 用titleMatches过滤与查询无关的条目，仅从相关结果中提取季号
               const testTitle = a.animeTitle || a.title || a.name || a.name_cn || "";
-              if (testTitle && !titleMatches(testTitle, queryTitle, null, true)) continue;
+              if (testTitle && !titleMatches(testTitle, queryTitle, null, true, 0.6)) continue;
               const s = extractSeasonNumberFromAnimeTitle(testTitle).season;
               if (s !== null && s > maxSeason) maxSeason = s;
             }
@@ -821,18 +822,25 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       if (maxSeason > querySeason) {
         log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${maxSeason}...`);
         const expandPromises = [];
-        for (let s = querySeason + 1; s <= maxSeason; s++) {
+        for (const source of globals.sourceOrderArr) {
+          if (!resultData[source]) continue;
+          // 在PLATFORM_ORDER模式下，跳过已满足平台的对应源
+          if (targetPlatform && !unsatisfiedPlatforms.has(source)) continue;
+          // 源间并发、源内顺序，防止同源并发导致模块级缓存竞态
           expandPromises.push((async () => {
-            const seasonAnimes = [];
-            await executeSourceHandlers(resultData, queryTitle, seasonAnimes, requestAnimeDetailsMap, s, preferAnimeId, preferSource);
-            // 缓存额外季度的结果
-            if (seasonAnimes.length > 0) {
-              setSearchCache(`${queryTitle}_S${s}`, seasonAnimes.map(({ links, ...pureAnime }) => pureAnime), requestAnimeDetailsMap);
+            const sourceResults = [];
+            for (let s = querySeason + 1; s <= maxSeason; s++) {
+              const seasonAnimes = [];
+              await executeSourceHandlers({ [source]: resultData[source] }, queryTitle, seasonAnimes, requestAnimeDetailsMap, s, preferAnimeId, preferSource);
+              if (seasonAnimes.length > 0) {
+                setSearchCache(`${queryTitle}_S${s}`, seasonAnimes.map(({ links, ...pureAnime }) => pureAnime), requestAnimeDetailsMap);
+              }
+              sourceResults.push(seasonAnimes);
             }
-            return seasonAnimes;
+            return sourceResults;
           })());
         }
-        const expandedResults = await Promise.all(expandPromises);
+        const expandedResults = (await Promise.all(expandPromises)).flat();
         for (const res of expandedResults) {
           curAnimes.push(...res);
         }

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -269,7 +269,7 @@ export function getExplicitSeasonNumber(text) {
  * @param {number|null} parsedSeason - 解析出的目标季度
  * @returns {boolean} 是否匹配
  */
-export function titleMatches(title, query, parsedSeason = null, forceNonStrict = false) {
+export function titleMatches(title, query, parsedSeason = null, forceNonStrict = false, threshold = 0.8) {
   if (title == null || query == null) return false;
 
   const titleText = String(title);
@@ -351,7 +351,7 @@ export function titleMatches(title, query, parsedSeason = null, forceNonStrict =
       }
     }
 
-    return (matchCount / kw.length) > 0.8;
+    return (matchCount / kw.length) > threshold;
   });
 
   // 年份噪音兜底：前序策略均未命中时，尝试去年份后再次包含匹配


### PR DESCRIPTION
## Summary
排查了很久的跨季边缘情况恶性重复请求bug
<img width="1464" height="779" alt="image" src="https://github.com/user-attachments/assets/764f1571-bbe2-46df-bc6e-6827693481c6" />

修复跨季扩展中的恶性重复请求问题（指定 `PLATFORM_ORDER` 后，不满足平台的源触发跨季扩展，导致所有启用源——包括已满足集数需求的源——被连带重复调用 `handleAnimes`，产生大量无意义 API 请求），并修正跨季场景下身份平台名与优选平台名不一致导致的两个问题：

1. **候选平台判定忽略集所挂标签**：`checkEpisodeSatisfied` 与 spillover 评分仅按番剧身份判断某源是否为目标平台提供数据，当源身份名（如 tencent）与配置平台名（如 qq）不一致、但集标题挂有目标平台标签（如 `【qq】`）时，该源被误判为「目标平台无数据」而跳过，配置 qq 却无法命中 tencent 源。
2. **未满足平台集合命名空间错配**：`checkEpisodeSatisfied` 在目标平台未满足时向集合写入规范平台名（如 qq），而跨季扩展过滤以源名（如 tencent）查询该集合，命名空间不一致使 `PLATFORM_ORDER` 模式下跨季扩展被静默整体跳过。

---

## 修复明细

### 1. checkEpisodeSatisfied — 输出不满足平台集合，支持按源过滤

**问题**：`checkEpisodeSatisfied` 在首个不满足平台处 `break`，无法区分哪些平台已满足、哪些不满足。跨季扩展拿到 `false` 即对所有启用源执行 `executeSourceHandlers`，已满足集数需求的源（如 youku 152 集可匹配第 120 集）被不满足的源（如 dandan 仅 13 集）牵连，在跨季 S2~S4 中重复拉取相同数据。

**修复**：移除 `break`，新增 `unsatisfiedOut` 参数记录所有不满足的平台。跨季扩展据此仅处理不满足平台对应源，已满足者直接跳过。

**实际案例**：

> 配置 `PLATFORM_ORDER=dandan&animeko&youku`，`SOURCE_ORDER=dandan,animeko,youku,renren`，查询 `师兄啊师兄 S01E120`
>
> 搜索返回多个源结果。修复前：dandan 仅 13 集不满足 → `checkEpisodeSatisfied` 返回 `false` → 跨季扩展 `S2~S4` 对 dandan、animeko、youku、renren 全部执行 `handleAnimes`。youku 拥有 152 集且包含第 120 集，但在跨季 `S2~S4` 中仍被重复调用 `getEpisodes(同 mediaId)` 三次，累计拉取 456 集无需数据。
>
> 修复后：`unsatisfiedPlatforms = {dandan, animeko}`，youku 和 renren 被跳过。youku 仅在初始管线 S1 拉取一次，跨季中不再出现。

### 2. 跨季执行结构调整 — 源分组并发

**问题**：原有"各季→全源"循环无法精细控制源级过滤，且全并发时同源内不同季可能因缓存竞态导致重复请求。

**实现**：改为"各源各季"独立任务：
- 源间 `Promise.all` 并发执行，不同源无数据依赖
- 同源内各季顺序 `await`，确保模块级缓存（如 animeko 的 `SUBJECT_CACHE`）在季后正确传播

**实际案例**：

> 同上案例，跨季仅处理 dandan 和 animeko。两个源并发启动，各自内部 S2→S3→S4 顺序执行。animeko S2 拉取的 subject 写入 `SUBJECT_CACHE` 后，S3 直接命中缓存而不发起新网络请求。

### 3. titleMatches — 支持自定义相似度阈值

**问题**：`titleMatches` 相似度阈值固定为 0.8，`maxSeason` 场景中无法放宽以适配跨源翻译差异。如 dandan 搜索返回的标题与用户查询词之间存在译名差异时被误过滤。

**修复**：`titleMatches` 新增 `threshold` 参数（默认 0.8，向后兼容）。`maxSeason` 调用处传入 0.6，放宽相似度阈值使翻译差异较大的结果仍能通过匹配参与季号提取。仅改动 `titleMatches` 签名与内部使用，不影响其他调用者。

### 4. checkEpisodeSatisfied / spillover — 候选平台并入命中集所挂标签

**问题**：跨季分支的 `checkEpisodeSatisfied`（判定某源是否为目标平台提供数据）与 `matchAniAndEp` 的 spillover 评分中，候选平台仅取番剧身份（标题 `from` 段或 `source`），未并入命中集所挂的平台标签。当源身份名与配置平台名不一致、但集标题挂有目标平台标签时（典型：tencent 源、集标题挂 `qq`），该源被误判为「目标平台无数据」而跳过，导致配置 qq 却无法命中 tencent 源。

**修复**：两处评分前，将候选平台由「身份标签」扩展为「身份标签与所挂集标签（`extractEpisodeTitle`）去重合并」（与 `matchAniAndEp` 主线 1421 修复口径一致）。`checkEpisodeSatisfied` 中将 `getBangumiDataForMatch`（详情缓存读取，无副作用）的调用提前到身份判定之后、匹配判定之前，用于收集集标签；该加性改动对身份即匹配目标、或集无标签的场景不改变结果。

**实际案例**：

> 配置 `PLATFORM_ORDER=qq`，`SOURCE_ORDER=tencent`（仅启用 tencent 源确保搜索结果单一），查询某番剧
>
> 搜索返回 tencent 条目（`from tencent`），其各集标题挂 `【qq】` 标签。
>
> 修复前：`checkEpisodeSatisfied` 以身份 `tencent` 比对 `qq` 得 0 → 该源被跳过；spillover 评分 `getPlatformMatchScore('tencent','qq') = 0` 被压低。配置 qq 却无法命中 tencent。
> 修复后：候选为 `'tencent&qq'` → `checkEpisodeSatisfied` 正确识别该源为 qq 数据；spillover 评分得 `998`（qq 命中且候选仅 2 段），符合「配置 qq 优先 tencent」预期。
>
> 不受影响验证：身份即目标平台（tencent/tencent）、集无标签（仅身份）、无优选平台（`platform=null` 一律得 1）等场景，修复前后判定与评分完全一致（已以 21 例用例验证，含 tencent/qq 受影响案例与上述不受影响案例）。

### 5. checkEpisodeSatisfied — 未满足平台集合按源名写入，修复跨季扩展过滤命名空间错配

**问题**：第 4 项虽已让 `tencent` 源被正确识别为 `qq` 数据提供方，但 `checkEpisodeSatisfied` 在「某目标平台未满足」时仍向 `unsatisfiedOut` 写入**规范平台名**（`tPlat`，如 `qq`）；而跨季扩展的源过滤分支以**源名**（`source`，如 `tencent`）查询该集合：

```js
if (targetPlatform && !unsatisfiedPlatforms.has(source)) continue;
```

命名空间不一致导致 `PLATFORM_ORDER` 模式下，即便 `tencent` 源提供了未满足的 `qq` 数据，过滤端查 `unsatisfiedPlatforms.has('tencent')` 恒为 `false`，全部源被误判为「已满足」而整体跳过跨季扩展，目标集被静默丢弃。

**修复**：在写入端就近收集提供该平台数据的 `anime.source`（`providedSources`），未满足时写入**源名**而非规范名，使集合命名空间与跨季扩展过滤对齐。该收集合并复用第 4 项已有的候选平台判定（`actualPlatform`），无新增映射表，仅当某 `tPlat` 子遍历确有数据且未满足时才写入对应源名；同一 `tPlat` 下多个源均提供数据则一并写入（均被正确纳入扩展），无关源（未匹配该平台或被过滤源）不会被污染。

**实际案例**：

> 配置 `PLATFORM_ORDER=qq`，`SOURCE_ORDER=tencent`，查询某番剧 S1E50（首季仅 40 集）
>
> 搜索返回 tencent 条目（`from tencent`），各集标题挂 `【qq】` 标签，第 50 集不在首季抓取。
> 修复前：`checkEpisodeSatisfied` 识别 tencent 为 qq 数据提供方 → 未满足 → `unsatisfiedOut.add('qq')` → 跨季扩展过滤查 `unsatisfiedPlatforms.has('tencent')` 为 `false` → tencent 被跳过 → S2~ 扩展未触发 → 目标集丢失。
> 修复后：`unsatisfiedOut` 写入 `tencent` → 过滤查 `unsatisfiedPlatforms.has('tencent')` 命中 → tencent 正确纳入跨季扩展 → S2~ 拉取第 50 集。

**验证**：新增 `cross-season-unsatisfied-test.mjs`，以修复后源码为正本、由其逐字回退本次写入改动得到修复前对照，覆盖修复前后对比（tencent/qq、iqiyi/qiyi 受影响案例，前写规范名/后被错误跳过、后写源名/后正确扩展）、常规流程（首季命中即满足、`_any_` 模式、源名即规范名无回归）与边界（多平台仅未满足源扩展、无关源不污染集合、主返回值契约不变）共 36 项全通过；既有跨季平台匹配测试 21/21 不受影响。

---

## 影响范围

| 场景 | PLATFORM_ORDER | 行为变化 |
|------|:--:|------|
| 无 PLATFORM_ORDER | 空 | 不受影响 |
| 指定平台且所有平台均满足 | 匹配 | 不受影响 |
| 指定平台且存在不满足平台 | 匹配 | **仅不满足平台对应源参与跨季扩展** |
| `titleMatches` 调用 | 任意 | **新增 threshold 参数，默认 0.8 向后兼容** |
| 身份名 ≠ 平台名但集挂有目标标签（如 tencent/qq） | 匹配集标签 | **修复（第 4 项）：checkEpisodeSatisfied 与 spillover 评分并入集标签，正确识别** |
| 身份名 ≠ 平台名、目标集跨季（如 tencent/qq） | 匹配集标签但未满足 | **修复（第 5 项）：unsatisfiedOut 改写源名，跨季扩展过滤按源名命中，正确展开** |
| 身份名 ≠ 平台名且集无目标标签 | 不匹配 | 不受影响（不误加） |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/apis/dandan-api.js` | checkEpisodeSatisfied 记录 unsatisfiedOut 并按源名写入、跨季源过滤、执行结构调整；checkEpisodeSatisfied 与 spillover 评分候选并入命中集所挂平台标签（第 4 项）；未满足时向 unsatisfiedOut 写入源名（providedSources）以对齐跨季扩展过滤（第 5 项） |
| `danmu_api/utils/common-util.js` | titleMatches 新增 threshold 参数 |
