### PR TITLE
fix(dandan): 优化详情请求数，原名搜索添加低门槛预过滤避免出现完全无关结果

### DIFF
--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -169,12 +169,8 @@ export default class DandanSource extends BaseSource {
         const preFiltered = originalResult.data.filter(anime => {
           if (anime.isTmdbSource) return true;
           const t = anime.animeTitle || anime.title || '';
-          log("info", `[debug-prefilter] 调用titleMatches: t="${t}"(${t.length}chars) kw="${keyword}"(${keyword.length}chars) season=${resolvedSeason}`);
-          const matched = titleMatches(t, keyword, resolvedSeason, true, 0.5);
-          log("info", `[debug-prefilter] id=${anime.animeId} title="${t}" keyword="${keyword}" season=${resolvedSeason} match=${matched}`);
-          return matched;
+          return titleMatches(t, keyword, resolvedSeason, true, 0.8);
         });
-        log("info", `[debug-prefilter] 结果: original=${originalResult.data.length}条 preFiltered=${preFiltered.length}条`);
         if (preFiltered.length > 0) {
           tmdbAbortController.abort();
           // 记录原始搜索结果的全部animeId，供handleAnimes关联作品恢复误过滤条目使用
@@ -187,9 +183,14 @@ export default class DandanSource extends BaseSource {
       // 原始搜索无结果或被初筛清空，等待并返回TMDB搜索结果
       const tmdbResult = await tmdbSearchPromise;
 
-      // 原始搜索无结果，返回 TMDB 搜索结果
+      // 原始搜索无结果，对TMDB日语原名结果做最终预过滤
       if (tmdbResult.success) {
-        return tmdbResult.data;
+        const resolvedSeason = getExplicitSeasonNumber(keyword);
+        const tmdbFiltered = tmdbResult.data.filter(anime => {
+          const t = anime.animeTitle || anime.title || '';
+          return titleMatches(t, keyword, resolvedSeason, true, 0.19);
+        });
+        if (tmdbFiltered.length > 0) return tmdbFiltered;
       }
 
       log("info", `[dandan] 原始搜索和基于TMDB的搜索均未返回任何结果 (当前搜索词: ${keyword})`);

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -169,10 +169,12 @@ export default class DandanSource extends BaseSource {
         const preFiltered = originalResult.data.filter(anime => {
           if (anime.isTmdbSource) return true;
           const t = anime.animeTitle || anime.title || '';
-          return titleMatches(t, keyword, resolvedSeason, false, 0.5);
+          return titleMatches(t, keyword, resolvedSeason, true, 0.5);
         });
         if (preFiltered.length > 0) {
           tmdbAbortController.abort();
+          // 记录原始搜索结果的全部animeId，供handleAnimes关联作品恢复误过滤条目使用
+          preFiltered._originalAnimeIds = originalResult.data.map(a => a.animeId);
           return preFiltered;
         }
         // 初筛清空原始结果时不abort，等待TMDB兜底
@@ -396,6 +398,36 @@ export default class DandanSource extends BaseSource {
                     rating: rel.rating || 0,
                     isRelated: true // 标记动态挖掘出的条目为相关作品
                   });
+                }
+              }
+            }
+
+            // 关联作品补回预过滤误剔除的原始搜索结果条目（如翻译差异导致误过滤）
+            if (!isTargetFoundInInitial && Array.isArray(details.relateds)) {
+              const originalIds = sourceAnimes._originalAnimeIds;
+              if (Array.isArray(originalIds) && originalIds.length > 0) {
+                const recoveredIds = new Set(originalIds);
+                for (const rel of details.relateds) {
+                  if (recoveredIds.has(rel.animeId) && !existingIds.has(rel.animeId)) {
+                    existingIds.add(rel.animeId);
+                    if (!sourceAnimes.some(a => a.animeId === rel.animeId)) {
+                      sourceAnimes.push({
+                        animeId: rel.animeId,
+                        animeTitle: rel.animeTitle,
+                        title: rel.animeTitle,
+                        imageUrl: rel.imageUrl,
+                        rating: rel.rating || 0,
+                        isRelated: true
+                      });
+                    }
+                    queue.push({
+                      animeId: rel.animeId,
+                      animeTitle: rel.animeTitle,
+                      imageUrl: rel.imageUrl,
+                      rating: rel.rating || 0,
+                      isRelated: true // 标记动态挖掘出的条目为相关作品
+                    });
+                  }
                 }
               }
             }

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -169,8 +169,12 @@ export default class DandanSource extends BaseSource {
         const preFiltered = originalResult.data.filter(anime => {
           if (anime.isTmdbSource) return true;
           const t = anime.animeTitle || anime.title || '';
-          return titleMatches(t, keyword, resolvedSeason, true, 0.5);
+          log("info", `[debug-prefilter] 调用titleMatches: t="${t}"(${t.length}chars) kw="${keyword}"(${keyword.length}chars) season=${resolvedSeason}`);
+          const matched = titleMatches(t, keyword, resolvedSeason, true, 0.5);
+          log("info", `[debug-prefilter] id=${anime.animeId} title="${t}" keyword="${keyword}" season=${resolvedSeason} match=${matched}`);
+          return matched;
         });
+        log("info", `[debug-prefilter] 结果: original=${originalResult.data.length}条 preFiltered=${preFiltered.length}条`);
         if (preFiltered.length > 0) {
           tmdbAbortController.abort();
           // 记录原始搜索结果的全部animeId，供handleAnimes关联作品恢复误过滤条目使用

--- a/danmu_api/sources/dandan.js
+++ b/danmu_api/sources/dandan.js
@@ -85,9 +85,6 @@ export default class DandanSource extends BaseSource {
             log("info", "[dandan] 原始搜索成功，但未返回任何结果 (source: original)");
             return { success: false, source: 'original' };
           }
-
-          // 原始搜索有结果，中断 TMDB 流程
-          tmdbAbortController.abort();
           const animes = resp.data.animes;
           log("info", `[dandan] dandanSearchresp (original): ${JSON.stringify(animes)}`);
           log("info", `[dandan] 返回 ${animes.length} 条结果 (source: original)`);
@@ -165,16 +162,24 @@ export default class DandanSource extends BaseSource {
         }
       })();
 
