### PR TITLE
refactor: 统一繁简转换处理，移除各数据源中的分散逻辑

### DIFF
--- a/danmu_api/sources/aiyifan.js
+++ b/danmu_api/sources/aiyifan.js
@@ -6,7 +6,6 @@ import { hexToInt } from "../utils/danmu-util.js";
 import { generateValidStartDate } from "../utils/time-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
 import { titleMatches, getExplicitSeasonNumber, extractSeasonNumberFromAnimeTitle } from "../utils/common-util.js";
-import { simplized } from "../utils/zh-util.js";
 import { globals } from '../configs/globals.js';
 import { AiyifanSigningProvider } from '../utils/aiyifan-util.js';
 
@@ -506,11 +505,6 @@ export default class AiyifanSource extends BaseSource {
         // 保留原始数据
         ...comment
       };
-    }).map(c => {
-      if (globals.danmuSimplifiedTraditional === 'simplified') {
-        if (c.m) c.m = simplized(c.m);
-      }
-      return c;
     });
   }
 }

--- a/danmu_api/sources/animeko.js
+++ b/danmu_api/sources/animeko.js
@@ -3,7 +3,6 @@ import { globals } from '../configs/globals.js';
 import { log } from "../utils/log-util.js";
 import { httpGet, httpPost } from "../utils/http-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
-import { simplized } from "../utils/zh-util.js";
 import { SegmentListResponse } from '../models/dandan-model.js';
 import { titleMatches, getExplicitSeasonNumber, extractSeasonNumberFromAnimeTitle } from "../utils/common-util.js";
 import { searchBangumiData } from '../utils/bangumi-data-util.js';
@@ -936,12 +935,11 @@ export default class AnimekoSource extends BaseSource {
         const time = (Number(info.playTime) / 1000).toFixed(2);
         const mode = locationMap[info.location] || 1;
         const color = info.color === -1 ? 16777215 : info.color;
-        const text = globals.danmuSimplifiedTraditional === 'simplified' ? simplized(info.text) : info.text;
 
         return {
           cid: item.id,
           p: `${time},${mode},${color},[animeko]`,
-          m: text
+          m: info.text
         };
       });
   }

--- a/danmu_api/sources/bahamut.js
+++ b/danmu_api/sources/bahamut.js
@@ -557,8 +557,7 @@ export default class BahamutSource extends BaseSource {
     return comments.map(c => ({
       cid: Number(c.sn),
       p: `${(c.time / 10).toFixed(2)},${positionToMode[c.position] || c.tp},${parseInt(c.color.slice(1), 16)},[bahamut]`,
-      // 根据 globals.danmuSimplifiedTraditional 控制是否繁转简
-      m: globals.danmuSimplifiedTraditional === 'simplified' ? simplized(c.text) : c.text,
+      m: c.text,
       t: c.time / 10
     }));
   }

