### PR TITLE
feat: 使用 bangumi-data 数据实现季边界映射，优化跨季请求量与准确性

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1,5 +1,5 @@
 import { globals } from '../configs/globals.js';
-import { getPageTitle, jsonResponse, httpGet, sourceLogContext, toLogSourceName } from '../utils/http-util.js';
+import { getPageTitle, jsonResponse, httpGet, sourceLogContext, toLogSourceName, runWithHttpCache, httpCacheContext } from '../utils/http-util.js';
 import { log } from '../utils/log-util.js'
 import { simplized } from '../utils/zh-util.js';
 import { setRedisKey, updateRedisCaches } from "../utils/redis-util.js";
@@ -16,7 +16,7 @@ import {
   extractEpisodeTitle, convertChineseNumber, parseFileName, createDynamicPlatformOrder, normalizeSpaces, 
   extractYear, titleMatches, extractAnimeInfo, extractEpisodeNumberFromTitle, extractSeasonNumberFromAnimeTitle, extractAnimeTitle
 } from "../utils/common-util.js";
-import { getTMDBChineseTitle } from "../utils/tmdb-util.js";
+import { getTMDBChineseTitle, getTmdbSeasonBoundaries } from "../utils/tmdb-util.js";
 import { applyMergeLogic, mergeDanmakuList, MERGE_DELIMITER, alignSourceTimelines } from "../utils/merge-util.js";
 import { getHanjutvSourceLabel } from "../utils/hanjutv-util.js";
 import AIClient from '../utils/ai-util.js';
