### PR TITLE
fix(ui): UI 细节与响应式优化

### DIFF
--- a/danmu_api/ui/css/base.css.js
+++ b/danmu_api/ui/css/base.css.js
@@ -7,6 +7,7 @@ export const baseCssContent = /* css */ `
     margin: 0;
     padding: 0;
     box-sizing: border-box;
+    -webkit-tap-highlight-color: transparent; /* 消除移动端点击时的蓝色框 */
 }
 
 :root {

--- a/danmu_api/ui/css/components.css.js
+++ b/danmu_api/ui/css/components.css.js
@@ -2680,9 +2680,7 @@ body[data-theme$="-dark"] .heatmap-bar {
     font-size: 12px;
     font-weight: 600;
     color: var(--theme-text);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow-wrap: break-word;
 }
 
 .anime-cache-child-actions {

--- a/danmu_api/ui/css/components.css.js
+++ b/danmu_api/ui/css/components.css.js
@@ -2593,6 +2593,11 @@ body[data-theme$="-dark"] .heatmap-bar {
     gap: 10px;
 }
 
+.recent-data-load-more {
+    width: 100%;
+    margin-top: 10px;
+}
+
 .anime-cache-card {
     background: var(--theme-container-bg);
     border: 1px solid var(--theme-border);
@@ -2616,8 +2621,7 @@ body[data-theme$="-dark"] .heatmap-bar {
     width: 56px;
     height: 76px;
     border-radius: 8px;
-    background-size: cover;
-    background-position: center;
+    object-fit: cover;
     background-color: var(--theme-panel-strong);
     flex-shrink: 0;
 }
@@ -2632,9 +2636,7 @@ body[data-theme$="-dark"] .heatmap-bar {
     font-weight: 700;
     color: var(--theme-text);
     margin-bottom: 4px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow-wrap: break-word;
 }
 
 .anime-cache-meta {
@@ -2664,8 +2666,7 @@ body[data-theme$="-dark"] .heatmap-bar {
     width: 36px;
     height: 48px;
     border-radius: 6px;
-    background-size: cover;
-    background-position: center;
+    object-fit: cover;
     background-color: var(--theme-panel-strong);
     flex-shrink: 0;
 }

--- a/danmu_api/ui/css/components.css.js
+++ b/danmu_api/ui/css/components.css.js
@@ -2051,7 +2051,9 @@ body.modal-open {
     border: 1px solid var(--theme-border);
 }
 
-
+.jump-to-episode > span {
+    font-size: 13px;
+}
 
 .jump-episode-input {
     padding: 7px 12px;

--- a/danmu_api/ui/css/components.css.js
+++ b/danmu_api/ui/css/components.css.js
@@ -2051,12 +2051,17 @@ body.modal-open {
     border: 1px solid var(--theme-border);
 }
 
+
+
 .jump-episode-input {
     padding: 7px 12px;
     width: 110px;
+    max-width: 100%;
+    min-width: 0;
     border: 1px solid var(--theme-border);
     border-radius: var(--app-radius-input);
     font-size: 13px;
+    text-align: center;
     background: var(--theme-input-bg);
     color: var(--theme-text);
 }

--- a/danmu_api/ui/css/components.css.js
+++ b/danmu_api/ui/css/components.css.js
@@ -969,6 +969,44 @@ body.modal-open {
     font-size: 13px;
 }
 
+.error-config-banner {
+    background: var(--theme-panel-strong);
+    border: 1px solid var(--theme-border);
+    padding: 15px;
+    border-radius: var(--app-radius-card-sm);
+    margin-bottom: 20px;
+}
+
+.error-config-title {
+    color: var(--theme-accent);
+    margin-top: 0;
+    font-size: 16px;
+}
+
+.error-config-text {
+    color: var(--theme-muted);
+    margin-bottom: 10px;
+    font-size: 14px;
+}
+
+.error-config-banner input {
+    padding: 8px 10px;
+    border: 1px solid var(--theme-border);
+    border-radius: 8px;
+    background: var(--theme-input-bg);
+    color: var(--theme-text);
+}
+
+.error-config-banner code {
+    background: var(--theme-panel-bg);
+    border: 1px solid var(--theme-border);
+    border-radius: 4px;
+    padding: 0.1em 0.35em;
+    font-size: 0.85em;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+    word-break: break-all;
+}
+
 .close-btn {
     background: var(--theme-panel-strong);
     border: none;
@@ -1953,6 +1991,32 @@ body.modal-open {
     border-radius: 999px;
     flex-shrink: 0;
     font-weight: 600;
+}
+
+.episode-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 12px;
+    border-radius: 8px;
+    gap: 16px;
+    transition: background 0.15s;
+}
+
+.episode-item:hover {
+    background: var(--theme-panel-bg);
+    box-shadow: inset 3px 0 0 var(--theme-accent);
+}
+
+.episode-item-content {
+    min-width: 0;
+    font-size: 14px;
+    color: var(--theme-text);
+}
+
+.episode-item .btn {
+    flex-shrink: 0;
+    margin-left: auto;
 }
 
 .danmu-mode-scroll { background: rgba(94, 196, 219, 0.15); color: #3aafc8; }

--- a/danmu_api/ui/css/forms.css.js
+++ b/danmu_api/ui/css/forms.css.js
@@ -540,7 +540,7 @@ input:checked + .slider:before {
     transition: transform 0.22s var(--app-ease-smooth);
 }
 .map-remove-btn:hover {
-    transform: rotate(90deg);
+    transform: translateY(-1px);
 }
 
 .map-item-template {

--- a/danmu_api/ui/css/responsive.css.js
+++ b/danmu_api/ui/css/responsive.css.js
@@ -238,4 +238,48 @@ export const responsiveCssContent = /* css */ `
         border-radius: 16px;
     }
 }
