### PR TITLE
fix(bilibili): 修复Bangumi Data 的区域结果弹幕获取失败

### DIFF
--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -862,18 +862,18 @@ export default class BilibiliSource extends BaseSource {
                     if (ep) { cid = ep.cid; aid = ep.aid; duration = ep.duration / 1000; title = ep.long_title; success = true; }
                 }
             } catch(e) {}
+        }
 
-            // 尝试 Section 接口 (直连回退)
-            if (!success) {
-                try {
-                    const res = await httpGet(`https://api.bilibili.com/pgc/web/season/section?season_id=${seasonId}`, { headers: { "User-Agent": "Mozilla/5.0", "Cookie": globals.bilibliCookie||"" } });
-                    const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
-                    if (data.code === 0 && data.result?.main_section?.episodes) {
-                        const ep = data.result.main_section.episodes.find(e => e.id == epid);
-                        if (ep) { cid = ep.cid; aid = ep.aid; duration = ep.duration ? ep.duration / 1000 : 0; title = ep.long_title; success = true; }
-                    }
-                } catch(e) {}
-            }
+        // 尝试 Section 接口作为回退，直连不走代理，无代理时也能覆盖 Bangumi Data 补充的港澳台条目
+        if (!success && seasonId) {
+            try {
+                const res = await httpGet(`https://api.bilibili.com/pgc/web/season/section?season_id=${seasonId}`, { headers: { "User-Agent": "Mozilla/5.0", "Cookie": globals.bilibliCookie||"" } });
+                const data = typeof res.data === "string" ? JSON.parse(res.data) : res.data;
+                if (data.code === 0 && data.result?.main_section?.episodes) {
+                    const ep = data.result.main_section.episodes.find(e => e.id == epid);
+                    if (ep) { cid = ep.cid; aid = ep.aid; duration = ep.duration ? ep.duration / 1000 : 0; title = ep.long_title; success = true; }
+                }
+            } catch(e) {}
         }
 
         if (!cid) {


### PR DESCRIPTION
pgc/web/season/section为直连接口不需要代理，从轨道二的
_hasBilibiliProxy()条件中提取至独立回退块。无代理配置时
Bangumi Data补充的港澳台条目也能通过直连Section接口获取
分集cid，正常获取弹幕。