### PR TITLE
fix(match): 修复偏好偏移计算目标集数为0时数组越界引发TypeError及400异常

### DIFF
--- a/danmu_api/apis/dandan-api.js
+++ b/danmu_api/apis/dandan-api.js
@@ -1077,10 +1077,12 @@ function findEpisodeByNumber(filteredEpisodes, episode, targetEpisode, platform 
   }
 
   // 策略2：使用数组索引
-  if (platformEpisodes.length >= targetEpisode) {
+  if (targetEpisode > 0 && platformEpisodes.length >= targetEpisode) {
     const fallbackEp = platformEpisodes[targetEpisode - 1];
-    log("info", `Using fallback array index for episode ${targetEpisode}: ${fallbackEp.episodeTitle}`);
-    return fallbackEp;
+    if (fallbackEp) {
+      log("info", `Using fallback array index for episode ${targetEpisode}: ${fallbackEp.episodeTitle}`);
+      return fallbackEp;
+    }
   }
   
   // 策略3：使用episodeNumber字段匹配
@@ -1346,19 +1348,21 @@ function findCrossSeasonEpisodeMap(searchData, title, year, season, episode, pla
       break;
     }
 
-    if (currentTargetEpisode <= allEps.length) {
+    if (currentTargetEpisode > 0 && currentTargetEpisode <= allEps.length) {
       const targetEp = allEps[currentTargetEpisode - 1];
-      if (platform && getPlatformMatchScore(extractEpisodeTitle(targetEp.episodeTitle), platform) === 0) {
-        currentSeason++;
-        continue;
+      if (targetEp) {
+        if (platform && getPlatformMatchScore(extractEpisodeTitle(targetEp.episodeTitle), platform) === 0) {
+          currentSeason++;
+          continue;
+        }
+        log("info", `[system] [spillover] 跨季溢出查找命中 (按相对排位计算) -> 所在季：S${currentSeason} 集标题：${targetEp.episodeTitle}`);
+        bestRes = {
+          anime: seasonData.anime,
+          episode: targetEp,
+          score: platform ? getPlatformMatchScore(seasonData.actualPlatform, platform) : 1
+        };
+        break;
       }
-      log("info", `[system] [spillover] 跨季溢出查找命中 (按相对排位计算) -> 所在季：S${currentSeason} 集标题：${targetEp.episodeTitle}`);
-      bestRes = {
-        anime: seasonData.anime,
-        episode: targetEp,
-        score: platform ? getPlatformMatchScore(seasonData.actualPlatform, platform) : 1
-      };
-      break;
     }
 
     // 目标集号超出实际集数但仍落在该季 TMDB 标准区间内: 真实集数偏短时返回该季最后一集, 避免无谓顺延至后续季
@@ -2077,10 +2081,10 @@ export async function matchAnime(url, req, clientIp) {
     // 示例返回
     return jsonResponse(resData);
   } catch (error) {
-    // 处理 JSON 解析错误或其他异常
-    log("error", `[system] [match] Failed to parse request body: ${error.message}`);
+    // 处理匹配请求中的异常
+    log("error", `[system] [match] Error processing match request: ${error.stack || error.message}`);
     return jsonResponse(
-      { errorCode: 400, success: false, errorMessage: "Invalid JSON body" },
+      { errorCode: 400, success: false, errorMessage: error.message || "Invalid JSON body" },
       400
     );
   }


### PR DESCRIPTION
## 🐛 问题背景与触发场景

在 `/api/v2/match` 接口匹配剧集弹幕时，如果当前请求的集数与系统记忆的历史偏好偏移（`offsets`）推演计算出目标集数为 `0` 或负数时，接口会触发 JavaScript `TypeError` 并向客户端返回 `400` 错误。

### 具体触发场景示例：
1. 系统中存在一条历史偏好记忆：`offsets["1"] = "5:【qiyi】 家业第1集 那我就不做李家人了！"`（即曾经在 Season 1 匹配第 5 集时，绑定到了爱奇艺包含《第1集》标题的资源，其在播放列表中的 index 为 `0`）。
2. 客户端下一次发起对 `S1E4`（第 4 集）的自动匹配请求。
3. 系统重新计算偏好偏移：
   - 差值 `offset = episode(4) - offsetEpisode(5) = -1`
   - 计算目标集号 `targetEpisode = offsetIndex(0) + offset(-1) + 1 = 0`
4. 代码执行到 `findEpisodeByNumber` 的策略 2（数组索引匹配）：
   - 原判断条件为 `if (platformEpisodes.length >= targetEpisode)`（当爱奇艺有 42 集时，`42 >= 0` 判定为 `true`）。
   - 代码尝试访问 `platformEpisodes[targetEpisode - 1]` 对应 `platformEpisodes[-1]`（返回 `undefined`）。
   - 紧接着在读取 `fallbackEp.episodeTitle` 时，抛出致命异常：
     `TypeError: Cannot read properties of undefined (reading 'episodeTitle')`
   - 外层 `try...catch` 捕获异常后向客户端返回了 HTTP `400` 错误。

---

## 🛠️ 所做改动 (Changes Made)

1. **`findEpisodeByNumber` 增加边界防护**：
   - 策略 2（数组索引匹配）增加 `targetEpisode > 0` 判定，防止 `targetEpisode <= 0` 时读取负索引。
   - 对获取到的 `fallbackEp` 增加存在性判断，规避潜在的越界访问。

2. **`findCrossSeasonEpisodeMap` 增加边界防护**：
   - 跨季 relative offset 匹配逻辑中，增加 `currentTargetEpisode > 0` 及 `targetEp` 存在性校验，防止推导越界访问 `allEps[-1]`。

3. **优化日志与错误捕获**：
   - 优化 `matchAnime` 最外层 `catch` 块的日志与错误返回，输出完整的错误堆栈，避免将未捕获的运行时异常误报为 `Failed to parse request body`。

---

## 🧪 验证情况 (Verification)

- **本地语法与单元验证**：代码经 Node 语法编译检查无误。
- **边界测试**：当偏好偏移推导出 `targetEpisode <= 0` 时，系统能安全忽略该偏好偏移，降级使用标准匹配策略匹配真实集数，不再触发 `TypeError` 崩溃。