+
+.search-actions {
+    display: flex;
+    gap: 10px;
+    margin-top: 5px;
+    flex-wrap: wrap;
+}
+
+/* 手机端：输入框独占第一行，收藏和搜索按钮并排 */
+@media (max-width: 500px) {
+    .search-actions input {
+        flex-basis: 100%;
+        min-width: 100%;
+        order: 1;
+    }
+    .search-actions .favorite-action-btn {
+        flex: 1;
+        order: 2;
+    }
+    .search-actions #manual-search-btn {
+        flex: 1;
+        order: 3;
+    }
+}
+
+/* 剧集操作按钮：PC 窄 120px、平板适中 160px、手机窄 100px */
+.episode-item .btn,
+.jump-episode-btn {
+    max-width: 120px;
+}
+
+@media (min-width: 501px) and (max-width: 768px) {
+    .episode-item .btn,
+    .jump-episode-btn {
+        max-width: 160px;
+    }
+}
+
+@media (max-width: 500px) {
+    .episode-item .btn,
+    .jump-episode-btn {
+        max-width: 100px;
+    }
+}
 `;

--- a/danmu_api/ui/js/main.js
+++ b/danmu_api/ui/js/main.js
@@ -8,7 +8,7 @@ function createCustomAlert() {
     }
 
     // 创建弹窗HTML元素
-    const alertHTML = '<div class="modal" id="custom-alert-overlay"><div class="modal-content" id="custom-alert-content"><div class="modal-header"><h3 id="custom-alert-title">提示</h3><button class="close-btn" id="custom-alert-close">&times;</button></div><div class="modal-body"><p id="custom-alert-message"></p></div><div class="modal-footer"><button class="btn btn-primary" id="custom-alert-confirm">确定</button></div></div></div>';
+    const alertHTML = '<div class="modal" id="custom-alert-overlay"><div class="modal-content" id="custom-alert-content"><div class="modal-header"><h3 id="custom-alert-title">提示</h3><button class="close-btn" id="custom-alert-close">&times;</button></div><div class="modal-body"><p id="custom-alert-message" style="word-break: break-all;"></p></div><div class="modal-footer"><button class="btn btn-primary" id="custom-alert-confirm">确定</button></div></div></div>';
 
     // 添加到body
     document.body.insertAdjacentHTML('beforeend', alertHTML);
@@ -49,7 +49,7 @@ function customAlert(message, title = '提示') {
 
     // 设置标题和消息
     titleElement.textContent = title;
-    messageElement.textContent = message;
+    messageElement.innerHTML = message.replace(/\\n/g, '<br>');
 
     // 显示弹窗
     overlay.classList.add('active');
@@ -717,9 +717,9 @@ const DANMAKU_DICT = [
     '@huangxd-', '@wan0ge', '@woleigedouer', '@Wo254992', '@lilixu3',
     '@Celestials316', '@dyphire', '@piaoyizy', '@xiaoQQya', '@liixing',
     '@goodcommunication', '@Mr-Quin', '@chason-zhao', '@DemoJameson',
-    '@rinnein', '@Lampon', '@zcw199604', 'Mashiro',
+    '@rinnein', '@Lampon', '@zcw199604', 'Mashiro', '@wade6716',
     '请合理使用', '公益服务请适当调高缓存避免滥用',
-    '有弹幕才有氛围~', '大家陪你看', 'LogVar可能会倒闭但绝对不会变质',
+    '有弹幕才有氛围~', '弹幕陪你看', 'LogVar可能会倒闭但绝对不会变质',
 ];
 
 // 共享弹幕发射间隔 0.5~1.5s

--- a/danmu_api/ui/js/main.js
+++ b/danmu_api/ui/js/main.js
@@ -8,7 +8,7 @@ function createCustomAlert() {
     }
 
     // 创建弹窗HTML元素
-    const alertHTML = '<div class="modal" id="custom-alert-overlay"><div class="modal-content" id="custom-alert-content"><div class="modal-header"><h3 id="custom-alert-title">提示</h3><button class="close-btn" id="custom-alert-close">&times;</button></div><div class="modal-body"><p id="custom-alert-message" style="word-break: break-all;"></p></div><div class="modal-footer"><button class="btn btn-primary" id="custom-alert-confirm">确定</button></div></div></div>';
+    const alertHTML = '<div class="modal" id="custom-alert-overlay"><div class="modal-content" id="custom-alert-content"><div class="modal-header"><h3 id="custom-alert-title">提示</h3><button class="close-btn" id="custom-alert-close">&times;</button></div><div class="modal-body"><p id="custom-alert-message" style="word-break: break-all; white-space: pre-line;"></p></div><div class="modal-footer"><button class="btn btn-primary" id="custom-alert-confirm">确定</button></div></div></div>';
 
     // 添加到body
     document.body.insertAdjacentHTML('beforeend', alertHTML);
@@ -49,7 +49,7 @@ function customAlert(message, title = '提示') {
 
     // 设置标题和消息
     titleElement.textContent = title;
-    messageElement.innerHTML = message.replace(/\\n/g, '<br>');
+    messageElement.textContent = message; // 使用 textContent 避免 message 中的 HTML 被解析执行；换行由元素 CSS white-space: pre-line 渲染
 
     // 显示弹窗
     overlay.classList.add('active');

--- a/danmu_api/ui/js/systemsettings.js
+++ b/danmu_api/ui/js/systemsettings.js
@@ -3257,7 +3257,6 @@ function applyInputFeedback(inputEl) {
     const oldBorder = inputEl.style.borderColor;
     inputEl.style.borderColor = '#28a745';
     setTimeout(() => inputEl.style.borderColor = oldBorder, 800);
-    inputEl.focus();
 }
 
 // 表单填充逻辑：合并映射表

--- a/danmu_api/ui/js/systemsettings.js
+++ b/danmu_api/ui/js/systemsettings.js
@@ -3006,6 +3006,11 @@ function toggleMapping(btnEl) {
     }
 }
 
+// 最近数据分页状态
+const RECENT_DATA_PAGE_SIZE = 5;
+let recentAnimeCacheData = []; // 最近数据完整缓存
+let recentAnimeDisplayedCount = 0; // 最近数据已显示条数
+
 // 快捷数据面板业务逻辑
 async function fetchAndShowRecentData() {
     const panel = document.getElementById('recent-data-panel');
@@ -3026,6 +3031,8 @@ async function fetchAndShowRecentData() {
         const result = await response.json();
 
         if (result.success && result.data && result.data.length > 0) {
+            recentAnimeCacheData = result.data;
+            recentAnimeDisplayedCount = 0;
             renderAnimeCachePanel(result.data, listContainer);
         } else {
             listContainer.innerHTML = '<div class="text-gray font-size-12" style="padding: 10px 0;">缓存中暂无番剧数据，请先通过客户端请求弹幕接口以生成缓存。</div>';
@@ -3061,11 +3068,14 @@ function renderAnimeCachePanel(data, listContainer) {
     // 内部辅助函数：清洗标题
     const cleanTitleStr = (rawTitle) => rawTitle.replace(/\\s*from\\s+.*$/i, '').trim().replace(/'/g, '&apos;');
 
-    let html = '<div class="anime-cache-list">';
+    const nextCount = Math.min(recentAnimeDisplayedCount + RECENT_DATA_PAGE_SIZE, data.length);
+    const newItems = data.slice(recentAnimeDisplayedCount, nextCount);
 
-    data.forEach(item => {
+    let html = recentAnimeDisplayedCount === 0 ? '<div class="anime-cache-list">' : '';
+
+    newItems.forEach(item => {
         const cleanTitle = cleanTitleStr(item.animeTitle);
-        const coverStyle = item.imageUrl ? \`background-image: url('\${item.imageUrl}');\` : '';
+        const coverHtml = item.imageUrl ? \`<img class="anime-cache-cover" src="\${escapeHtml(item.imageUrl)}" alt="" referrerpolicy="no-referrer" loading="lazy">\` : '<div class="anime-cache-cover"></div>';
 
         // 1. 构建合并子源模块
         let childrenHtml = '';
@@ -3075,7 +3085,7 @@ function renderAnimeCachePanel(data, listContainer) {
             const childItems = item.mergedChildren.map(child => {
                 const childCleanTitle = cleanTitleStr(child.animeTitle);
 
-                const childCoverStyle = child.imageUrl ? \`background-image: url('\${child.imageUrl}');\` : '';
+                const childCoverHtml = child.imageUrl ? \`<img class="anime-cache-child-cover" src="\${escapeHtml(child.imageUrl)}" alt="" referrerpolicy="no-referrer" loading="lazy">\` : '<div class="anime-cache-child-cover"></div>';
 
                 // 解析映射数据并按匹配状态排序
                 let mappingHtml = '';
@@ -3164,7 +3174,7 @@ function renderAnimeCachePanel(data, listContainer) {
                 return \`
                     <div class="anime-cache-child-item">
                         <div class="anime-cache-child-main">
-                            <div class="anime-cache-child-cover" style="\${childCoverStyle}"></div>
+                            \${childCoverHtml}
                             <div class="anime-cache-child-info">
                                 <div class="anime-cache-child-title" title="\${child.animeTitle}">\${childCleanTitle}</div>
                                 <div class="anime-cache-meta">[\${child.source}] (\${child.episodes}集)</div>
@@ -3227,7 +3237,7 @@ function renderAnimeCachePanel(data, listContainer) {
         html += \`
             <div class="anime-cache-card">
                 <div class="anime-cache-card-body">
-                    <div class="anime-cache-cover" style="\${coverStyle}"></div>
+                    \${coverHtml}
                     <div class="anime-cache-info">
                         <div class="anime-cache-title" title="\${item.animeTitle}">\${cleanTitle}</div>
                         <div class="anime-cache-meta">[\${item.source}] (\${item.episodes}集)</div>
@@ -3243,8 +3253,40 @@ function renderAnimeCachePanel(data, listContainer) {
         \`;
     });
 
-    html += '</div>';
-    listContainer.innerHTML = html;
+    if (recentAnimeDisplayedCount === 0) {
+        html += '</div>';
+        listContainer.innerHTML = html;
+    } else {
+        const listEl = listContainer.querySelector('.anime-cache-list');
+        if (listEl) listEl.insertAdjacentHTML('beforeend', html);
+    }
+
+    recentAnimeDisplayedCount = nextCount;
+    updateRecentDataLoadMore(listContainer, data.length, nextCount);
+}
+
+// 更新最近数据加载更多按钮
+function updateRecentDataLoadMore(listContainer, total, displayed) {
+    let loadMoreBtn = listContainer.querySelector('.recent-data-load-more');
+    if (displayed < total) {
+        if (!loadMoreBtn) {
+            loadMoreBtn = document.createElement('button');
+            loadMoreBtn.type = 'button';
+            loadMoreBtn.className = 'btn btn-primary btn-sm recent-data-load-more';
+            loadMoreBtn.onclick = loadMoreRecentData;
+            listContainer.appendChild(loadMoreBtn);
+        }
+        loadMoreBtn.textContent = '加载更多 (' + displayed + '/' + total + ')';
+    } else if (loadMoreBtn) {
+        loadMoreBtn.remove();
+    }
+}
+
+// 加载更多最近数据
+function loadMoreRecentData() {
+    const listContainer = document.getElementById('recent-data-list');
+    if (!listContainer) return;
+    renderAnimeCachePanel(recentAnimeCacheData, listContainer);
 }
 
 /* ========================================

--- a/danmu_api/ui/js/systemsettings.js
+++ b/danmu_api/ui/js/systemsettings.js
@@ -3050,23 +3050,25 @@ function renderAnimeCachePanel(data, listContainer) {
 
     // 内部辅助函数：生成操作按钮
     const generateButtons = (title, source) => {
+        const safeTitle = escapeHtml(title);
+        const safeSource = escapeHtml(source);
         if (currentKey === 'CUSTOM_MERGE_RULES') {
             return \`
                 <div style="display:flex;flex-direction:column;gap:4px;">
-                    <button type="button" class="btn btn-sm btn-xs" onclick="fillMergeEntity('sec', '\${title}', '\${source}')">设为副</button>
-                    <button type="button" class="btn btn-sm btn-primary btn-xs" onclick="fillMergeEntity('prim', '\${title}', '\${source}')">设为主</button>
+                    <button type="button" class="btn btn-sm btn-xs" data-fill-action="merge-sec" data-fill-title="\${safeTitle}" data-fill-source="\${safeSource}">设为副</button>
+                    <button type="button" class="btn btn-sm btn-primary btn-xs" data-fill-action="merge-prim" data-fill-title="\${safeTitle}" data-fill-source="\${safeSource}">设为主</button>
                 </div>
             \`;
         } else if (currentKey === 'DANMU_OFFSET') {
             return \`
-                <button type="button" class="btn btn-sm btn-primary btn-xs" onclick="fillOffsetEntity('\${title}', '\${source}')">填入</button>
+                <button type="button" class="btn btn-sm btn-primary btn-xs" data-fill-action="offset" data-fill-title="\${safeTitle}" data-fill-source="\${safeSource}">填入</button>
             \`;
         }
         return '';
     };
 
     // 内部辅助函数：清洗标题
-    const cleanTitleStr = (rawTitle) => rawTitle.replace(/\\s*from\\s+.*$/i, '').trim().replace(/'/g, '&apos;');
+    const cleanTitleStr = (rawTitle) => rawTitle.replace(/\\s*from\\s+.*$/i, '').trim();
 
     const nextCount = Math.min(recentAnimeDisplayedCount + RECENT_DATA_PAGE_SIZE, data.length);
     const newItems = data.slice(recentAnimeDisplayedCount, nextCount);
@@ -3101,8 +3103,8 @@ function renderAnimeCachePanel(data, listContainer) {
 
                         let mainSide = '(主源越界)';
                         if (hasMainMatch) {
-                            const cleanMainEpTitle = (link.title || '未知剧集').replace(/^【.*?】\\s*/, '').replace(/'/g, '&apos;').replace(/"/g, '&quot;');
-                            mainSide = \`【\${item.source}】\${cleanMainEpTitle}\`;
+                            const cleanMainEpTitle = escapeHtml((link.title || '未知剧集').replace(/^【.*?】\\s*/, ''));
+                            mainSide = \`【\${escapeHtml(item.source)}】\${cleanMainEpTitle}\`;
                         }
 
                         let childSide = '(副源缺失)';
@@ -3120,13 +3122,13 @@ function renderAnimeCachePanel(data, listContainer) {
                                 if (child.links && child.links.length > 0) {
                                     const childLink = child.links.find(l => String(l.url) === String(childId));
                                     if (childLink && childLink.title) {
-                                        childTitleStr = childLink.title.replace(/^【.*?】\\s*/, '').replace(/'/g, '&apos;').replace(/"/g, '&quot;');
+                                        childTitleStr = childLink.title.replace(/^【.*?】\\s*/, '');
                                     }
                                 }
                             } else {
-                                childTitleStr = (link.title || '').replace(/^【.*?】\\s*/, '').replace(/'/g, '&apos;').replace(/"/g, '&quot;');
+                                childTitleStr = (link.title || '').replace(/^【.*?】\\s*/, '');
                             }
-                            childSide = \`【\${child.source}】\${childTitleStr}\`;
+                            childSide = \`【\${escapeHtml(child.source)}】\${escapeHtml(childTitleStr)}\`;
                             
                             const numMatch = childTitleStr.match(/\\d+/);
                             if (numMatch) {
@@ -3176,8 +3178,8 @@ function renderAnimeCachePanel(data, listContainer) {
                         <div class="anime-cache-child-main">
                             \${childCoverHtml}
                             <div class="anime-cache-child-info">
-                                <div class="anime-cache-child-title" title="\${child.animeTitle}">\${childCleanTitle}</div>
-                                <div class="anime-cache-meta">[\${child.source}] (\${child.episodes}集)</div>
+                                <div class="anime-cache-child-title" title="\${escapeHtml(child.animeTitle)}">\${escapeHtml(childCleanTitle)}</div>
+                                <div class="anime-cache-meta">[\${escapeHtml(child.source)}] (\${child.episodes}集)</div>
                             </div>
                             <div class="anime-cache-child-actions">
                                 \${generateButtons(childCleanTitle, child.source)}
@@ -3201,7 +3203,7 @@ function renderAnimeCachePanel(data, listContainer) {
         if (item.links && item.links.length > 0) {
             episodesCount = item.links.length;
             const epItems = item.links.map(link => {
-                const safeTitle = link.title ? link.title.replace(/'/g, '&apos;').replace(/"/g, '&quot;') : '未知剧集';
+                const safeTitle = link.title ? escapeHtml(link.title) : '未知剧集';
                 return \`
                     <div class="anime-cache-child-item" style="padding: 6px;">
                         <div class="anime-cache-child-main">
@@ -3239,8 +3241,8 @@ function renderAnimeCachePanel(data, listContainer) {
                 <div class="anime-cache-card-body">
                     \${coverHtml}
                     <div class="anime-cache-info">
-                        <div class="anime-cache-title" title="\${item.animeTitle}">\${cleanTitle}</div>
-                        <div class="anime-cache-meta">[\${item.source}] (\${item.episodes}集)</div>
+                        <div class="anime-cache-title" title="\${escapeHtml(item.animeTitle)}">\${escapeHtml(cleanTitle)}</div>
+                        <div class="anime-cache-meta">[\${escapeHtml(item.source)}] (\${item.episodes}集)</div>
                     </div>
                     <div class="anime-cache-actions">
                         \${generateButtons(cleanTitle, item.source)}
@@ -3348,4 +3350,20 @@ function fillOffsetEntity(title, source) {
         applyInputFeedback(inputEl);
     }
 }
+
+// 处理最近数据面板快捷填入按钮的点击
+document.addEventListener('click', function(e) {
+    const btn = e.target.closest('[data-fill-action]');
+    if (!btn) return;
+    const action = btn.dataset.fillAction;
+    const title = btn.dataset.fillTitle;
+    const source = btn.dataset.fillSource;
+    if (action === 'offset') {
+        fillOffsetEntity(title, source);
+    } else if (action === 'merge-sec') {
+        fillMergeEntity('sec', title, source);
+    } else if (action === 'merge-prim') {
+        fillMergeEntity('prim', title, source);
+    }
+});
 `;

