### PR TITLE
fix: 旧版 Node 与 iOS 环境下请求降级至 node-fetch v3 修复响应头丢失导致个别源弹幕获取失败

### DIFF
--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -23,6 +23,11 @@ import { startFavoriteScheduler, stopFavoriteScheduler } from './utils/favorite-
 // 导入 ES module 兼容层（始终加载，但内部会根据需要启用）
 import './esm-shim.cjs';
 
+// 预加载 node-fetch v3：仅在 Node < 20.19.0 等需兼容层的环境实际加载，其他环境为无操作；必须在首个请求前完成，否则 esm-shim 的 require 代理会拒绝同步取用
+if (typeof global.loadNodeFetch === 'function') {
+  await global.loadNodeFetch();
+}
+
 // 构建 CommonJS 环境下才有的全局变量
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -54,7 +54,7 @@ function linkSignal(externalSignal, internalController) {
   };
 }
 
-// 旧版 Node（自带 undici 解析响应头时会丢弃 Set-Cookie，导致依赖该响应头的令牌握手等请求失败）与 iOS 巨魔环境（无 WebAssembly、无原生 fetch）改用 node-fetch v3（由 esm-shim 在 Node < 20.19.0 时提供，其 Headers 正常暴露 Set-Cookie）；与 esm-shim 的兼容性边界 20.19.0 保持一致，Node >= 20.19.0 仍用原生 fetch。该判定仅依赖静态环境、进程内恒定，故模块加载时计算一次并缓存，避免每次请求重复判定与重复日志
+// 旧版 Node（<20.19.0，自带 undici 解析响应头时丢弃 Set-Cookie）与 iOS 巨魔（无 WebAssembly、无原生 fetch）改用 node-fetch v3（其 Headers 正常暴露 Set-Cookie）；降级边界与 esm-shim 的 20.19.0 一致，Node >= 20.19.0 仍用原生 fetch。判定仅依赖静态环境、进程内恒定，故模块加载时算一次并缓存。
 function detectNodeFetchDowngrade() {
   if (typeof WebAssembly === 'undefined') return true;
   const [major, minor] = process.versions.node.split('.').map(Number);

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -52,6 +52,13 @@ function linkSignal(externalSignal, internalController) {
   };
 }
 
