### PR TITLE
fix(envs): 修复配置中带 # 井号的内容（如剧名）被误截断失效

### DIFF
--- a/danmu_api/configs/envs.js
+++ b/danmu_api/configs/envs.js
@@ -13,6 +13,13 @@ export class Envs {
   static originalEnvVars = new Map();
   static accessedEnvVars = new Map();
 
+  // Node 本地部署时由 server.js 注入：启动前的真实系统环境变量快照（最高优先级判定依据）与 .env 原始解析结果
+  static systemEnvBackup = null;
+  static rawEnvValues = null;
+
+  // 允许在值中写入 # 等 dotenv 视为注释字符的文本类变量；读取时绕过 dotenv 截断以保留完整内容。仅纳入 encrypt=false 变量（带令牌/密码 URL 若入此集合会绕过加密返回明文，故禁止纳入）。
+  static RAW_ENV_KEYS = new Set(['AI_MATCH_PROMPT', 'ANIME_TITLE_FILTER', 'AUTO_MATCH_MAPPING_TABLE', 'BLOCKED_WORDS', 'COLOR_POOL', 'CUSTOM_MERGE_RULES', 'DANMU_OFFSET', 'DANMU_PUSH_URL', 'EPISODE_TITLE_FILTER', 'IP_BLACKLIST', 'OTHER_SERVER', 'TITLE_MAPPING_TABLE', 'TITLE_NOISE_FILTER', 'VOD_SERVERS']);
+
   static VOD_ALLOWED_PLATFORMS = ['qiyi', 'bilibili1', 'imgo', 'youku', 'qq', 'migu', 'sohu', 'leshi', 'xigua', 'maiduidui', 'aiyifan']; // vod允许的播放平台
   static ALLOWED_PLATFORMS = ['qiyi', 'bilibili1', 'imgo', 'youku', 'qq', 'migu', 'renren', 'hanjutv', 'sohu', 'leshi', 'xigua', 'maiduidui', 'aiyifan', 'hongguo', 'dandan', 'bahamut', 'animeko', 'custom']; // 全部源允许的播放平台
   static ALLOWED_SOURCES = ['360', 'vod', 'tmdb', 'douban', 'tencent', 'youku', 'iqiyi', 'imgo', 'bilibili', 'migu', 'renren', 'hanjutv', 'sohu', 'leshi', 'xigua', 'maiduidui', 'aiyifan', 'hongguo', 'dandan', 'bahamut', 'animeko', 'custom']; // 允许的源
@@ -63,6 +70,10 @@ export class Envs {
    * @returns {any} 转换后的值
    */
   static get(key, defaultValue, type = 'string', encrypt = false) {
+    // 文本类且未加密的自定义变量绕过 dotenv 注释截断，保留 # 等字符；加密变量不在此路径，避免绕过加密返回明文
+    if (type === 'string' && !encrypt && Envs.RAW_ENV_KEYS.has(key)) {
+      return this.getRawEnv(key, defaultValue);
+    }
     let value;
     if (typeof this.env !== 'undefined' && this.env[key]) {
       value = this.env[key];
@@ -117,6 +128,64 @@ export class Envs {
    */
   static encryptStr(str) {
     return '*'.repeat(str.length);
+  }
+
+  /**
+   * 解析 .env 原始内容：跳过整行 # 注释、保留行内 #，并剥除整体双引号包裹（与 node-handler 引号写入一致）。
+   * @param {string} text .env 文件原始内容
+   * @returns {Object} 键值映射
+   */
+  static parseRawEnvText(text) {
+    const result = {};
+    if (typeof text !== 'string') return result;
+    const lines = text.split(/\r?\n/);
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eq = trimmed.indexOf('=');
+      if (eq === -1) continue;
+      const key = trimmed.slice(0, eq).trim();
+      if (!key) continue;
+      let value = trimmed.slice(eq + 1).trim();
+      if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+        value = value.slice(1, -1);
+      }
+      result[key] = value;
+    }
+    return result;
+  }
+
+  /**
+   * 读取自定义文本类变量，绕过 dotenv 截断保留 #：系统环境变量 > .env 原始值 > 默认值；非 Node 部署退化为普通取值。
+   * @param {string} key 环境变量键
+   * @param {string} defaultValue 默认值
+   * @returns {string} 原始值（含 #）
+   */
+  static getRawEnv(key, defaultValue = '') {
+    const finalize = (v) => {
+      this.originalEnvVars.set(key, v);
+      this.accessedEnvVars.set(key, v);
+      return v;
+    };
+
+    // 非 Node 运行时（测试 / Workers）：不做文件读取，等价于普通取值，保证测试隔离与平台兼容
+    if (!Envs.systemEnvBackup) {
+      if (this.env && this.env[key]) return finalize(this.env[key]);
+      if (typeof process !== 'undefined' && process.env?.[key]) return finalize(process.env[key]);
+      return finalize(defaultValue);
+    }
+
+    // Node 运行时：系统环境变量始终最高优先级
+    if (Object.prototype.hasOwnProperty.call(Envs.systemEnvBackup, key)) {
+      return finalize(Envs.systemEnvBackup[key]);
+    }
+
+    // 否则读取 .env 原始行（保留 #），未配置该键时回退 process.env 或默认值
+    if (Envs.rawEnvValues && Object.prototype.hasOwnProperty.call(Envs.rawEnvValues, key)) {
+      return finalize(Envs.rawEnvValues[key]);
+    }
+    if (typeof process !== 'undefined' && process.env?.[key]) return finalize(process.env[key]);
+    return finalize(defaultValue);
   }
 
   /**
@@ -321,8 +390,7 @@ export class Envs {
         console.warn(`[Envs] 解析合并映射表规则失败: ${rStr}`, e);
       }
     }
-    
-    this.accessedEnvVars.set('CUSTOM_MERGE_RULES', raw);
+
     return rules;
   }
 

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -10,6 +10,7 @@ import dotenv from 'dotenv';
 import { Request as NodeFetchRequest } from 'node-fetch';
 import { handleRequest } from './worker.js';
 import { Globals } from './configs/globals.js';
+import { Envs } from './configs/envs.js';
 import { clearBangumiDataCache, initBangumiData } from './utils/bangumi-data-util.js';
 import { getLocalCaches, judgeLocalCacheValid } from './utils/cache-util.js';
 import { getRedisCaches, judgeRedisValid } from './utils/redis-util.js';
@@ -40,6 +41,9 @@ const envPath = path.join(configDir, '.env');
 
 // 保存系统环境变量的副本，确保它们具有最高优先级
 const systemEnvBackup = { ...process.env };
+
+// 注入到 Envs，供自定义规则变量读取时判定系统环境变量优先级（绕过 dotenv 注释截断）
+Envs.systemEnvBackup = systemEnvBackup;
 
 
 // 引入 zlib 模块，用于响应数据的 GZIP 压缩
@@ -135,6 +139,15 @@ function loadEnv() {
     // 最后，恢复系统环境变量的值，确保它们具有最高优先级
     for (const [key, value] of Object.entries(systemEnvBackup)) {
       process.env[key] = value;
+    }
+
+    // 解析 .env 原始内容，供支持自定义规则的变量绕过 dotenv 注释截断（保留 # 等字符）
+    try {
+      if (fs.existsSync(envPath)) {
+        Envs.rawEnvValues = Envs.parseRawEnvText(fs.readFileSync(envPath, 'utf8'));
+      }
+    } catch (e) {
+      // 原始解析失败不影响启动，相关变量回退到普通取值语义
     }
 
     console.log('[server] .env file loaded successfully');

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -2727,3 +2727,36 @@ test('worker.js API endpoints', async (t) => {
 //     }
 //   });
 // });
+
+// // 测试自定义文本类变量绕过 dotenv 注释截断（保留 # 等字符），对应 envs.js RAW_ENV_KEYS 修复
+// import { Envs } from './configs/envs.js';
+//
+// test('envs RAW_ENV_KEYS 保留 # 不被 dotenv 截断', async (t) => {
+//   const reset = () => { Envs.systemEnvBackup = null; Envs.rawEnvValues = null; Envs.env = undefined; };
+//
+//   await t.test('parseRawEnvText 保留行内 # 与剥除外层双引号', () => {
+//     const parsed = Envs.parseRawEnvText('K1=v1\nK2=v with # hash\nK3="q # v"');
+//     assert.strictEqual(parsed.K2, 'v with # hash');
+//     assert.strictEqual(parsed.K3, 'q # v');
+//   });
+//
+//   await t.test('CUSTOM_MERGE_RULES / COLOR_POOL / URL 类变量含 # 完整保留', () => {
+//     reset();
+//     Envs.systemEnvBackup = {};
+//     Envs.rawEnvValues = {
+//       CUSTOM_MERGE_RULES: 'A #1 revival@bili',
+//       COLOR_POOL: '#FF0000,#00FF00',
+//       DANMU_PUSH_URL: 'http://h.com/cb#frag',
+//     };
+//     assert.strictEqual(Envs.get('CUSTOM_MERGE_RULES', '', 'string'), 'A #1 revival@bili');
+//     assert.strictEqual(Envs.get('COLOR_POOL', '', 'string'), '#FF0000,#00FF00');
+//     assert.strictEqual(Envs.get('DANMU_PUSH_URL', '', 'string'), 'http://h.com/cb#frag');
+//   });
+//
+//   await t.test('!encrypt 守卫：加密变量不走原始解析，防止绕过加密', () => {
+//     reset();
+//     Envs.systemEnvBackup = {};
+//     Envs.rawEnvValues = { DANMU_PUSH_URL: 'http://x.com/cb#frag' };
+//     assert.strictEqual(Envs.get('DANMU_PUSH_URL', 'DEF', 'string', true), 'DEF');
+//   });
+// });


### PR DESCRIPTION
不一定是最佳方案

## Summary

为文本类自定义环境变量引入原始读取能力，绕过 dotenv 将值中 `#` 视为注释的截断行为，并加固加密变量守卫，覆盖四个维度：

1. **文本类自定义变量原始读取**：新增 `RAW_ENV_KEYS` 白名单（14 个纯文本类变量：各类 filter / mapping / blocklist / url 等）、`parseRawEnvText`（保留行内 `#`、剥外层双引号）、`getRawEnv`（系统环境变量 > `.env` 原始值 > 默认值），使值中的 `#` 等 dotenv 视为注释的字符不再被截断。
2. **加密变量守卫**：`Envs.get` 在 `type === 'string' && !encrypt && RAW_ENV_KEYS.has(key)` 时路由到 `getRawEnv`；加密变量（`encrypt = true`）绝不走此路径，防止绕过加密返回明文。
3. **Node 运行时注入**：server.js 注入 `Envs.systemEnvBackup`（启动前系统环境变量快照）与 `Envs.rawEnvValues`（`.env` 原始解析结果）；非 Node（测试/Workers）无二者时 `getRawEnv` 退化为普通取值，保证测试隔离与平台兼容。
4. **清理冗余记录**：移除 `resolveCustomMergeRules` 内冗余的 `accessedEnvVars.set`（`CUSTOM_MERGE_RULES` 经 `get()`→`getRawEnv.finalize` 已记录）。

---

## 改动明细

### 1. 文本类变量原始读取绕过 dotenv 截断

**上游原版行为**：`Envs.get` 解析自定义变量时依赖 dotenv 已加载的 `this.env`，dotenv 将值中首个 `#` 视为注释起始，导致含 `#` 的文本（如 `COLOR_POOL='#FF0000,#00FF00'`、带 `#` 的 URL、含 `#` 的合并映射规则）被截断丢失。

**改动后行为**：新增 `RAW_ENV_KEYS` 白名单与 `getRawEnv`：`get()` 在字符串且未加密且键在白名单时改走 `getRawEnv`。`getRawEnv` 优先系统环境变量（最高优先级，与既有 `systemEnvBackup` 体系一致），否则读 `.env` 原始解析值（`parseRawEnvText` 保留行内 `#`、仅剥外层双引号），未配置回退 `process.env` 或默认值。

**实际观察**：

> 注释态测试验证 `parseRawEnvText` 保留行内 `#` 与剥引号；`CUSTOM_MERGE_RULES`/`COLOR_POOL`/`DANMU_PUSH_URL` 含 `#` 经 `get` 完整保留。

### 2. 加密变量守卫

**上游原版行为**：无针对 RAW 路径的加密隔离；若误将带令牌/密码的变量纳入 RAW 白名单，会绕过加密以明文返回。

**改动后行为**：`get()` 守卫要求 `!encrypt`；`RAW_ENV_KEYS` 14 项经人工甄别均为非凭据类文本（端点 URL 不含密钥），注释明确禁止纳入带令牌/密码变量。

**实际观察**：

> 注释态测试验证 `encrypt = true` 时 `DANMU_PUSH_URL` 走加密路径返回默认值而非原始含 `#` 值，守卫生效。

### 3. Node 运行时注入与平台兼容

**上游原版行为**：`Envs` 无系统环境变量快照与 `.env` 原始解析入口，无法在 `getRawEnv` 层面绕过 dotenv。

**改动后行为**：server.js 在既有的 `systemEnvBackup` 旁注入 `Envs.systemEnvBackup`，并在 `loadEnv()` 内 `try/catch` 解析 `.env` 原始内容写入 `Envs.rawEnvValues`（解析失败不影响启动）。`getRawEnv` 在非 Node（无 `systemEnvBackup`）时退化为 `this.env > process.env > default`。

**实际观察**：

> Node 启动时注入生效；测试/Workers 无注入时退化为普通取值，不影响既有测试与平台运行。

### 4. 移除冗余 accessedEnvVars.set

**上游原版行为**：`resolveCustomMergeRules` 末尾 `this.accessedEnvVars.set('CUSTOM_MERGE_RULES', raw)`，但 `CUSTOM_MERGE_RULES` 已在 `RAW_ENV_KEYS` 内，经 `get()`→`getRawEnv.finalize` 同时写入 `originalEnvVars` 与 `accessedEnvVars`，该显式 set 冗余。

**改动后行为**：移除该冗余 set，统一由 `finalize` 记录。

**实际观察**：

> `getRawEnv` 测试覆盖 `CUSTOM_MERGE_RULES` 经 `get` 既返回原始值又完成记录，无功能回退。

---

## 实际案例

### CUSTOM_MERGE_RULES 含 # 井号键被 dotenv 截断失效

某用户使用 `CUSTOM_MERGE_RULES` 配置跨源合并规则，其中剧名携带 `#` 井号（舞台剧/演唱会副标题常见）：

```text
CUSTOM_MERGE_RULES=少女☆歌剧Revue Starlight -The LIVE- #1 revival(2019)【动漫】@bilibili × 少女☆歌剧 Revue Starlight(2018)【TV动画】@dandan
```

上游原版经 dotenv 加载后，值中首个 `#` 被视为注释起始，变量实际被截断为 `少女☆歌剧Revue Starlight -The LIVE- `（`#1 revival(2019)...` 及后续整条规则丢失），导致该合并规则残缺或完全失效，用户无法将带 `#` 副标题的条目正确合并。本分支将 `CUSTOM_MERGE_RULES` 纳入 `RAW_ENV_KEYS`，经 `getRawEnv`（`parseRawEnvText` 保留行内 `#`、仅剥外层双引号）读取，上述完整规则被原样保留，`×` 分隔的两条合并关系正常生效。

---

## 影响范围

| 场景 | 行为变化 |
|------|:--:|
| 含 `#` 的文本类自定义变量（`COLOR_POOL` / 带 `#` URL / 合并映射规则等） | **完整保留，不再被 dotenv 截断** |
| 加密变量（`encrypt = true`） | **不走 RAW 路径，明文不外泄** |
| 非 `RAW` 白名单变量 | **仍走原 dotenv 解析，无变化** |
| 测试 / Workers（无 `systemEnvBackup`） | **`getRawEnv` 退化为普通取值，平台兼容** |
| `.env` 原始解析失败 | **不影响启动，相关变量回退普通取值** |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/configs/envs.js` | 新增 `RAW_ENV_KEYS` / `systemEnvBackup` / `rawEnvValues` / `parseRawEnvText` / `getRawEnv`；`get` 路由守卫；移除冗余 `accessedEnvVars.set` |
| `danmu_api/server.js` | 注入 `Envs.systemEnvBackup`；`loadEnv` 内解析 `.env` 原始内容写入 `Envs.rawEnvValues` |
| `danmu_api/worker.test.js` | 注释态新增 envs `RAW_ENV_KEYS` 保留 `#` / 加密守卫 测试 |
