### PR TITLE
fix(bilibili): 修复多 p 视频按总时长计算分段数导致越界请求 304 空响应

### DIFF
--- a/danmu_api/sources/bilibili.js
+++ b/danmu_api/sources/bilibili.js
@@ -815,7 +815,7 @@ export default class BilibiliSource extends BaseSource {
           return null;
         }
 
-        duration = data.data.duration;
+        duration = data.data.pages[p - 1].duration;
         cid = data.data.pages[p - 1].cid;
       } catch (error) {
         log("error", "[bilibili] 请求普通投稿视频信息失败:", error);


### PR DESCRIPTION
普通投稿视频分支使用 data.data.duration（全部分 p 的总时长）计算弹幕分段数，却只对第 p 页的 cid 发起请求。多 p 视频单页时长远小于总时长，按总时长算出的分段数远超该页实际分段，越界请求的分段在 B 站不存在、返回 304 空响应，被熔断逻辑误判为视频结束而中断后续分段获取，造成弹幕缺漏。

改为使用 data.data.pages[p - 1].duration（第 p 页真实时长）计算分段数，与 cid 取值同源；单 p 视频 pages[0].duration 与 data.duration 相等，无回归。