+// iOS 巨魔环境（无 WebAssembly）与旧版 Node（自带 undici 解析响应头时会丢弃 Set-Cookie，导致依赖该响应头的令牌握手等请求失败）改用 node-fetch v3（由 esm-shim 在 Node < 20.19.0 时提供），其 Headers 正常暴露 Set-Cookie；与 esm-shim 的兼容性边界 20.19.0 保持一致，Node >= 20.19.0 仍用原生 fetch
+function shouldUseNodeFetch() {
+  if (typeof WebAssembly === 'undefined') return true;
+  const [major, minor] = process.versions.node.split('.').map(Number);
+  return major < 20 || (major === 20 && minor < 19);
+}
+
 export async function httpGet(url, options = {}) {
   // 从 options 中获取重试次数，默认为 0
   const maxRetries = parseInt(options.retries || '0', 10) || 0;
@@ -86,10 +93,10 @@ export async function httpGet(url, options = {}) {
     const cleanupSignal = linkSignal(options.signal, controller);
 
     try {
-      // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
+      // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
       let response;
-      if (typeof WebAssembly === 'undefined') {
-        log("info", "[system] [http] iOS环境降级使用node-fetch");
+      if (shouldUseNodeFetch()) {
+        log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, {
           method: 'GET',
@@ -306,10 +313,10 @@ export async function httpPost(url, body, options = {}) {
     }
 
     try {
-      // 兼容iOS巨魔环境：使用node-fetch替代内置fetch
+      // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
       let response;
-      if (typeof WebAssembly === 'undefined') {
-        log("info", "[system] [http] iOS环境降级使用node-fetch");
+      if (shouldUseNodeFetch()) {
+        log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, fetchOptions);
       } else {
@@ -430,7 +437,15 @@ async function httpRequestMethod(method, url, body, options = {}) {
   }
 
   try {
-    const response = await fetch(url, fetchOptions);
+    // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
+    let response;
+    if (shouldUseNodeFetch()) {
+      log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
+      const fetch = (await import('node-fetch')).default;
+      response = await fetch(url, fetchOptions);
+    } else {
+      response = await fetch(url, fetchOptions);
+    }
     const textData = await response.text();
 
     if (!response.ok && !validStatusCodes.includes(response.status)) {
@@ -690,11 +705,23 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
     const currentSource = sourceLogContext.getStore() || "system";
     log("info", `[${currentSource}] [流式请求] HTTP GET: ${url}`);
 
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: headers,
-      signal: controller.signal
-    });
+    // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
+    let response;
+    if (shouldUseNodeFetch()) {
+      log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
+      const fetch = (await import('node-fetch')).default;
+      response = await fetch(url, {
+        method: 'GET',
+        headers: headers,
+        signal: controller.signal
+      });
+    } else {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: headers,
+        signal: controller.signal
+      });
+    }
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);

--- a/danmu_api/utils/http-util.js
+++ b/danmu_api/utils/http-util.js
@@ -1,6 +1,8 @@
 import { globals } from '../configs/globals.js';
 import { log } from './log-util.js'
 import { AsyncLocalStorage } from 'node:async_hooks';
+import https from 'node:https';
+import http from 'node:http';
 
 // 跨异步生命周期链路的日志上下文追踪器
 export const sourceLogContext = new AsyncLocalStorage();
@@ -52,11 +54,29 @@ function linkSignal(externalSignal, internalController) {
   };
 }
 
-// iOS 巨魔环境（无 WebAssembly）与旧版 Node（自带 undici 解析响应头时会丢弃 Set-Cookie，导致依赖该响应头的令牌握手等请求失败）改用 node-fetch v3（由 esm-shim 在 Node < 20.19.0 时提供），其 Headers 正常暴露 Set-Cookie；与 esm-shim 的兼容性边界 20.19.0 保持一致，Node >= 20.19.0 仍用原生 fetch
-function shouldUseNodeFetch() {
+// 旧版 Node（自带 undici 解析响应头时会丢弃 Set-Cookie，导致依赖该响应头的令牌握手等请求失败）与 iOS 巨魔环境（无 WebAssembly、无原生 fetch）改用 node-fetch v3（由 esm-shim 在 Node < 20.19.0 时提供，其 Headers 正常暴露 Set-Cookie）；与 esm-shim 的兼容性边界 20.19.0 保持一致，Node >= 20.19.0 仍用原生 fetch。该判定仅依赖静态环境、进程内恒定，故模块加载时计算一次并缓存，避免每次请求重复判定与重复日志
+function detectNodeFetchDowngrade() {
   if (typeof WebAssembly === 'undefined') return true;
   const [major, minor] = process.versions.node.split('.').map(Number);
   return major < 20 || (major === 20 && minor < 19);
+}
+
+const USE_NODE_FETCH = detectNodeFetchDowngrade();
+if (USE_NODE_FETCH) {
+  // 模块载入时 logLevel 尚未初始化，用 console.log 保证启动提示必现
+  console.log("[system] [http] 检测到旧版Node/iOS环境，已全局切换至 node-fetch v3 作为请求实现");
+}
+
+// 降级分支共享 keep-alive Agent，复用 TCP/TLS 连接以与原生 undici 连接池达到实际等价（消除重复握手开销）；按协议区分 https/http
+const nodeFetchHttpsAgent = USE_NODE_FETCH ? new https.Agent({ keepAlive: true, keepAliveMsecs: 1000, maxSockets: 256 }) : null;
+const nodeFetchHttpAgent = USE_NODE_FETCH ? new http.Agent({ keepAlive: true, keepAliveMsecs: 1000, maxSockets: 256 }) : null;
+function nodeFetchAgent(parsedUrl) {
+  const protocol = parsedUrl instanceof URL ? parsedUrl.protocol : new URL(parsedUrl).protocol;
+  return protocol === 'https:' ? nodeFetchHttpsAgent : nodeFetchHttpAgent;
+}
+
+function shouldUseNodeFetch() {
+  return USE_NODE_FETCH;
 }
 
 export async function httpGet(url, options = {}) {
@@ -96,14 +116,14 @@ export async function httpGet(url, options = {}) {
       // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
       let response;
       if (shouldUseNodeFetch()) {
-        log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
         const fetch = (await import('node-fetch')).default;
         response = await fetch(url, {
           method: 'GET',
           headers: {
             ...options.headers,
           },
-          signal: controller.signal
+          signal: controller.signal,
+          agent: nodeFetchAgent
         });
       } else {
         // 现代浏览器环境
@@ -316,9 +336,8 @@ export async function httpPost(url, body, options = {}) {
       // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
       let response;
       if (shouldUseNodeFetch()) {
-        log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
         const fetch = (await import('node-fetch')).default;
-        response = await fetch(url, fetchOptions);
+        response = await fetch(url, { ...fetchOptions, agent: nodeFetchAgent });
       } else {
         // 现代浏览器环境
         response = await fetch(url, fetchOptions);
@@ -440,9 +459,8 @@ async function httpRequestMethod(method, url, body, options = {}) {
     // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
     let response;
     if (shouldUseNodeFetch()) {
-      log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
       const fetch = (await import('node-fetch')).default;
-      response = await fetch(url, fetchOptions);
+      response = await fetch(url, { ...fetchOptions, agent: nodeFetchAgent });
     } else {
       response = await fetch(url, fetchOptions);
     }
@@ -708,12 +726,12 @@ export async function httpGetWithStreamCheck(url, options = {}, checkCallback) {
     // 兼容iOS巨魔或旧版Node：使用node-fetch替代内置fetch
     let response;
     if (shouldUseNodeFetch()) {
-      log("info", "[system] [http] 降级使用node-fetch（iOS巨魔或旧版Node）");
       const fetch = (await import('node-fetch')).default;
       response = await fetch(url, {
         method: 'GET',
         headers: headers,
-        signal: controller.signal
+        signal: controller.signal,
+        agent: nodeFetchAgent
       });
     } else {
       response = await fetch(url, {


### PR DESCRIPTION
## 概述

修复 youku 等依赖响应头 `Set-Cookie` 做令牌握手的源，在 **Node < 20.19.0** 下获取弹幕失败的问题。做法是：在旧版 Node 与 iOS 巨魔环境下，将 `http-util` 托管的**请求层统一降级**为 node-fetch v3（其 Headers 正常暴露 Set-Cookie），与原生 undici 功能等价；并通过共享 keep-alive 连接池消除降级带来的连接复用差异，使并发性能与原生 undici 达到实际等价。

## 根因

- Node 18 自带的 undici（`fetch` 实验特性）在解析响应头时会**整体丢弃 `Set-Cookie`**——它根本不会进入 `response.headers` 对象。Node ≥ 20.19.0 的较新 undici 正常暴露该头。
- youku 的令牌握手读取 `tkEncRes.headers["set-cookie"]` 取 `_m_h5_tk` / `_m_h5_tk_enc`；拿不到令牌 → 后续请求 `FAIL_SYS_TOKEN_EMPTY` → `segmentList` 为空 → 迭代报 `TypeError: segmentList is not iterable`。
- 该缺陷位于运行时响应头解析层，上游原版在 Node 18 下即存在（非 youku 源逻辑问题）。

## 改动对照（vs 上游）

- `http-util.js`：
  - 原 `shouldUseNodeFetch()` 仅针对 iOS 巨魔环境（`typeof WebAssembly === 'undefined'`）降级到 node-fetch v3，扩展为「**Node < 20.19.0** 也走 node-fetch v3」，与 `esm-shim.cjs` 兼容层激活边界 `20.19.0` 对齐。原仅 `httpGet` / `httpPost` 各有一处降级分支，现统一覆盖全部 **4 个** fetch 调用点：`httpGet`、`httpPost`、`httpRequestMethod`（PATCH/PUT/DELETE 共用，原缺失）、`httpGetWithStreamCheck`（流式嗅探 GET，原缺失）。
  - 降级判定仅依赖静态环境（WebAssembly 与 Node 版本），进程内恒定，故**模块加载时计算一次并缓存**；原 4 处「每次请求都输出」的降级日志收敛为**运行时单次启动日志**，避免降级环境下日志刷屏。
  - 降级分支新增**共享 keep-alive Agent**（按协议区分 https/http），复用 TCP/TLS 连接，使 node-fetch v3 与原生 undici 连接池达到实际等价（消除重复握手开销），补齐降级路径的并发性能——项目核心是并发请求各源接口，连接复用对此至关重要。
- `server.js`：在导入 `esm-shim.cjs` 之后、首个请求之前，`await global.loadNodeFetch()` 预加载 node-fetch v3。原因：`esm-shim.cjs` 把 `import('node-fetch')` 改写为 `require('node-fetch')` 返回同步代理，该代理**仅在 `loadNodeFetch()` 先被 await 后**才有 `fetch`（否则抛 "must be loaded asynchronously first"）；此前全项目从未调用，故 node-fetch v3 实际从未被加载。

## 已知说明（影响范围与取舍）

- **环境级请求层降级（非按源）**：在 Node < 20.19.0 或 iOS 巨魔环境下，**所有经 `http-util` 托管的请求**（即项目统一请求入口，覆盖 youku/dandan/iqiyi/tencent 等几乎所有源）都会改用 node-fetch v3，而不仅是 youku。这是为通用性做的取舍——避免将来每新增一个依赖 Set-Cookie 的源都需逐个改造（`http-util` 保持源无关、零源改动）。现代 Node（≥ 20.19.0）完全不受影响，仍走原生 fetch。绕过 `http-util` 直接调用 fetch 的少数后端文件（见影响面）不受影响。
- **降级并非无代价，已用 keep-alive 抹平**：node-fetch v3 默认走 `keepAlive: false` 的全局 Agent，并发下比原生 undici 连接池更重、更慢；本分支通过共享 keep-alive Agent 复用连接，消除主导开销，与原生达到实际等价。对数量有限 host、大量短 HTTPS GET 的访问模式（跨季并行 mapping 即属此类），剩余差异可忽略。
- **与原生 fetch 的其余差异**：node-fetch v3 响应体为 Node Readable 流（非 Web ReadableStream），`httpGetWithStreamCheck` 已用 `if (!reader)` 回退兼容；错误类型为 `FetchError`（重试逻辑看 `cause.code` / `name`，仍生效）；超时统一走 `AbortController`，两条路一致。

## 验证案例

以同一剧名查询实测（仅描述行为结果，不引用本地调试文件）：

- **修复前 Node 18**：令牌取不到（`set-cookie` 被旧 undici 丢弃）→ 后续请求 `FAIL_SYS_TOKEN_EMPTY` → `segmentList` 为空 → `TypeError: segmentList is not iterable`。
- **对照修复前 Node 22（原生 undici）**：令牌（`_m_h5_tk` / `_m_h5_tk_enc`）正常取回 → 弹幕处理完成，返回上万条。✅
- **修复后 Node 18（+esm-shim 激活 + 启动预加载 node-fetch v3）**：令牌经 node-fetch v3 取回 → 弹幕处理完成，返回正确条数（与 Node 22 同量级）。✅
- **多版本边界验证**：Node 18.0.0、20.18.3（均 < 20.19.0，触发降级）与 Node 20.19.0（≥ 20.19.0，走原生 fetch）均正常处理。✅

## 审查结论

| 维度 | 结论 |
|---|---|
| 代码风格 | 与现有代码一致 |
| 正规做法 | `shouldUseNodeFetch()` 封装 WebAssembly + Node 版本双重检查，4 个 fetch 调用点统一使用；降级边界与 `esm-shim.cjs` 的 `20.19.0` 对齐；共享 keep-alive Agent 为业界常规连接复用做法 |
| 新漏洞 | 无。`loadNodeFetch` 预加载在 server.js 顶层 `await`；esm-shim 在 Node ≥ 20.19.0 时 `global.loadNodeFetch` 为无操作，整块跳过 |
| 正常流程 | Node ≥ 20.19.0 → 原生 fetch（等价于上游）；iOS → node-fetch（不变）；Node < 20.19.0 → node-fetch v3（新行为，仅此分支生效） |
| 日志 | 降级判定模块级算一次，启动时日志一次；不再每次请求输出 |

## 影响面与范围

- 仅 2 个文件改动：`server.js`、`http-util.js`。
- 全局 `fetch` 行为完全未动；直连全局 `fetch` 的 `bangumi-data-util.js` / `cookie-util.js`（bilibili 登录）/ `redis-util.js` 在 Node 18 实测不受影响（不消费 Set-Cookie），故未扩展修复范围。