--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -1135,9 +1135,6 @@ export default class BilibiliSource extends BaseSource {
 
   formatComments(comments) {
     return comments.map(c => {
-        if (globals.danmuSimplifiedTraditional === 'simplified') {
-            if (c.m) c.m = simplized(c.m);
-        }
         c.like = c.like_num;
         return c;
     });

--- a/danmu_api/sources/custom.js
+++ b/danmu_api/sources/custom.js
@@ -3,7 +3,6 @@ import { globals } from '../configs/globals.js';
 import { log } from "../utils/log-util.js";
 import { httpGet } from "../utils/http-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
-import { simplized } from "../utils/zh-util.js";
 import { SegmentListResponse } from '../models/dandan-model.js';
 
 // =====================
@@ -196,8 +195,7 @@ export default class CustomSource extends BaseSource {
         const decimalColor = r * 256 * 256 + g * 256 + b;
         return `${platform}${decimalColor}`;
       })}`,
-      // 根据 globals.danmuSimplifiedTraditional 控制是否繁转简
-      m: globals.danmuSimplifiedTraditional === 'simplified' ? simplized(c.m) : c.m,
+      m: c.m,
     }));
   }
 }

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -3,7 +3,6 @@ import { globals } from '../configs/globals.js';
 import { log } from "../utils/log-util.js";
 import { httpGet } from "../utils/http-util.js";
 import { addAnime, removeEarliestAnime } from "../utils/cache-util.js";
-import { simplized } from "../utils/zh-util.js";
 import { SegmentListResponse } from '../models/dandan-model.js';
 import { getTmdbJaOriginalTitle, smartTitleReplace } from "../utils/tmdb-util.js";
 import TencentSource from "./tencent.js";
@@ -540,11 +539,8 @@ export default class DandanSource extends BaseSource {
 
   formatComments(comments) {
     return comments.map(c => {
-      // 已经被实时抓取的其它源弹幕，略过复杂的 Dandan 转换，进行繁转简处理
+      // 已经被实时抓取的其它源弹幕，略过复杂的 Dandan 转换。
       if (c.isRealTimePulled) {
-        if (globals.danmuSimplifiedTraditional === 'simplified' && c.m) {
-          return { ...c, m: simplized(c.m) };
-        }
         return c;
       }
 
@@ -558,8 +554,7 @@ export default class DandanSource extends BaseSource {
           const decimalColor = r * 256 * 256 + g * 256 + b;
           return `${platform}${decimalColor}`;
         })}`,
-        // 根据 globals.danmuSimplifiedTraditional 控制是否繁转简
-        m: globals.danmuSimplifiedTraditional === 'simplified' ? simplized(c.m) : c.m,
+        m: c.m,
       };
     });
   }

--- a/danmu_api/utils/danmu-util.js
+++ b/danmu_api/utils/danmu-util.js
@@ -1,7 +1,7 @@
 import { globals } from '../configs/globals.js';
 import { log } from './log-util.js'
 import { binResponse, jsonResponse, xmlResponse } from "./http-util.js";
-import { traditionalized } from './zh-util.js';
+import { simplized, traditionalized } from './zh-util.js';
 import { convertDanAny } from './dan-any.js';
 
 // =====================
@@ -292,6 +292,22 @@ export function convertToDanmakuJson(contents, platform) {
     danmus.push({ p: attributes, m, cid: cidCounter++, like: item?.like });
   }
 
