### PR TITLE
fix: 修复在低 Node 版本下个别源获取弹幕失败

### DIFF
--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -23,6 +23,11 @@ import { startFavoriteScheduler, stopFavoriteScheduler } from './utils/favorite-
 // 导入 ES module 兼容层（始终加载，但内部会根据需要启用）
 import './esm-shim.cjs';
 
+// 预加载 node-fetch v3：仅在 Node < 20.19.0 等需兼容层的环境实际加载，其他环境为无操作；必须在首个请求前完成，否则 esm-shim 的 require 代理会拒绝同步取用
+if (typeof global.loadNodeFetch === 'function') {
+  await global.loadNodeFetch();
+}
+
 // 构建 CommonJS 环境下才有的全局变量
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -52,6 +52,13 @@ function linkSignal(externalSignal, internalController) {
   };
 }
 
+// iOS 巨魔环境（无 WebAssembly）与旧版 Node（自带 undici 解析响应头时会丢弃 Set-Cookie，导致依赖该响应头的令牌握手等请求失败）改用 node-fetch v3（由 esm-shim 在 Node < 20.19.0 时提供），其 Headers 正常暴露 Set-Cookie；与 esm-shim 的兼容性边界 20.19.0 保持一致，Node >= 20.19.0 仍用原生 fetch
+function shouldUseNodeFetch() {
+  if (typeof WebAssembly === 'undefined') return true;
+  const [major, minor] = process.versions.node.split('.').map(Number);
+  return major < 20 || (major === 20 && minor < 19);
+}
+
 export async function httpGet(url, options = {}) {
   // 从 options 中获取重试次数，默认为 0
   const maxRetries = parseInt(options.retries || '0', 10) || 0;
@@ -86,10 +93,10 @@ export async function httpGet(url, options = {}) {
     const cleanupSignal = linkSignal(options.signal, controller);
 
     try {
-      // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
+      // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
       let response;
-      if (typeof WebAssembly === 'undefined') {
-        log("info", "[system] [http] iOS环境降级使用node-fetch");
+      if (shouldUseNodeFetch()) {
+        log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, {
           method: 'GET',
@@ -306,10 +313,10 @@ export async function httpPost(url, body, options = {}) {
     }
 
     try {
-      // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
+      // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
       let response;
-      if (typeof WebAssembly === 'undefined') {
-        log("info", "[system] [http] iOS环境降级使用node-fetch");
+      if (shouldUseNodeFetch()) {
+        log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, fetchOptions);
       } else {
@@ -430,7 +437,15 @@ async function httpRequestMethod(method, url, body, options = {}) {
   }
 
   try {
-    const response = await fetch(url, fetchOptions);
+    // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
+    let response;
+    if (shouldUseNodeFetch()) {
+      log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
+      const fetch = (await import('node-fetch')).default;
+      response = await fetch(url, fetchOptions);
+    } else {
+      response = await fetch(url, fetchOptions);
+    }
     const textData = await response.text();
 
     if (!response.ok && !validStatusCodes.includes(response.status)) {
@@ -690,11 +705,23 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
     const currentSource = sourceLogContext.getStore() || "system";
     log("info", `[${currentSource}] [流式请求] HTTP GET: ${url}`);
 
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: headers,
-      signal: controller.signal
-    });
+    // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
+    let response;
+    if (shouldUseNodeFetch()) {
+      log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
+      const fetch = (await import('node-fetch')).default;
+      response = await fetch(url, {
+        method: 'GET',
+        headers: headers,
+        signal: controller.signal
+      });
+    } else {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: headers,
+        signal: controller.signal
+      });
+    }
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);


### PR DESCRIPTION
## 概述

修复 youku 等依赖响应头 `Set-Cookie` 做令牌握手的源，在 **Node < 20.19.0** 下获取弹幕失败的问题。

## 根因

- Node 18 自带的 undici（`fetch` 实验特性）在解析响应头时会**整体丢弃 `Set-Cookie`**——它根本不会进入 `response.headers` 对象。Node ≥ 20.19.0 的较新 undici 正常暴露该头。
- youku 的令牌握手读取 `tkEncRes.headers["set-cookie"]` 取 `_m_h5_tk` / `_m_h5_tk_enc`；拿不到令牌 → 后续请求 `FAIL_SYS_TOKEN_EMPTY` → `segmentList` 为空 → 迭代报 `TypeError: segmentList is not iterable`。
- 该缺陷位于运行时响应头解析层，上游原版在 Node 18 下即存在（非 youku 源逻辑问题）。

## 改动对照（vs 上游）

- `http-util.js`：原 `shouldUseNodeFetch()` 仅针对 iOS 巨魔环境（`typeof WebAssembly === 'undefined'`）降级到 node-fetch v3，扩展为「**Node < 20.19.0** 也走 node-fetch v3」，与 `esm-shim.cjs` 兼容层激活边界 `20.19.0` 对齐。原仅 `httpGet` / `httpPost` 各有一处降级分支，现统一覆盖全部 **4 个** fetch 调用点：`httpGet`、`httpPost`、`httpRequestMethod`（PATCH/PUT/DELETE 共用，原缺失）、`httpGetWithStreamCheck`（流式嗅探 GET，原缺失）。
- `server.js`：在导入 `esm-shim.cjs` 之后、首个请求之前，`await global.loadNodeFetch()` 预加载 node-fetch v3。原因：`esm-shim.cjs` 把 `import('node-fetch')` 改写为 `require('node-fetch')` 返回同步代理，该代理**仅在 `loadNodeFetch()` 先被 await 后**才有 `fetch`（否则抛 "must be loaded asynchronously first"）；此前全项目从未调用，故 node-fetch v3 实际从未被加载。

## 验证案例

以同一剧名查询实测（仅描述行为结果，不引用本地调试文件）：

- **修复前 Node 18**：令牌取不到（`set-cookie` 被旧 undici 丢弃）→ 后续请求 `FAIL_SYS_TOKEN_EMPTY` → `segmentList` 为空 → `TypeError: segmentList is not iterable`。
- **对照修复前 Node 22（原生 undici）**：令牌（`_m_h5_tk` / `_m_h5_tk_enc`）正常取回 → 弹幕处理完成，返回上万条。✅
- **修复后 Node 18（+esm-shim 激活 + 启动预加载 node-fetch v3）**：令牌经 node-fetch v3 取回 → 弹幕处理完成，返回正确条数（与 Node 22 同量级）。✅
- **多版本边界验证**：Node 18.0.0、20.18.3（均 < 20.19.0，触发降级）与 Node 20.19.0（≥ 20.19.0，走原生 fetch）均正常处理。✅

## 审查结论

| 维度 | 结论 |
|---|---|
| 代码风格 | 与现有代码一致 |
| 正规做法 | `shouldUseNodeFetch()` 封装 WebAssembly + Node 版本双重检查，4 个 fetch 调用点统一使用；降级边界与 `esm-shim.cjs` 的 `20.19.0` 对齐 |
| 新漏洞 | 无。`loadNodeFetch` 预加载在 server.js 顶层 `await`；esm-shim 在 Node ≥ 20.19.0 时 `global.loadNodeFetch` 为无操作，整块跳过 |
| 正常流程 | Node ≥ 20.19.0 → 原生 fetch（等价于上游）；iOS → node-fetch（不变）；Node < 20.19.0 → node-fetch v3（新行为，仅此分支生效） |

## 影响面与范围

- 仅 2 个文件改动：`server.js`、`http-util.js`。
- 全局 `fetch` 行为完全未动；直连全局 `fetch` 的 `bangumi-data-util.js` / `cookie-util.js`（bilibili 登录）/ `redis-util.js` 在 Node 18 实测不受影响（不消费 Set-Cookie），故未扩展修复范围。