### PR TITLE
fix: 修复 PLATFORM_ORDER 平台优先递进失效

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1507,6 +1507,11 @@ async function matchAniAndEp(season, episode, year, searchData, title, req, plat
     }
   }
 
+  // 指定平台偏好时仅当最佳结果真实命中该平台（得分 > 0）才视为有效匹配，否则视作该平台无可用源交由上层按 PLATFORM_ORDER 顺延到下一平台或回退默认匹配，避免首个命中标题但平台得分 0 的番剧被误判为该平台匹配而阻断后续平台递进
+  if (platform && bestRes.score <= 0) {
+    return { resEpisode: null, resAnime: null };
+  }
+
   return { resEpisode: bestRes.episode, resAnime: bestRes.anime };
 }
 


### PR DESCRIPTION
希望这是当前架构下最后一个相关问题（

PLATFORM_ORDER 配置多个平台时，预期按序递进：qq 优选未匹配则顺延 qiyi→youku…，依次类推。实际表现为首个标题命中但平台得分 0 的番剧被误当作当前平台匹配，导致后续平台无法递进。

根因：matchAniAndEp(title,…,platform,…) 仅将 platform 参数用于评分，从不作为硬接受条件；而上层 for (const platform of dynamicPlatformOrder) 一旦取到任意 truthy 的 resAnime 即 break。二者契约错位，使首个标题命中、但平台不匹配（得分 0）的番剧（如 dandan&animeko 对 qq）被当成该平台匹配，阻断了后续平台递进。日志中 Found match with platform: qq 打印的实为循环变量而非真实平台，正是误导来源。

修复：在 matchAniAndEp 返回前增加守卫——指定平台偏好且最佳结果得分 <= 0 时返回空匹配，交由上层按 PLATFORM_ORDER 顺延到下一平台；全序耗尽则回退默认匹配（首个满足条件的番剧），契合「两者都没有则返回第一个满足条件的平台」。

影响范围：仅收紧了「指定平台偏好」时的接受条件；手动优选（isPreferredAnime +9999 绝对优先）、未配置 PLATFORM_ORDER 时的默认行为均不变。