### PR TITLE
feat: 支持反向代理HTTPS协议配置，生成正确的对外链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ LogVar 弹幕 API 服务器
    ```
    服务器将在 `http://{ip}:9321` 运行，默认token是`87654321`。
    如需修改端口，可设置环境变量 `DANMU_API_PORT`（例如 `DANMU_API_PORT=8080 npm start`）。
+   HTTPS 反向代理应传递 `X-Forwarded-Proto`；无法传递时可设置 `DANMU_API_PUBLIC_PROTO=https`，用于生成正确的对外弹幕链接。
 
    **热更新支持**：修改 `config/.env`，应用会自动检测并重新加载配置（无需重启应用）。
 

--- a/config/.env.example
+++ b/config/.env.example
@@ -22,6 +22,10 @@ TOKEN=87654321
 # 说明：本地 Node 服务会优先读取 DANMU_API_PORT；未设置时回退到 9321
 # DANMU_API_PORT=9321
 
+# API 对外访问协议（反向代理未传递 X-Forwarded-Proto 时使用）
+# 可选值：http、https；默认值：http
+# DANMU_API_PUBLIC_PROTO=https
+
 # 系统管理访问令牌（用于系统管理功能）
 # 如果未配置此值，则无法访问系统管理功能，需要先配置后在URL中填入此token才能打开系统管理
 # 默认值：空（不启用系统管理访问控制）

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -49,6 +49,21 @@ function detectNodeDeployPlatform() {
   return "node";
 }
 
+function resolvePublicRequestProtocol(req) {
+  const forwardedProto = String(req.headers['x-forwarded-proto'] || '')
+    .split(',')[0]
+    .trim()
+    .toLowerCase();
+  if (forwardedProto === 'http' || forwardedProto === 'https') {
+    return forwardedProto;
+  }
+
+  const configuredProto = String(process.env.DANMU_API_PUBLIC_PROTO || 'http')
+    .trim()
+    .toLowerCase();
+  return configuredProto === 'https' ? 'https' : 'http';
+}
+
 /**
  * 检查并自动复制配置文件
  * 在Node环境下，如果config目录下没有.env，则自动从.env.example拷贝一份生成.env
@@ -270,8 +285,9 @@ process.on('SIGINT', cleanupWatcher);
 function createServer() {
   return http.createServer(async (req, res) => {
     try {
-      // 构造完整的请求 URL
-      const fullUrl = `http://${req.headers.host}${req.url}`;
+      // 构造完整的请求 URL，反向代理场景优先使用客户端原始协议
+      const scheme = resolvePublicRequestProtocol(req);
+      const fullUrl = `${scheme}://${req.headers.host}${req.url}`;
 
       // 获取请求客户端的ip，兼容反向代理场景
       let clientIp = 'unknown';


### PR DESCRIPTION
- 新增环境变量 `DANMU_API_PUBLIC_PROTO` 用于指定对外协议
- 请求处理时优先读取 `X-Forwarded-Proto` 头，无则回退至配置变量
- 修复反向代理环境下弹幕链接协议错误的问题

Close #400 