### PR TITLE
fix: 修复无法优选 qq 平台匹配

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -950,9 +950,9 @@ export function filterSameEpisodeTitle(filteredTmpEpisodes) {
 function getPlatformMatchScore(candidatePlatform, targetPlatform) {
   if (!candidatePlatform || !targetPlatform) return 0;
   
-  // 预处理：按 & 分割，转小写，去空格
-  const cParts = candidatePlatform.split('&').map(s => s.trim().toLowerCase()).filter(s => s);
-  const tParts = targetPlatform.split('&').map(s => s.trim().toLowerCase()).filter(s => s);
+  // 预处理：按半角/全角 & 分割，转小写去空格并去重，避免合并标题重复标签抬高杂质长度导致评分失真
+  const cParts = [...new Set(candidatePlatform.split(/[&＆]/).map(s => s.trim().toLowerCase()).filter(s => s))];
+  const tParts = [...new Set(targetPlatform.split(/[&＆]/).map(s => s.trim().toLowerCase()).filter(s => s))];
   
   let matchCount = 0;
 
@@ -980,7 +980,7 @@ function getPlatformMatchScore(candidatePlatform, targetPlatform) {
 
 // 辅助函数：从标题中提取来源平台列表 (新增函数 - 适配合并源标题格式)
 function extractPlatformFromTitle(title) {
-    const match = title.match(/from\s+([a-zA-Z0-9&]+)/i);
+    const match = title.match(/from\s+([a-zA-Z0-9&＆]+)/i);
     return match ? match[1] : null;
 }
 
@@ -1417,12 +1417,16 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
     // 3. 匹配结果处理与评分比较
     if (matchedEpisode) {
         // 计算当前匹配的得分
-        const actualPlatform = extractPlatformFromTitle(anime.animeTitle) || anime.source;
+        // 候选平台由番剧身份标签（标题 from 段或 source）与命中集所挂平台标签共同决定，使身份名（如 tencent）与优选平台名（如 qq）不一致但集上挂有该标签的源也能正确加分
+        const identityPlatform = extractPlatformFromTitle(anime.animeTitle) || anime.source;
+        const epPlatform = matchedEpisode ? extractEpisodeTitle(matchedEpisode.episodeTitle) : null;
+        const candidatePlatform = [...new Set([identityPlatform, epPlatform].filter(Boolean)
+            .flatMap(p => p.split(/[&＆]/).map(s => s.trim().toLowerCase())).filter(s => s))].join('&');
         let currentScore = 0;
-        
+
         if (platform) {
             // 如果指定了平台偏好，计算匹配得分
-            currentScore = getPlatformMatchScore(actualPlatform, platform);
+            currentScore = getPlatformMatchScore(candidatePlatform, platform);
         } else {
             // 如果没有指定平台偏好，默认为 1
             currentScore = 1;


### PR DESCRIPTION
## Summary

修复 `PLATFORM_ORDER` 配置 `qq` 却无法优选命中 `tencent` 源的平台匹配失效：

1. **候选平台仅用番剧身份、忽略命中集所挂标签（主要修复）**：`matchAniAndEp` 评分时以 `extractPlatformFromTitle(animeTitle) || source` 作为候选，当源身份名与配置平台名不一致、但命中集标题挂有目标平台标签时（如 tencent 源、集标题挂 `qq`）得 0 分，与无交集的 dandan 平局，导致配置 `qq` 却选中 dandan 而非 tencent。
2. **候选/目标平台预处理不支持全角＆且不去重**：`getPlatformMatchScore` 仅按半角 `&` 分割、不去重，合并标题的重复标签（如 `dandan&qiyi&qiyi`）抬高杂质长度导致评分失真；标题含全角＆（如 `dandan＆tencent`）时整串被当作单一 token，未识别为分隔符。
3. **身份平台提取漏掉全角＆**：`extractPlatformFromTitle` 正则只接受半角 `&`，合并源标题含全角＆时被截断（如 `from dandan＆tencent` 仅提取到 `dandan`）。

---

## 修复明细

### 1. matchAniAndEp — 候选平台并入命中集所挂标签（身份 + 集标签去重合并，主要修复）

**问题**：`matchAniAndEp` 评分时 `actualPlatform = extractPlatformFromTitle(anime.animeTitle) || anime.source` 仅反映番剧身份。当源身份名与配置平台名不一致、但集标题挂有目标平台标签时（典型：tencent 源、集标题 `【qq】 ...`），`getPlatformMatchScore('tencent','qq')` 得 0，与无交集的 dandan 同为 0 分，平局回退 `SOURCE_ORDER` 决定，导致配置了 `qq` 却选中 dandan。

**修复**：评分候选由「番剧身份标签」与「命中集所挂平台标签（`extractEpisodeTitle`）」去重合并组成（`[...new Set([identity, ep].filter(Boolean).flatMap(split(/[&＆]/)).filter(s))].join('&')`），使身份名与优选平台名不一致、但集上挂有该标签的源也能正确加分。该改动为加性：纯身份场景（无集标签或集标签与身份一致）合并后候选不变。

**实际案例**：

> 配置 `PLATFORM_ORDER=qq`，`SOURCE_ORDER=dandan,tencent`（同时启用 dandan 与 tencent 源，二者均返回搜索结果以便比较平台优先级），查询某番剧
>
> 搜索返回 tencent 条目（`from tencent`，其各集标题挂 `【qq】` 标签）与 dandan 条目（`from dandan`，集标题无 qq 标签）。
>
> 修复前：`actualPlatform='tencent'` → `getPlatformMatchScore('tencent','qq') = 0`；dandan 条目 `getPlatformMatchScore('dandan','qq') = 0`，二者同为 0 分平局，按 `SOURCE_ORDER` 选中靠前的 dandan，tencent 落败。
> 修复后：tencent 候选为 `'tencent&qq'` → `getPlatformMatchScore('tencent&qq','qq') = 998`（qq 命中且候选仅 2 段），tencent 源以明显得分胜出，符合「配置 qq 优先 tencent」的预期。

**真实案例（遮天 S01E01，本仓库 `遮天 S01E01/` 测试数据）**：

> 配置：`SOURCE_ORDER=dandan,tencent`、`PLATFORM_ORDER=qq`，查询 `遮天 S01E01`。
>
> 搜索返回两个同名候选：
> - dandan：`animeTitle="遮天(2023)【3D网络放送】from dandan"`，各集标题 `【dandan】 第N话`（无 qq 标签）。
> - tencent：`animeTitle="遮天(2023)【3D动漫】from tencent"`，各集标题 `【qq】 遮天_N`（挂 qq 标签）。
>
> 实测日志（匹配日志.txt）最终 `isMatched=true` 落在 `animeId=18005`（即 dandan 条目），而非带 qq 标签的 tencent（`animeId=3255619`）——即配置了 `qq` 却选中了 dandan。
>
> 修复前根因：`actualPlatform='tencent'` → `getPlatformMatchScore('tencent','qq') = 0`；dandan 条目 `getPlatformMatchScore('dandan','qq') = 0`，二者平局，按 `SOURCE_ORDER` 取靠前的 dandan，tencent 落败。
> 修复后：tencent 命中集带 `【qq】` 标签，候选并入为 `'tencent&qq'` → `getPlatformMatchScore('tencent&qq','qq') = 998`，tencent 以明显得分胜出，符合「配置 qq 优先 tencent」的预期。

> 不受影响验证：同一配置但 tencent 集标题**不含** qq 标签时，候选为 `'tencent'`，评分仍为 0，与修复前一致（不误加）；手动优选（`isPreferredAnime`）仍绝对优先于平台评分，行为前后不变。

### 2. getPlatformMatchScore — 候选/目标平台预处理支持全角＆并去重

**问题**：评分预处理 `candidatePlatform.split('&')` 仅按半角分隔、不去重。合并源标题（如 `dandan&qiyi&qiyi`）重复标签使 `cParts.length` 偏大，评分公式 `matchCount*1000 - cParts.length` 被杂质长度拉低，在临界平局场景下改变优选结果；全角＆未作为分隔符，整串作为一个 token，子串模糊匹配行为不可控。

**修复**：按 `/[&＆]/` 分割，转小写去空格，并对候选与目标分别 `[...new Set(...)]` 去重后再评分。

**实际案例**：

> 配置 `PLATFORM_ORDER=dandan&qiyi&qiyi`（合并源重复标签），查询某番剧，搜索返回 `from dandan&qiyi&qiyi` 条目。
>
> 修复前：`cParts = ['dandan','qiyi','qiyi']`（长度 3，未去重），`getPlatformMatchScore(candidate,'qiyi')` 得 `1000 - 3 = 997`。
> 修复后：`cParts = ['dandan','qiyi']`（长度 2，已去重），同场景得 `1000 - 2 = 998`，杂质长度不再稀释匹配得分。
>
> 全角示例：候选传入 `dandan＆qiyi`、目标 `qiyi`。修复前整串作为一个 token，`qiyi` 仅以子串方式命中；修复后正确拆为 `['dandan','qiyi']`，匹配判定稳定。

### 3. extractPlatformFromTitle — 正则支持全角＆

**问题**：正则 `/from\s+([a-zA-Z0-9&]+)/i` 的字符组不含全角＆，合并源标题 `from dandan＆tencent` 因 `＆` 不在字符组内被截断为 `dandan`，丢失后续平台，导致该源身份评分失真。

**修复**：字符组扩展为 `[a-zA-Z0-9&＆]`，全角＆与半角＆同等视作平台分隔符。

**实际案例**：

> 合并源标题 `【番剧】 from dandan＆tencent`。
>
> 修复前：`extractPlatformFromTitle` 返回 `'dandan'`（全角＆后续 `tencent` 被截断）。
> 修复后：返回 `'dandan＆tencent'`，下游按 `/[&＆]/` 拆分可得 `['dandan','tencent']`，身份平台完整。

---

## 影响范围

| 场景 | PLATFORM_ORDER | 行为变化 |
|------|:--:|------|
| 未指定优选平台 | 空 | 不受影响（默认得分 1） |
| 指定平台且搜索结果身份匹配 | 匹配 | 不受影响 |
| 合并源标题含重复标签 | 任意 | **修复：去重后评分不再被杂质长度稀释** |
| 合并源标题含全角＆ | 任意 | **修复：身份平台提取不再截断** |
| 源身份名 ≠ 平台名，但集标题挂有目标标签（如 tencent/qq） | 匹配集标签 | **修复：候选并入集标签，正确加分** |
| 源身份名 ≠ 平台名，且集标题无目标标签 | 不匹配 | 不受影响（不误加，仍 0 分） |
| 手动优选番剧 | 任意 | 不受影响（绝对优先于平台评分） |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/apis/dandan-api.js` | `getPlatformMatchScore` 预处理支持全角＆并去重；`extractPlatformFromTitle` 正则支持全角＆；`matchAniAndEp` 评分候选并入命中集所挂平台标签并去重合并 |