--- a/danmu_api/ui/template.js
+++ b/danmu_api/ui/template.js
@@ -84,16 +84,16 @@ export const HTML_TEMPLATE = /* html */ `
             <div class="section active" id="preview-section">
                 <h2>配置预览</h2>
                 
-                <div id="proxy-config-container" style="display: none; background: #fff3cd; border: 1px solid #ffeeba; padding: 15px; border-radius: 5px; margin-bottom: 20px;">
-                    <h3 style="color: #856404; margin-top: 0; font-size: 16px;">⚠️ 获取配置失败</h3>
-                    <p style="color: #856404; margin-bottom: 10px; font-size: 14px;">
+                <div id="proxy-config-container" class="error-config-banner" style="display: none;">
+                    <h3 class="error-config-title">⚠️ 获取配置失败</h3>
+                    <p class="error-config-text">
                         检测到无法获取配置。如果您使用了复杂的反向代理：例如将 <code>http://{ip}:9321/</code> 代理到了 <code>http://{ip}:9321/danmu_api/</code>，请在此处手动输入完整的反代后链接（不包含TOKEN和ADMIN_TOKEN的）
                     </p>
                     <div style="display: flex; gap: 10px; flex-wrap: wrap;">
-                        <input type="text" id="custom-base-url" placeholder="例如: http://192.168.8.1:2333/danmu_api/ (留空保存即恢复默认)" style="flex: 1; min-width: 200px; padding: 8px; border: 1px solid #ced4da; border-radius: 4px;">
+                        <input type="text" id="custom-base-url" placeholder="例如: http://192.168.8.1:2333/danmu_api/ (留空保存即恢复默认)" style="flex: 1; min-width: 200px;">
                         <button class="btn btn-primary" onclick="saveBaseUrl()">保存并刷新</button>
                     </div>
-                    <p style="color: #666; font-size: 12px; margin-top: 5px;">* 设置将保存在浏览器本地存储中，清除网页的‘本地存储空间’或者输入框中留空并保存可恢复默认</p>
+                    <p style="color: var(--theme-muted); font-size: 12px; margin-top: 5px;">* 设置将保存在浏览器本地存储中，清除网页的"本地存储空间"或者输入框中留空并保存可恢复默认</p>
                 </div>
 
                 <p class="preview-description">当前生效的环境变量配置</p>
@@ -194,10 +194,10 @@ export const HTML_TEMPLATE = /* html */ `
                         <p style="color: #666; margin-bottom: 15px;">模拟播放器手动搜索流程：搜索动漫 → 选择番剧 → 选择剧集 → 获取弹幕</p>
                         <div class="form-group" style="margin-bottom: 15px;">
                             <label>搜索关键字</label>
