### PR TITLE
fix: 修复源不在优选平台时跨季被跳过，并使弹弹关联作品可参与跨季匹配

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -838,8 +838,8 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
         const expandPromises = [];
         for (const source of globals.sourceOrderArr) {
           if (!resultData[source]) continue;
-          // 在PLATFORM_ORDER模式下，跳过已满足平台的对应源
-          if (targetPlatform && !unsatisfiedPlatforms.has(source)) continue;
+          // 在PLATFORM_ORDER模式下，跳过已满足平台的对应源；unsatisfied为空时不跳过
+          if (targetPlatform && unsatisfiedPlatforms.size > 0 && !unsatisfiedPlatforms.has(source)) continue;
           // 源间并发、源内顺序，防止同源并发导致模块级缓存竞态
           expandPromises.push((async () => {
             const sourceResults = [];

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -368,18 +368,31 @@ export default class DandanSource extends BaseSource {
 
           // 相似度高于10%时，对每个关联作品单独判断是否符合展开条件：
           // 关联作品标题含季度信息（避免范围发散），或初始搜索结果不少于25个（API25个结果上限，用相关作品突破）
-          if (similarity >= 0.1 && details.relateds && Array.isArray(details.relateds) && canExpandRelateds) {
+          if (similarity >= 0.1 && details.relateds && Array.isArray(details.relateds)) {
             for (const rel of details.relateds) {
               const hasSeason = extractSeasonNumberFromAnimeTitle(rel.animeTitle).season !== null;
               if (!existingIds.has(rel.animeId) && (hasSeason || initialCount >= 25)) {
                 existingIds.add(rel.animeId);
-                queue.push({
-                  animeId: rel.animeId,
-                  animeTitle: rel.animeTitle,
-                  imageUrl: rel.imageUrl,
-                  rating: rel.rating || 0,
-                  isRelated: true // 标记动态挖掘出的条目为相关作品
-                });
+                // 关联作品追加到sourceAnimes供跨季扩展感知
+                if (!sourceAnimes.some(a => a.animeId === rel.animeId)) {
+                  sourceAnimes.push({
+                    animeId: rel.animeId,
+                    animeTitle: rel.animeTitle,
+                    title: rel.animeTitle,
+                    imageUrl: rel.imageUrl,
+                    rating: rel.rating || 0,
+                    isRelated: true
+                  });
+                }
+                if (canExpandRelateds) {
+                  queue.push({
+                    animeId: rel.animeId,
+                    animeTitle: rel.animeTitle,
+                    imageUrl: rel.imageUrl,
+                    rating: rel.rating || 0,
+                    isRelated: true // 标记动态挖掘出的条目为相关作品
+                  });
+                }
               }
             }
           }


### PR DESCRIPTION
这问题怎么修不完啊（

handleAnimes发现关联作品后追加到sourceAnimes参数，不受canExpandRelateds 约束。同ID唯一性检查确保注入行为与搜索结果一致，不产生重复getEpisodes请求。
existingIds记录始终执行以消除并发竞态窗口。

跨季源过滤新增unsatisfiedPlatforms.size>0条件：当targetPlatform设了 但unsatisfiedPlatforms为空时不再跳过所有源。