-      // 等待两个搜索任务同时完成，优先采用原始搜索结果
-      const [originalResult, tmdbResult] = await Promise.all([
-        originalSearchPromise,
-        tmdbSearchPromise
-      ]);
-
-      // 优先返回原始搜索结果
+      // 搜索结果预过滤：先拿到原始结果再决定是否等待TMDB兜底
+      const originalResult = await originalSearchPromise;
       if (originalResult.success) {
-        return originalResult.data;
+        const resolvedSeason = getExplicitSeasonNumber(keyword);
+        const preFiltered = originalResult.data.filter(anime => {
+          if (anime.isTmdbSource) return true;
+          const t = anime.animeTitle || anime.title || '';
+          return titleMatches(t, keyword, resolvedSeason, false, 0.5);
+        });
+        if (preFiltered.length > 0) {
+          tmdbAbortController.abort();
+          return preFiltered;
+        }
+        // 初筛清空原始结果时不abort，等待TMDB兜底
       }
+
+      // 原始搜索无结果或被初筛清空，等待并返回TMDB搜索结果
+      const tmdbResult = await tmdbSearchPromise;
 
       // 原始搜索无结果，返回 TMDB 搜索结果
       if (tmdbResult.success) {

--- a/danmu_api/utils/common-util.js
+++ b/danmu_api/utils/common-util.js
@@ -368,7 +368,7 @@ export function titleMatches(title, query, parsedSeason = null, forceNonStrict =
     }
   }
 