-                            <div style="display:flex;gap:10px;margin-top:5px;">
+                            <div class="search-actions">
                                 <input type="text" id="manual-search-keyword" placeholder="请输入动漫名称" style="flex:1;">
-                                <button class="btn btn-primary" id="manual-search-btn" onclick="manualSearchAnime()">搜索</button>
                                 <button class="btn btn-success favorite-action-btn" id="manual-favorite-btn" onclick="favoriteManualSearch()" disabled>收藏</button>
+                                <button class="btn btn-primary" id="manual-search-btn" onclick="manualSearchAnime()">搜索</button>
                             </div>
                         </div>
                         <div id="manual-anime-list" style="display:none;"></div>


### PR DESCRIPTION
- 配置错误 banner 迁移至主题变量，支持暗浅色切换
- custom-alert 访问方式前换行，长 URL 添加 word-break 防溢出
- applyInputFeedback 移除 focus() 避免快捷填充时视点跳转
- map-remove-btn hover rotate→translateY，修复删除按钮旋转
- 手动匹配收藏按钮移至搜索按钮左侧
- episode-item flex 布局+hover 背景+左边框 accent，改善辨识度
- 弹幕词库新增 `@wade6716`，`大家陪你看`→`弹幕陪你看`
- 响应式：搜索栏手机端输入独占上行、收藏搜索下行
- 响应式：剧集按钮三段宽度 PC:120px、平板:160px、手机:100px

<img width="2560" height="1238" alt="image" src="https://github.com/user-attachments/assets/e2a822f7-6765-4616-9fdb-21ee4246645c" />


<img width="663" height="1238" alt="image" src="https://github.com/user-attachments/assets/5bf6c089-5eaa-4bee-977d-519059934be3" />