+  // 文本字段归一化为 m 后统一转换，确保所有来源及输入格式行为一致。
+  const textConverter = globals.danmuSimplifiedTraditional === 'simplified'
+    ? simplized
+    : globals.danmuSimplifiedTraditional === 'traditional'
+      ? traditionalized
+      : null;
+
+  if (textConverter) {
+    danmus = danmus.map(danmu => ({
+      ...danmu,
+      m: typeof danmu.m === 'string' ? textConverter(danmu.m) : danmu.m
+    }));
+    const targetLabel = globals.danmuSimplifiedTraditional === 'simplified' ? '简体字' : '繁体字';
+    log("info", `[system] [danmu] [danmu convert] 转换了 ${danmus.length} 条弹幕为${targetLabel}`);
+  }
+
   // 切割字符串成正则表达式数组
   const regexArray = globals.blockedWords.split(/(?<=\/),(?=\/)/).map(str => {
     // 去除两端的斜杠并转换为正则对象
@@ -375,15 +391,6 @@ export function convertToDanmakuJson(contents, platform) {
     if (colorCount > 0) {
       log("info", `[system] [danmu] [danmu convert] 转换了 ${colorCount} 条弹幕颜色`);
     }
-  }
-
-  // 根据 danmuSimplifiedTraditional 设置转换弹幕文本
-  if (globals.danmuSimplifiedTraditional === 'traditional') {
-    convertedDanmus = convertedDanmus.map(danmu => ({
-      ...danmu,
-      m: traditionalized(danmu.m)
-    }));
-    log("info", `[system] [danmu] [danmu convert] 转换了 ${convertedDanmus.length} 条弹幕为繁体字`);
   }
 
   log("info", `[system] [danmu] danmus_original: ${danmus.length}`);

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -39,7 +39,7 @@ import { HandlerFactory } from "./configs/handlers/handler-factory.js";
 import { Globals } from "./configs/globals.js";
 import { addAnime, addEpisode } from "./utils/cache-util.js";
 import { convertToAsciiSum } from "./utils/codec-util.js";
-import { handleDanmusLike } from "./utils/danmu-util.js";
+import { convertToDanmakuJson, handleDanmusLike } from "./utils/danmu-util.js";
 import { Segment, SegmentListResponse } from "./models/dandan-model.js"
 import { initBangumiData, searchBangumiData, clearBangumiDataCache } from "./utils/bangumi-data-util.js";
 
@@ -247,6 +247,52 @@ test('worker.js API endpoints', async (t) => {
 
     ({title, season, episode} = await extractTitleSeasonEpisode("宇宙Marry Me? S02E08"));
     assert(title === "宇宙Marry Me?" && season == 2 && episode == 8, `Expected title === "宇宙Marry Me?" && season == 2 && episode == 8, but got ${title} ${season} ${episode}`);
+  });
+  
+  await t.test('danmu text conversion should run after normalization and before filtering and grouping', () => {
+    const baseEnv = {
+      BLOCKED_WORDS: '',
+      GROUP_MINUTE: '0',
+      DANMU_LIMIT: '0',
+      CONVERT_COLOR: 'default'
+    };
+
+    Globals.init({ ...baseEnv, DANMU_SIMPLIFIED_TRADITIONAL: 'simplified' });
+    const simplified = convertToDanmakuJson([
+      { progress: 1000, mode: 1, color: 16777215, content: '來看能不能發彈幕' },
+      { p: '2,1,16777215,[test]', m: '繁體彈幕' }
+    ], 'bilibili1');
+    assert.deepEqual(simplified.map(item => item.m), ['来看能不能发弹幕', '繁体弹幕']);
+
+    Globals.init({
+      ...baseEnv,
+      DANMU_SIMPLIFIED_TRADITIONAL: 'simplified',
+      BLOCKED_WORDS: '/来看/'
+    });
+    const filtered = convertToDanmakuJson([
+      { progress: 1000, mode: 1, color: 16777215, content: '來看' }
+    ], 'bilibili1');
+    assert.equal(filtered.length, 0);
+
+    Globals.init({
+      ...baseEnv,
+      DANMU_SIMPLIFIED_TRADITIONAL: 'simplified',
+      GROUP_MINUTE: '1'
+    });
+    const grouped = convertToDanmakuJson([
+      { progress: 1000, mode: 1, color: 16777215, content: '來看' },
+      { p: '2,1,16777215,[test]', m: '来看' }
+    ], 'bilibili1');
+    assert.equal(grouped.length, 1);
+    assert.match(grouped[0].m, /^来看.*2$/);
+
+    Globals.init({ ...baseEnv, DANMU_SIMPLIFIED_TRADITIONAL: 'traditional' });
+    const traditional = convertToDanmakuJson([
+      { p: '1,1,16777215,[test]', m: '来看能不能发弹幕' }
+    ], 'test');
+    assert.equal(traditional[0].m, '來看能不能發彈幕');
+
+    resetSearchState();
   });
 
   // await t.test('GET /api/v2/comment/:id?format=json&duration=true should return segment duration and reuse comment cache', async () => {


### PR DESCRIPTION
将原本在各个弹幕源（aiyifan、animeko、bahamut、bilibili、custom、dandan等）中根据 `globals.danmuSimplifiedTraditional` 条件调用 `simplized` 的代码全部移除，改为在统一出口处集中处理繁简转换。此举避免逻辑分散、减少重复代码，并便于后续维护和调整转换策略。

Close #410
Close #413 