-  return false;
+  return simMatch;
 }
 
 /**


### PR DESCRIPTION


## 变更摘要

弹弹源 `search()` 返回后、`handleAnimes` 执行前，用低阈值 `titleMatches` 对搜索结果做初筛，剔除明显无关条目以避免浪费 `getEpisodes` 详情请求。同时将 TMDB 执行时机推迟至预过滤确认需要后才 `await`，确保 abort 在 TMDB 请求完成前生效。

## 上游原版行为

上游 `search()` 使用 `Promise.all` 并发执行原始搜索和 TMDB 日语原名搜索，无论原始搜索结果是否相关，TMDB 都会完成全部请求（即便原始搜索已返回足够相关的结果）。原始搜索结果全部进入 `handleAnimes`，每条都触发 `getEpisodes` 详情请求，由 `handleAnimes` 内部的 `titleMatches(threshold=0.8)` 和别名匹配做最终过滤。

以 "正相反的你与我" 为例：原始搜索返回一条 "相反的你和我"，该条目的详情接口返回别名 "正相反的你与我"，`handleAnimes` 通过包含匹配命中。同时 TMDB 的日语原名搜索并行执行完毕，但结果未被采用（原始结果优先）。多余的 TMDB 搜索请求无实际产出。

## 本 PR 变更

### 预过滤

`search()` 原始搜索完成后，对被搜索条目做 `titleMatches(threshold=0.4, forceNonStrict=true)` 检查：

- **命中**：立即 abort TMDB 并返回预过滤后的结果，跳过对已通过门阀条目的 TMDB 请求
- **初筛清空**：不 abort TMDB，保留日语原名兜底路径

预过滤使用较低门阀 0.4（默认 0.8），仅挡明显无关的条目（如仅含个别匹配字的杂讯），翻译差异结果（如 "相反的你和我" vs "正相反的你与我"，相似度约 0.71）保留通过。

### TMDB 结果预过滤

当原始搜索无结果或初筛清空、进入 TMDB 日语原名兜底时，对 TMDB 返回结果也做 `titleMatches(threshold=0.19, forceNonStrict=true)` 检查。TMDB 使用 episodes 接口按日语原名返回可能包含大量仅含个别匹配字的杂讯（如 "大正野球娘"、"正能量企鹅" 等），0.19 门阀仅需 2 个匹配字即可通过，1 字命中的噪声被剔除。

### 关联作品恢复预过滤误剔除

当预过滤因低相似度剔除了原始搜索结果中存在的关联作品（如搜索 "胆大党" 时 "超自然武装当哒当" 因翻译差异被 0.4 门阀过滤），`handleAnimes` 在处理保留条目的关联作品时，检查其 `animeId` 是否在原始搜索结果中被误剔除，若是则补回至处理队列。仅在未指定目标季时触发，避免干扰用户明确指定 "胆大党 第二季" 的场景。

### 执行顺序调整

原 `Promise.all` 并发改为先 `await` 原始搜索、预过滤判断后再决定是否 `await` TMDB，确保 abort 信号在 TMDB 请求完成前到达。

### titleMatches 相似度回归修复

`common-util.js` `titleMatches` 末尾 `return false` 改为 `return simMatch`。上游 commit 3345ed19 添加年份噪音兜底时误将返回值改为 `return false`，导致相似度策略（策略3）返回 `true` 时跳过年份兜底块后直接落到 `return false`——相似度比对的 `true` 结果在任何触发策略3的调用中均被丢弃。本 PR 的预过滤功能依赖低门阀相似度比对，故一并修复。

## 文件变更

| 文件 | 变更 |
|---|---|
| `danmu_api/utils/common-util.js` | `return false` → `return simMatch`，修复相似度策略返回值 |
| `danmu_api/sources/dandan.js` | 预过滤 + TMDB 预过滤 + 关联作品补回 + 执行顺序调整 +33/-1 行 |