@@ -480,6 +480,14 @@ async function executeSourceHandlers(resultData, queryTitle, targetAnimesList, r
 
 // Extracted function for GET /api/v2/search/anime
 export async function searchAnime(url, preferAnimeId = null, preferSource = null, detailStore = null, targetPlatform = null, forceRefresh = false) {
+  // 单次搜索请求内启用 HTTP 响应复用缓存: 作为各源通用的请求级复用安全网, 借助 AsyncLocalStorage 做请求级隔离
+  if (httpCacheContext.getStore()) {
+    return searchAnimeBody(url, preferAnimeId, preferSource, detailStore, targetPlatform, forceRefresh);
+  }
+  return runWithHttpCache(() => searchAnimeBody(url, preferAnimeId, preferSource, detailStore, targetPlatform, forceRefresh));
+}
+
+async function searchAnimeBody(url, preferAnimeId = null, preferSource = null, detailStore = null, targetPlatform = null, forceRefresh = false) {
   let queryTitle = url.searchParams.get("keyword");
 
   // 搜索词杂音清理：移除画质/配音/版本等杂音词后再提交源站搜索
@@ -491,6 +499,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
   querySeason = querySeason ? parseInt(querySeason, 10) : null;
   let queryEpisode = url.searchParams.get("episode");
   queryEpisode = queryEpisode ? parseInt(queryEpisode, 10) : null;
+  let tmdbSeasonBoundaries = null;
   log("info", `[system] [searchAnime] Search anime with keyword: ${queryTitle}, target season: ${querySeason}, target episode: ${queryEpisode}`);
 
   // 关键字为空直接返回，不用多余查询
@@ -847,6 +856,24 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
 
       if (maxSeason > querySeason) {
         log("info", `[system] [LogVar-API] Episode ${queryEpisode} not satisfied in Season ${querySeason}. Parallel mapping to S${querySeason + 1}~S${maxSeason}...`);
+        // 依据 bangumi-data 的 TMDB 季边界定位目标集所在季, 跨季扩展直接收敛至目标季并跳过无关中间季, 集数扣减交由 findCrossSeasonEpisodeMap 借 TMDB 边界完成
+        let targetSeasons = [];
+        if (globals.useBangumiData && queryEpisode) {
+          tmdbSeasonBoundaries = await getTmdbSeasonBoundaries(queryTitle);
+          if (tmdbSeasonBoundaries && tmdbSeasonBoundaries.length >= 2) {
+            for (let i = tmdbSeasonBoundaries.length - 1; i >= 0; i--) {
+              const b = tmdbSeasonBoundaries[i];
+              if (queryEpisode >= b.startEpisode) {
+                targetSeasons = [b.order];
+                break;
+              }
+            }
+          }
+        }
+
+        const expansionStart = targetSeasons.length > 0 ? Math.min(...targetSeasons) : querySeason + 1;
+        const expansionEnd = targetSeasons.length > 0 ? Math.max(...targetSeasons) : maxSeason;
+
         const expandPromises = [];
         for (const source of globals.sourceOrderArr) {
           if (!resultData[source]) continue;
@@ -855,7 +882,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
           // 源间并发、源内顺序，防止同源并发导致模块级缓存竞态
           expandPromises.push((async () => {
             const sourceResults = [];
-            for (let s = querySeason + 1; s <= maxSeason; s++) {
+            for (let s = expansionStart; s <= expansionEnd; s++) {
               const seasonAnimes = [];
               await executeSourceHandlers({ [source]: resultData[source] }, queryTitle, seasonAnimes, requestAnimeDetailsMap, s, preferAnimeId, preferSource);
               if (seasonAnimes.length > 0) {
@@ -952,6 +979,7 @@ export async function searchAnime(url, preferAnimeId = null, preferSource = null
       success: true,
       errorMessage: "",
       animes: responseAnimes,
+      tmdbSeasonBoundaries,
     });
 
 }
@@ -1259,13 +1287,40 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
     }
   }
 
+  // 依据 TMDB 季边界推导「季号 -> 该季标准集数」, 使跨季顺延按剧集标准结构扣减而非依赖单源实际集数
+  const boundaries = searchData.tmdbSeasonBoundaries;
+  const seasonBoundaryCount = new Map();
+  if (Array.isArray(boundaries) && boundaries.length >= 2) {
+    for (let i = 0; i < boundaries.length; i++) {
+      const cur = boundaries[i];
+      const next = boundaries[i + 1];
+      seasonBoundaryCount.set(cur.order, next ? next.startEpisode - cur.startEpisode : null);
+    }
+  }
+
+
   let currentTargetEpisode = episode;
   let currentSeason = season;
   let bestRes = { anime: null, episode: null, score: 0 };
 
-  while (seasonMap.has(currentSeason)) {
+  while (seasonMap.has(currentSeason) || seasonBoundaryCount.has(currentSeason)) {
     const seasonData = seasonMap.get(currentSeason);
+    // 该季标准集数: 优先取 TMDB 边界推导值, 末季或边界缺失时回退至实际过滤后集数
+    const boundaryCount = seasonBoundaryCount.get(currentSeason);
+
+    // 中间季未拉取详情(已被 TMDB 边界跳过)时, 仅按其标准集数扣减以推进到目标季, 不参与实际集标题匹配
+    if (!seasonData) {
+      if (boundaryCount && boundaryCount > 0) {
+        currentTargetEpisode -= boundaryCount;
+        currentSeason++;
+        continue;
+      }
+      break;
+    }
+
     const allEps = seasonData.episodes;
+    const seasonEpisodeTotal = (boundaryCount && boundaryCount > 0) ? boundaryCount : allEps.length;
+
 
     let absoluteMatch = null;
     for (const ep of allEps) {
@@ -1293,6 +1348,22 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
     if (currentTargetEpisode <= allEps.length) {
       const targetEp = allEps[currentTargetEpisode - 1];
       if (platform && getPlatformMatchScore(extractEpisodeTitle(targetEp.episodeTitle), platform) === 0) {
+        currentSeason++;
+        continue;
+      }
+      log("info", `[system] [spillover] 跨季溢出查找命中 (按相对排位计算) -> 所在季：S${currentSeason} 集标题：${targetEp.episodeTitle}`);
+      bestRes = {
+        anime: seasonData.anime,
+        episode: targetEp,
+        score: platform ? getPlatformMatchScore(seasonData.actualPlatform, platform) : 1
+      };
+      break;
+    }
+
+    // 目标集号超出实际集数但仍落在该季 TMDB 标准区间内: 真实集数偏短时返回该季最后一集, 避免无谓顺延至后续季
+    if (currentTargetEpisode <= seasonEpisodeTotal) {
+      const targetEp = allEps[allEps.length - 1];
+      if (platform && getPlatformMatchScore(extractEpisodeTitle(targetEp.episodeTitle), platform) === 0) {
           currentSeason++;
           continue;
       }
@@ -1305,8 +1376,8 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
       break;
     }
 
-    log("info", `[system] [spillover] S${currentSeason} 共有 ${allEps.length} 集(已过滤番外)，剩余目标集数为 ${currentTargetEpisode}，映射至 S${currentSeason + 1} 继续查找`);
-    currentTargetEpisode -= allEps.length;
+    log("info", `[system] [spillover] S${currentSeason} 共有 ${seasonEpisodeTotal} 集(已过滤番外)，剩余目标集数为 ${currentTargetEpisode}，映射至 S${currentSeason + 1} 继续查找`);
+    currentTargetEpisode -= seasonEpisodeTotal;
     currentSeason++;
   }
 

--- a/danmu_api/sources/iqiyi.js
+++ b/danmu_api/sources/iqiyi.js
@@ -56,14 +56,15 @@ export default class IqiyiSource extends BaseSource {
       const queryString = buildQueryString(params);
       const url = `https://mesh.if.iqiyi.com/portal/lw/search/homePageV3?${queryString}`;
 
-      const doSearch = async () => {
+      const doSearch = async (bypassCache = false) => {
         const resp = await httpGet(url, {
           headers: {
             'accept': '*/*',
             'origin': 'https://www.iqiyi.com',
             'referer': 'https://www.iqiyi.com/',
             'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-          }
+          },
+          bypassCache
         });
         if (!resp || !resp.data) return null;
         return typeof resp.data === "string" ? JSON.parse(resp.data) : resp.data;
@@ -76,7 +77,7 @@ export default class IqiyiSource extends BaseSource {
         const reason = !data ? "搜索响应为空" : `搜索接口风控 (code=${data.code})`;
         log("info", `[iqiyi] ${reason}，等待 3 秒后重试 (${attempt + 1}/${MAX_RETRIES})`);
         await new Promise(r => setTimeout(r, 3000));
-        data = await doSearch();
+        data = await doSearch(true);
       }
 
       if (!data) {
@@ -522,13 +523,14 @@ export default class IqiyiSource extends BaseSource {
 
     // base_info 接口可能返回空响应或结构残缺的响应，此处最多重试两次再放弃
     const MAX_EPISODE_RETRIES = 2;
-    const fetchEpisodeData = async () => {
+    const fetchEpisodeData = async (bypassCache = false) => {
       try {
         const resp = await httpGet(url, {
           headers: {
             'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
             'Referer': 'https://www.iqiyi.com/'
-          }
+          },
+          bypassCache
         });
         if (!resp || !resp.data) return null;
         return typeof resp.data === "string" ? JSON.parse(resp.data) : resp.data;
@@ -542,7 +544,7 @@ export default class IqiyiSource extends BaseSource {
     for (let attempt = 0; attempt < MAX_EPISODE_RETRIES && (!data || data.status_code !== 0 || !data.data || !data.data.template); attempt++) {
       log("info", `[iqiyi] 分集接口返回异常${data ? ` (status_code: ${data.status_code})` : " (响应为空或解析失败)"}，等待 3 秒后重试 (${attempt + 1}/${MAX_EPISODE_RETRIES})`);
       await new Promise(r => setTimeout(r, 3000));
-      data = await fetchEpisodeData();
+      data = await fetchEpisodeData(true);
     }
 
     if (!data || data.status_code !== 0 || !data.data || !data.data.template) {
@@ -972,6 +974,7 @@ export default class IqiyiSource extends BaseSource {
             "Content-Type": "application/json",
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
           },
+          bypassCache: true
         });
         const retryData = typeof retryRes.data === "string" ? JSON.parse(retryRes.data) : retryRes.data;
         const retryDuration = Number(retryData.data.durationSec) || 0;

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -5,6 +5,13 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 // 跨异步生命周期链路的日志上下文追踪器
 export const sourceLogContext = new AsyncLocalStorage();
 
+// 单次搜索请求内的 HTTP 响应复用缓存: 相同 URL 的重复 GET 直接复用, 借助 AsyncLocalStorage 实现请求级隔离
+export const httpCacheContext = new AsyncLocalStorage();
+
+export function runWithHttpCache(fn) {
+  return httpCacheContext.run(new Map(), fn);
+}
+
 // 源调度键名（sourceOrderArr）到日志标签规范名称的映射
 // sourceOrderArr 中部分键名与对应源文件的标签命名不一致（如 360→360kan, imgo→mango）
 // 此映射表统一转换，确保 HTTP 日志标签与源文件内部标签一致
@@ -53,6 +60,14 @@ function linkSignal(externalSignal, internalController) {
 }
 
 export async function httpGet(url, options = {}) {
+  // 单次搜索请求内 HTTP 响应复用: 若当前请求上下文已激活复用缓存且本 URL 已缓存, 直接返回克隆结果, 跳过重复网络请求
+  const requestHttpCache = httpCacheContext.getStore();
+  if (requestHttpCache && requestHttpCache.has(url)) {
+    const cached = requestHttpCache.get(url);
+    log("info", `[${sourceLogContext.getStore() || 'system'}] [请求复用] 复用请求内已缓存的 HTTP 响应, 跳过重复请求: ${url}`);
+    return { data: structuredClone(cached.data), status: cached.status, headers: { ...cached.headers } };
+  }
+
   // 从 options 中获取重试次数，默认为 0
   const maxRetries = parseInt(options.retries || '0', 10) || 0;
   // 提取允许放行的特定状态码白名单
@@ -203,6 +218,11 @@ export async function httpGet(url, options = {}) {
       // 请求成功，返回结果
       if (attempt > 0) {
         log("info", `[${currentSource}] [请求模拟] 重试成功`);
+      }
+
+      // 将本次响应记入请求内复用缓存, 供同请求内相同 URL 的后续请求直接复用
+      if (requestHttpCache) {
+        requestHttpCache.set(url, { data: structuredClone(parsedData), status: response.status, headers });
       }
 
       // 模拟 iOS 环境：返回 { data: ... } 结构

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -62,7 +62,9 @@ function linkSignal(externalSignal, internalController) {
 export async function httpGet(url, options = {}) {
   // 单次搜索请求内 HTTP 响应复用: 若当前请求上下文已激活复用缓存且本 URL 已缓存, 直接返回克隆结果, 跳过重复网络请求
   const requestHttpCache = httpCacheContext.getStore();
-  if (requestHttpCache && requestHttpCache.has(url)) {
+  // 重试调用传入 bypassCache 时跳过复用，避免复用首次已缓存的失败响应而令重试被静默吞掉
+  const bypassCache = options.bypassCache === true;
+  if (requestHttpCache && !bypassCache && requestHttpCache.has(url)) {
     const cached = requestHttpCache.get(url);
     log("info", `[${sourceLogContext.getStore() || 'system'}] [请求复用] 复用请求内已缓存的 HTTP 响应, 跳过重复请求: ${url}`);
     return { data: structuredClone(cached.data), status: cached.status, headers: { ...cached.headers } };
@@ -221,7 +223,7 @@ export async function httpGet(url, options = {}) {
       }
 
       // 将本次响应记入请求内复用缓存, 供同请求内相同 URL 的后续请求直接复用
-      if (requestHttpCache) {
+      if (requestHttpCache && !bypassCache) {
         requestHttpCache.set(url, { data: structuredClone(parsedData), status: response.status, headers });
       }
 

--- a/danmu_api/utils/tmdb-util.js
+++ b/danmu_api/utils/tmdb-util.js
@@ -759,3 +759,67 @@ export function smartTitleReplace(animes, cnAlias) {
     }
   }
 }
+
+// =====================
+// TMDB 季边界映射
+// =====================
+
+/**
+ * 将 bangumi-data 的 TMDB 扁平检索结果转换为跨季边界序列.
+ * 每个 matchedSiteKey 为 'tmdb' 的结果, 其 siteId 形如 "tv/{id}" 或
+ * "tv/{id}/season/N/episode/{M}", M 为该条目在 TMDB 绝对编号中的起始集数;
+ * 收集同一 tv/{id} 下各条目起始集数即可推算跨季映射边界
+ * @param {Array<Object>} matches searchBangumiData 返回的扁平结果数组
+ * @returns {Array<{order:number, startEpisode:number, title:string, tmdbId:string}>|null}
+ */
+export function buildTmdbSeasonBoundaries(matches) {
+  const baseMaps = new Map();
+
+  for (const m of matches) {
+    if (!m || m.matchedSiteKey !== 'tmdb' || !m.siteId) continue;
+
+    const epMatch = m.siteId.match(/^(tv\/\d+)(?:\/season\/\d+\/episode\/(\d+))?$/);
+    if (!epMatch) continue;
+
+    const baseId = epMatch[1];
+    const startEp = epMatch[2] ? parseInt(epMatch[2], 10) : 1;
+
+    const entry = { order: 0, startEpisode: startEp, title: m.title || '', tmdbId: baseId };
+    if (!baseMaps.has(baseId)) {
+      baseMaps.set(baseId, [entry]);
+    } else {
+      baseMaps.get(baseId).push(entry);
+    }
+  }
+
+  if (baseMaps.size === 0) return null;
+
+  const best = [...baseMaps.entries()]
+    .sort((a, b) => b[1].length - a[1].length)[0];
+
+  if (best[1].length < 2) return null;
+
+  best[1].sort((a, b) => a.startEpisode - b.startEpisode);
+  for (let i = 0; i < best[1].length; i++) {
+    best[1][i].order = i + 1;
+  }
+  return best[1];
+}
+
+/**
+ * 依据番剧标题从 bangumi-data 推导 TMDB 跨季边界, 用于在目标集不在首季时跳过无关季号
+ * @param {string} title 检索标题 (直接传给 searchBangumiData, 内部已做季剥离处理)
+ * @param {(title: string, siteKeys: string[]) => Promise<Array<Object>>} [searchFn]
+ * @returns {Promise<Array<{order:number, startEpisode:number, title:string, tmdbId:string}>|null>}
+ */
+export async function getTmdbSeasonBoundaries(title, searchFn = searchBangumiData) {
+  if (!globals.useBangumiData) return null;
+
+  try {
+    const matches = await searchFn(title, ['tmdb']);
+    return buildTmdbSeasonBoundaries(matches);
+  } catch (e) {
+    log('warn', `[system] [tmdb] Bangumi-Data 本地获取TMDB季边界失败: ${e.message}（检索词：${title}）`);
+    return null;
+  }
+}


### PR DESCRIPTION
Bangumi Data 上游 [采纳了我提议的tmdb不分季的id写法](https://github.com/bangumi-data/bangumi-data/pull/357)（tv/203737/season/1/episode/25） 现在能够从 Bangumi Data 推算出这些不分季条目的明确边界，优化跨季请求量与准确性🥰

## 概述

本分支包含两项相互独立但同分支演进的改动：

1. **feat：使用 bangumi-data 数据实现 TMDB 季边界映射，优化跨季请求量与准确性**
2. **fix：修复请求级 HTTP 缓存误杀源级同 URL 重试**

---

## 改动对照（vs 上游）

### 1. TMDB 季边界映射（新增 `tmdb-util.js`；改动 `dandan-api.js`）

- 新增 `buildTmdbSeasonBoundaries` / `getTmdbSeasonBoundaries`：消费 bangumi-data 的扁平结果 `{matchedSiteKey, siteId}`，将 TMDB 的季结构映射为「季序 → 起始集」边界表（取条目最多的 TMDB `tv` 组；至少 2 条边界才生效，否则返回 null）。
- 跨季扩展：在启用 Bangumi Data 且能解析到 TMDB 季边界时，由上游原版「向后逐季顺序扩展（S+1、S+2…）」收敛为「依据 TMDB 边界直接定位目标集所在季」，跳过其间无关季（如要看 S5、中间 S4 无需拉取），降低无效 API 请求量；**未启用 Bangumi Data 或边界未解析时，维持上游原版逐季顺序扩展**。
- 跨季顺延集数扣减：能解析到 TMDB 边界时按「TMDB 标准总集数」扣减，否则按上游原版「某季实际拉到的集数」扣减，避免中间季集数统计偏差导致收敛到错误季。

### 2. 请求级 HTTP 响应复用（全源去重，零源改动，`http-util.js`）

- `httpGet` 新增请求级缓存：同一搜索请求内相同 URL 的重复 GET 直接复用首次响应，不再发网络请求；配套 `httpCacheContext` 与 `runWithHttpCache`（基于 `AsyncLocalStorage` 请求级隔离）。
- `searchAnime` 用 `runWithHttpCache` 把整次搜索（主搜索 + 跨季扩展）包进同一请求级缓存上下文；跨季扩展重跑各源 `getEpisodes` 用的是与主搜索相同的番剧 id（详情 URL 一致），重复 GET 自动抹平。该机制位于共享 `httpGet`，对所有源自动生效，**无需改动任何源文件**。

### 3. 修复请求级缓存误杀源级同 URL 重试（`http-util.js` + `iqiyi.js`）

- **根因**：请求级缓存对每次成功响应写缓存（含 HTTP-200 但语义失败），读缓存在 `httpGet` 顶部、先于源级重试逻辑；iqiyi 搜索风控（`code=-1`）与 base_info 异常的源级同 URL 重试重调 `httpGet` 时命中缓存，复用首次已缓存的失败响应，导致重试被静默吞掉、始终失败。
- **修复**：新增 `bypassCache` 选项——源级重试显式声明后跳过读/写缓存，刻意重取绕过去重；首次（非重试）调用仍走缓存，跨季扩展的全源去重收益保留。通用请求工具内置的 `retries:` 重试不受此问题影响（失败尝试不写缓存、循环内重发网络）。经全源遍历确认，仅 iqiyi 有源级同 URL 重试，故根机制配合其重试接线即覆盖全部受影响源。

### 改动范围最小化

- 最终仅 4 个文件有分支专属改动：`tmdb-util.js`（新增）、`dandan-api.js`、`http-util.js`、`iqiyi.js`。各源文件（含 `dandan.js`）经评审全部回退至上游，未携带任何分支专属改动。

---

## 验证案例

以下均为真实端到端运行（启动服务、用真实番剧查询跑出的匹配结果），核心结论抽象如下：

### 跨季直达目标季、跳过无关季请求（dandan，上游 vs 分支）

以我推的孩子 S1E28（dandan）为例：该剧第一季仅 11 集，目标集第 28 话实际落在第三季。

- **上游原版**：`Episode 28 not satisfied in Season 1. Parallel mapping to S2~S3...`，依次拉取第二季与第三季详情，其中第二季为无关季、其详情请求被浪费；最终按标题数字命中第三季「第 28 话 盲目」。
- **当前分支**：启用 Bangumi Data 后命中 TMDB 季边界（E28 在第 3 季，边界 S1@E1、S2@E12、S3@E25），`TMDB 边界已定位目标季 S3, 跨季扩展仅收敛至该季, 跳过中间的无关季(如 S2)请求` → `Parallel mapping to S3~S3...`，**跳过第二季详情请求**，直接复用主搜结果定位第三季，同样命中「第 28 话 盲目」。

结果一致且正确，分支少发一次无关季的详情请求。

### 准确性修复：上游错选第七集、分支正确选第四集（最能体现价值）

以我推的孩子 S01E28、数据源 renren 为例（同一查询、同一数据源）：

- **上游原版**：逐季扩展顺序拉取 S2 与 S3 详情；按某季「实际拉到集数」扣减（该源第一季仅列 8 集）→ 28−8−13=7，错选第三季第 7 集。
- **当前分支**：TMDB 边界直接定位目标季 S3，跳过 S2 详情请求（减少一次无效 API 调用）；按 TMDB 标准集数（S1=11、S2=13）扣减 → 28−11−13=4，正确命中第三季第 4 集。

根因：部分数据源某一季只列出部分集数（如该源 S1 实际标准应为 11 集却只列 8 集），上游按「实际集数」扣减产生 off-by-3 误差；分支改用 TMDB 权威标准集数后消除，同时减少一次无关季请求。

### 请求级缓存去重

同源同 URL 在主搜与跨季扩展间重复出现时，由 `httpGet` 请求级缓存一次性复用，跨季扩展复用主搜结果即依赖此机制，对所有源零改动生效。

---

## 边界与回退（保证常规流程不受影响）

- `useBangumiData=false` → 无边界 → 走上游原版逐季扩展。
- 边界未解析 → 按原「某季实际集数」扣减。
- `bypassCache=false`（默认）→ 不绕过缓存。
- 既有项目回归测试套件全部通过。

## 审查结论

| 维度 | 结论 |
|---|---|
| 代码风格 | 与现有代码一致，注释无时间性质词 |
| 正规做法 | `buildTmdbSeasonBoundaries` 为可测试纯函数；`httpCacheContext` 基于 `AsyncLocalStorage` 请求级隔离；`bypassCache` 开门式避免静默吞重试 |
| 正常流程 | `useBangumiData=false` / 无边界 / `bypassCache=false` 均回退上游原版行为，不受影响 |
