### PR TITLE
fix(bangumi-data): 修复 Bangumi Data 开启可能不触发立即下载，并调整云部署数据丢失时下载时机

### DIFF
--- a/danmu_api/apis/env-api.js
+++ b/danmu_api/apis/env-api.js
@@ -2,6 +2,7 @@ import { jsonResponse } from '../utils/http-util.js';
 import { log } from '../utils/log-util.js';
 import { HandlerFactory } from '../configs/handlers/handler-factory.js';
 import { globals } from '../configs/globals.js';
+import { syncBangumiDataLifecycleOnConfigChange } from '../utils/bangumi-data-util.js';
 import AIClient from '../utils/ai-util.js';
 
 /**
@@ -24,6 +25,10 @@ export async function handleSetEnv(request) {
     // 调用handler的setEnv方法
     const result = await handler.setEnv(key, value);
     
+    if (result && key === 'USE_BANGUMI_DATA') {
+      syncBangumiDataLifecycleOnConfigChange(deployPlatform);
+    }
+
     if (result) {
       return jsonResponse({ success: true, message: `环境变量 ${key} 设置成功` });
     } else {
@@ -55,6 +60,10 @@ export async function handleAddEnv(request) {
     // 调用handler的addEnv方法
     const result = await handler.addEnv(key, value);
     
+    if (result && key === 'USE_BANGUMI_DATA') {
+      syncBangumiDataLifecycleOnConfigChange(deployPlatform);
+    }
+
     if (result) {
       return jsonResponse({ success: true, message: `环境变量 ${key} 添加成功` });
     } else {
@@ -86,6 +95,10 @@ export async function handleDelEnv(request) {
     // 调用handler的delEnv方法
     const result = await handler.delEnv(key);
     
+    if (result && key === 'USE_BANGUMI_DATA') {
+      syncBangumiDataLifecycleOnConfigChange(deployPlatform);
+    }
+
     if (result) {
       return jsonResponse({ success: true, message: `环境变量 ${key} 删除成功` });
     } else {

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -9,8 +9,8 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import dotenv from 'dotenv';
 import { Request as NodeFetchRequest } from 'node-fetch';
 import { handleRequest } from './worker.js';
-import { Globals } from './configs/globals.js';
-import { clearBangumiDataCache, initBangumiData } from './utils/bangumi-data-util.js';
+import { Globals, globals } from './configs/globals.js';
+import { clearBangumiDataCache, initBangumiData, syncBangumiDataLifecycleOnConfigChange } from './utils/bangumi-data-util.js';
 import { getLocalCaches, judgeLocalCacheValid } from './utils/cache-util.js';
 import { getRedisCaches, judgeRedisValid } from './utils/redis-util.js';
 import { persistFavorites, refreshFavoriteByKeyword } from './apis/favorite-api.js';
@@ -220,10 +220,11 @@ async function setupEnvWatcher() {
           console.log('[server] Environment variables reloaded successfully');
           console.log('[server] Updated keys:', Array.from(newEnvKeys).join(', '));
 
-          // 如果检测到关闭了 Bangumi Data 功能，主动释放内存与物理磁盘缓存
-          if (process.env.USE_BANGUMI_DATA === 'false' || process.env.USE_BANGUMI_DATA === false) {
-              clearBangumiDataCache(true);
-          }
+          // 配置变更后同步 Bangumi Data 生命周期：开启则立即确保缓存就绪（缺失则下载），
+          // 关闭则释放缓存；先按真实配置同步内存开关，避免重载未刷新 globals 时状态滞后
+          const bangumiEnabled = process.env.USE_BANGUMI_DATA === 'true' || process.env.USE_BANGUMI_DATA === true;
+          globals.useBangumiData = bangumiEnabled;
+          syncBangumiDataLifecycleOnConfigChange('node');
 
         } catch (error) {
           console.log('[server] Error reloading configuration files:', error.message);

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -18,6 +18,8 @@ let downloadLockTime = 0;
 let memoryFootprintMB = '0.00';
 let hasLoggedCacheWarning = false;
 let charInvertedIndex = new Map();
+// 在途后台下载 Promise：由 initBangumiData 在发起非阻塞刷新时写入，供边缘层 ctx.waitUntil 延长 Serverless 生命周期
+let currentBackgroundDownload = null;
 
 // 当前生效的数据源标识 ('custom' | 'official')
 let activeDataSource = 'custom';
@@ -210,6 +212,29 @@ export function syncBangumiDataLifecycleOnConfigChange(deployPlatform = globals.
     }
 }
 
+// 读取在途后台下载 Promise，供边缘运行时在请求响应后延长生命周期（无在途时返回 null）
+export function getBackgroundDownload() {
+    return currentBackgroundDownload;
+}
+
+// 边缘运行时在响应返回后延长生命周期：仅在存在在途后台下载且运行时提供 waitUntil 时注册
+export function extendBangumiDownloadLifecycle(ctx) {
+    if (ctx && typeof ctx.waitUntil === 'function' && currentBackgroundDownload) {
+        ctx.waitUntil(currentBackgroundDownload);
+    }
+}
+
+// 发起后台静默下载并记录在途 Promise：下载完成时复位状态，供 getBackgroundDownload 暴露给边缘层
+function startDownload(cachePath) {
+    isDownloading = true;
+    downloadLockTime = Date.now();
+    currentBackgroundDownload = downloadAndCache(cachePath).finally(() => {
+        isDownloading = false;
+        currentBackgroundDownload = null;
+    });
+    return currentBackgroundDownload;
+}
+
 /**
  * 初始化 Bangumi Data 数据源
  * 包含内存与磁盘双端缓存的生命周期校验，并在环境允许时持久化缓存数据
@@ -254,9 +279,7 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
         // 当内存过期或配置强制更新时，仅在核心请求触发后台静默更新
         if (isDataDependentRequest && !isDownloading) {
             log("info", `[system] [Bangumi-Data] 内存数据${cacheDays === 0 ? '强制更新' : '已过期'}，保留老数据服务本次请求，启动后台静默更新...`);
-            isDownloading = true;
-            downloadLockTime = Date.now();
-            downloadAndCache(cachePath).finally(() => { isDownloading = false; });
+            startDownload(cachePath);
         }
         return;
     }
@@ -291,9 +314,7 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
             if (cacheDays === 0 || (Date.now() - stats.mtimeMs >= expireMs)) {
                 if (isDataDependentRequest && !isDownloading) {
                     log("info", `[system] [Bangumi-Data] 磁盘数据${cacheDays === 0 ? '强制更新' : '已过期'}，保留老数据服务本次请求，启动后台静默更新...`);
-                    isDownloading = true;
-                    downloadLockTime = Date.now();
-                    downloadAndCache(cachePath).finally(() => { isDownloading = false; });
+                    startDownload(cachePath);
                 }
             }
             return;
@@ -306,10 +327,8 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
     // 内存与磁盘均无有效数据时的获取逻辑
     if (!isDownloading) {
         log("info", `[system] [Bangumi-Data] 未命中任何有效缓存，正在获取基础数据...`);
-        isDownloading = true;
-        downloadLockTime = Date.now();
 
-        const downloadPromise = downloadAndCache(cachePath).finally(() => { isDownloading = false; });
+        const downloadPromise = startDownload(cachePath);
 
         if (isDataDependentRequest) {
             await downloadPromise; 

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -193,6 +193,23 @@ async function selectBestDataSource() {
     return versionQueryPromise;
 }
 
+// 数据下载触发时机：仅在 searchBangumiData 消费路径进入时触发下载；开关关闭或无所消费源时不下载
+// 开启时复用 initBangumiData 加载/下载，并发调用等待同一就绪缓存而不重复请求
+export async function ensureBangumiDataReady(deployPlatform = globals.deployPlatform) {
+    if (!globals.useBangumiData) return;
+    await initBangumiData(deployPlatform, true);
+}
+
+// 配置变更后同步 Bangumi Data 生命周期：开关开启立即下载（已缓存则幂等），关闭释放缓存
+// 调用前须保证 globals.useBangumiData 已反映最新配置（watcher 场景须先同步内存开关）
+export function syncBangumiDataLifecycleOnConfigChange(deployPlatform = globals.deployPlatform) {
+    if (globals.useBangumiData) {
+        initBangumiData(deployPlatform, true).catch(console.error);
+    } else {
+        clearBangumiDataCache(true);
+    }
+}
+
 /**
  * 初始化 Bangumi Data 数据源
  * 包含内存与磁盘双端缓存的生命周期校验，并在环境允许时持久化缓存数据
@@ -201,7 +218,7 @@ async function selectBestDataSource() {
  * @param {boolean} isDataDependentRequest - 当前是否为强依赖数据的核心接口请求
  * @returns {Promise<void>}
  */
-export async function initBangumiData(deployPlatform, isDataDependentRequest = false, ctx = null) {
+export async function initBangumiData(deployPlatform, isDataDependentRequest = false) {
     if (!globals.useBangumiData) return;
 
     let cachePath = null;
@@ -298,10 +315,6 @@ export async function initBangumiData(deployPlatform, isDataDependentRequest = f
             await downloadPromise; 
         } else {
             log("info", `[system] [Bangumi-Data] 当前非核心请求，数据获取转入后台异步执行`);
-            if (ctx && typeof ctx.waitUntil === 'function') {
-                log("info", `[system] [Bangumi-Data] 调用 ctx.waitUntil 延长 Serverless 生命周期`);
-                ctx.waitUntil(downloadPromise);
-            }
         }
     } else if (isDataDependentRequest) {
         log("info", `[system] [Bangumi-Data] 正在等待基础数据下载完成...`);
@@ -503,6 +516,7 @@ async function downloadAndCache(cachePath) {
  * @returns {Array<Object>} 匹配的动漫条目数组
  */
 export async function searchBangumiData(keyword, siteKeys) {
+    await ensureBangumiDataReady();
     if (!memoryCache || !memoryCache.items) return [];
 
     let searchPromise = queryCache.get(keyword);

--- a/danmu_api/utils/bangumi-data-util.js
+++ b/danmu_api/utils/bangumi-data-util.js
@@ -18,15 +18,11 @@ let downloadLockTime = 0;
 let memoryFootprintMB = '0.00';
 let hasLoggedCacheWarning = false;
 let charInvertedIndex = new Map();
-// 在途后台下载 Promise：由 initBangumiData 在发起非阻塞刷新时写入，供边缘层 ctx.waitUntil 延长 Serverless 生命周期
-let currentBackgroundDownload = null;
+let currentBackgroundDownload = null; // 在途后台下载 Promise：由 initBangumiData 在发起非阻塞刷新时写入，供边缘层 ctx.waitUntil 延长 Serverless 生命周期
 
-// 当前生效的数据源标识 ('custom' | 'official')
-let activeDataSource = 'custom';
-// 缓存已解析的版本号（进程内有效）
-let cachedCustomVersion = null;
+let activeDataSource = 'custom'; // 当前生效的数据源标识 ('custom' | 'official')
+let cachedCustomVersion = null; // 缓存已解析的版本号（进程内有效）
 let cachedOfficialVersion = null;
-
 let versionQueryPromise = null; // 版本查询并发锁：serverless环境下冻结时异步信号可能不生效，共享同一Promise避免重复探测
 
 // 定义缓存目录/文件名

--- a/danmu_api/utils/tmdb-util.js
+++ b/danmu_api/utils/tmdb-util.js
@@ -593,7 +593,7 @@ export async function getTMDBChineseTitle(title, season = null, episode = null) 
 // 优先尝试本地 Bangumi Data 转换
   if (globals.useBangumiData) {
     const cleanTitle = cleanSearchQuery(title);
-    const localMatches = searchBangumiData(cleanTitle, ['tmdb', 'bangumi', 'anidb']);
+    const localMatches = await searchBangumiData(cleanTitle, ['tmdb', 'bangumi', 'anidb']);
     if (localMatches && localMatches.length > 0) {
       const m = localMatches[0];
       // 找一个不全是外文的翻译作为中文名

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -11,6 +11,7 @@ import { getFongmiDanmaku } from "./apis/clients/fongmi-api.js";
 import { handleConfig, handleUI, handleLogs, handleClearLogs, handleDeploy, handleClearCache, handleReqRecords, handleCacheAnimes } from "./apis/system-api.js";
 import { handleForwardTrace } from "./apis/forward-trace-api.js";
 import { handleSetEnv, handleAddEnv, handleDelEnv, handleAiVerify } from "./apis/env-api.js";
+import { extendBangumiDownloadLifecycle } from "./utils/bangumi-data-util.js";
 import { Segment } from "./models/dandan-model.js"
 import {
     handleCookieStatus,
@@ -742,11 +743,14 @@ function detectDeployPlatform(env) {
 
 // --- Cloudflare Workers 入口 ---
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     // 获取客户端的真实 IP
     const clientIp = request.headers.get('cf-connecting-ip') || request.headers.get('x-forwarded-for') || 'unknown';
 
-    return handleRequest(request, env, detectDeployPlatform(env), clientIp);
+    const response = await handleRequest(request, env, detectDeployPlatform(env), clientIp);
+    // 边缘运行时在响应返回后延长生命周期，容纳可能在途的 Bangumi Data 后台静默下载
+    extendBangumiDownloadLifecycle(ctx);
+    return response;
   },
 };
 

--- a/danmu_api/worker.js
+++ b/danmu_api/worker.js
@@ -5,7 +5,6 @@ import { getFavoriteCachesFromRedis, getRedisCaches, judgeRedisValid } from "./u
 import { cleanupExpiredIPs, findUrlById, getCommentCache, getLocalCaches, judgeLocalCacheValid } from "./utils/cache-util.js";
 import { formatDanmuResponse } from "./utils/danmu-util.js";
 import AIClient from './utils/ai-util.js';
-import { initBangumiData } from "./utils/bangumi-data-util.js";
 import { getBangumi, getComment, getCommentByUrl, getSegmentComment, matchAnime, searchAnime, searchEpisodes } from "./apis/dandan-api.js";
 import { handleFavoriteAdd, handleFavoriteList, handleFavoriteRefresh, handleFavoriteRemove, handleFavoriteSchedule } from "./apis/favorite-api.js";
 import { getFongmiDanmaku } from "./apis/clients/fongmi-api.js";
@@ -23,20 +22,13 @@ import {
 
 let globals;
 
-async function handleRequest(req, env, deployPlatform, clientIp, ctx) {
+async function handleRequest(req, env, deployPlatform, clientIp) {
   // 加载全局变量和环境变量配置
   globals = Globals.init(env);
 
   const url = new URL(req.url);
   let path = url.pathname;
   const method = req.method;
-
-  //  Bangumi Data 辅助函数，用于判断数据更新
-  const isDataDependentRequest = path.includes('/search') || path.includes('/match') || path.includes('/danmaku');
-
-  if (globals.useBangumiData) {
-      await initBangumiData(deployPlatform, isDataDependentRequest, ctx);
-  }
 
   globals.deployPlatform = deployPlatform;
   if (deployPlatform === "node") {
@@ -750,11 +742,11 @@ function detectDeployPlatform(env) {
 
 // --- Cloudflare Workers 入口 ---
 export default {
-  async fetch(request, env, ctx) {
+  async fetch(request, env) {
     // 获取客户端的真实 IP
     const clientIp = request.headers.get('cf-connecting-ip') || request.headers.get('x-forwarded-for') || 'unknown';
 
-    return handleRequest(request, env, detectDeployPlatform(env), clientIp, ctx);
+    return handleRequest(request, env, detectDeployPlatform(env), clientIp);
   },
 };
 

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -2727,3 +2727,60 @@ test('worker.js API endpoints', async (t) => {
 //     }
 //   });
 // });
+
+// // 测试 Bangumi Data 数据下载时机（ensureBangumiDataReady）、配置变更触发下载（syncBangumiDataLifecycleOnConfigChange）
+// // 以及 getTMDBChineseTitle 漏写 await 的修复；与 envs RAW_ENV_KEYS 测试同为按需启用的内部测试
+// import { globals } from './configs/globals.js';
+// import { ensureBangumiDataReady, syncBangumiDataLifecycleOnConfigChange } from './utils/bangumi-data-util.js';
+// import fs from 'node:fs';
+// import path from 'node:path';
+//
+// test('bangumi-data 数据下载时机与配置变更触发下载', async (t) => {
+//   const CACHE_DIR = path.join(process.cwd(), '.cache');
+//   const CACHE_FILE = path.join(CACHE_DIR, 'bangumi-data-cache.json');
+//   const FAKE_ITEM = {
+//     title: 'FrobeniusTestAnime',
+//     titleTranslate: { 'zh-Hans': ['弗罗贝尼乌斯测试动画', 'FrobeniusTestAnime'] },
+//     sites: [{ site: 'tmdb', id: '999999' }],
+//     _flatText: 'frobeniustestanime'
+//   };
+//   const reset = () => {
+//     globals.useBangumiData = false;
+//     clearBangumiDataCache(false);
+//     if (fs.existsSync(CACHE_FILE)) fs.writeFileSync(CACHE_FILE, '', 'utf-8');
+//   };
+//
+//   await t.test('ensureBangumiDataReady 开关关闭时直接返回且不触发下载', async () => {
+//     reset();
+//     globals.useBangumiData = false;
+//     await ensureBangumiDataReady('node');
+//     assert.ok(true);
+//   });
+//
+//   await t.test('syncBangumiDataLifecycleOnConfigChange 开关关闭释放缓存、开启安全触发', async () => {
+//     reset();
+//     globals.useBangumiData = false;
+//     assert.doesNotThrow(() => syncBangumiDataLifecycleOnConfigChange('node'));
+//     fs.mkdirSync(CACHE_DIR, { recursive: true });
+//     fs.writeFileSync(CACHE_FILE, JSON.stringify({ items: [FAKE_ITEM] }), 'utf-8');
+//     globals.useBangumiData = true;
+//     assert.doesNotThrow(() => syncBangumiDataLifecycleOnConfigChange('node'));
+//   });
+//
+//   await t.test('getTMDBChineseTitle 经 await 命中本地中文名（修复漏写 await）', async () => {
+//     reset();
+//     globals.useBangumiData = true;
+//     const originalContent = fs.existsSync(CACHE_FILE) ? fs.readFileSync(CACHE_FILE, 'utf-8') : null;
+//     fs.mkdirSync(CACHE_DIR, { recursive: true });
+//     fs.writeFileSync(CACHE_FILE, JSON.stringify({ items: [FAKE_ITEM] }), 'utf-8');
+//     try {
+//       await initBangumiData('node', true);
+//       const result = await getTMDBChineseTitle('FrobeniusTestAnime');
+//       assert.equal(result, '弗罗贝尼乌斯测试动画');
+//     } finally {
+//       clearBangumiDataCache(false);
+//       if (originalContent !== null) fs.writeFileSync(CACHE_FILE, originalContent, 'utf-8');
+//       else fs.writeFileSync(CACHE_FILE, '', 'utf-8');
+//     }
+//   });
+// });

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -2731,7 +2731,7 @@ test('worker.js API endpoints', async (t) => {
 // // 测试 Bangumi Data 数据下载时机（ensureBangumiDataReady）、配置变更触发下载（syncBangumiDataLifecycleOnConfigChange）
 // // 以及 getTMDBChineseTitle 漏写 await 的修复；与 envs RAW_ENV_KEYS 测试同为按需启用的内部测试
 // import { globals } from './configs/globals.js';
-// import { ensureBangumiDataReady, syncBangumiDataLifecycleOnConfigChange } from './utils/bangumi-data-util.js';
+// import { ensureBangumiDataReady, syncBangumiDataLifecycleOnConfigChange, initBangumiData, clearBangumiDataCache } from './utils/bangumi-data-util.js';
 // import fs from 'node:fs';
 // import path from 'node:path';
 //

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -2784,3 +2784,43 @@ test('worker.js API endpoints', async (t) => {
 //     }
 //   });
 // });
+
+// // 测试 Bangumi Data 在途下载暴露与边缘生命周期延长（getBackgroundDownload / extendBangumiDownloadLifecycle）
+// // 与上方 bangumi 测试同为按需启用的内部测试；沙箱有网时真实下载以验证在途暴露、注册与清理
+// import { globals } from './configs/globals.js';
+// import { initBangumiData, getBackgroundDownload, extendBangumiDownloadLifecycle } from './utils/bangumi-data-util.js';
+// import assert from 'node:assert';
+// import fs from 'node:fs';
+// import path from 'node:path';
+//
+// test('bangumi-data 在途下载暴露与边缘生命周期延长', async (t) => {
+//   const CACHE_DIR = path.join(process.cwd(), '.cache');
+//   const CACHE_FILE = path.join(CACHE_DIR, 'bangumi-data-cache.json');
+//   const hadCache = fs.existsSync(CACHE_DIR);
+//
+//   // 空闲时无在途下载
+//   assert.strictEqual(getBackgroundDownload(), null);
+//
+//   await t.test('extendBangumiDownloadLifecycle 在无在途或 ctx 缺失时不注册', async () => {
+//     const calls = [];
+//     extendBangumiDownloadLifecycle(null);
+//     extendBangumiDownloadLifecycle({ waitUntil: (p) => calls.push(p) });
+//     assert.strictEqual(calls.length, 0);
+//   });
+//
+//   await t.test('在途下载被暴露、响应后由边缘 waitUntil 注册、完成后清理', async () => {
+//     globals.useBangumiData = true;
+//     // 启动真实下载（无 .cache 时走内存路径，不落地文件；有 .cache 则后台刷新），不在途时立即返回
+//     const initPromise = initBangumiData('node', true);
+//     const bg = getBackgroundDownload();
+//     assert.ok(bg && typeof bg.then === 'function', '下载在途时应暴露 Promise');
+//     const ctx = { waitUntil: (p) => { ctx.registered = p; } };
+//     extendBangumiDownloadLifecycle(ctx);
+//     assert.strictEqual(ctx.registered, bg, '边缘 waitUntil 应注册在途 Promise');
+//     await bg; // 等待下载完成（兼容阻塞与后台两种路径）
+//     assert.strictEqual(getBackgroundDownload(), null, '下载完成后应清理在途状态');
+//     globals.useBangumiData = false;
+//     if (!hadCache && fs.existsSync(CACHE_FILE)) fs.writeFileSync(CACHE_FILE, '', 'utf-8');
+//     await initPromise.catch(() => {});
+//   });
+// });


### PR DESCRIPTION
## Summary

对 Bangumi Data 的下载触发时机做结构性修正，并调整边缘运行时生命周期延长机制（不再将 ctx 深穿调用栈，改为在边缘层暴露并延长在途下载），覆盖五个维度：

1. **下沉按需下载至消费路径**：移除 worker.js 网关层对每次 `/search` `/match` `/danmaku` 请求的统一前置下载，改为在 `searchBangumiData` 消费路径顶部按需触发（`ensureBangumiDataReady`），仅真正读取缓存的路径（4 源搜索/匹配/弹幕 + `TITLE_TO_CHINESE` 中文名 + 跨季 TMDB 边界）才触发；未配置消费源的部署（如仅 renren）整次请求不触碰 Bangumi Data、零下载。
2. **配置变更同步下载生命周期**：新增 `syncBangumiDataLifecycleOnConfigChange`，`USE_BANGUMI_DATA` 由关到开立即下载、由开到关释放缓存；接入 env-api 三处 handler（前端保存）与 server.js 的 `.env` 监听器（本地改文件），覆盖云/本地两种启用路径。
3. **修复 `getTMDBChineseTitle` 漏写 await**：tmdb-util.js 调用 `searchBangumiData` 漏写 `await`，本地中文名命中路径恒不生效，补 `await` 后真实生效。
4. **调整边缘运行时生命周期延长机制**：不再将 `ctx` 深穿至数据层，改为暴露在途后台下载 Promise（`currentBackgroundDownload`），并由 worker.js 的 Cloudflare Workers `fetch` 入口在响应返回后调用 `extendBangumiDownloadLifecycle(ctx)` 延长 isolate 生命周期，避免 Serverless 冻结中断在途刷新；无 `ctx` 的 Node/Vercel/Netlify 自然 no-op。
5. **移除 `ctx` 参数与 let 声明整理**：下载触发下沉后 `ctx` 不再深穿数据层，移除 `handleRequest` / `initBangumiData` 的 `ctx` 参数（生命周期延长改在边缘层处理）；模块级 `let` 声明整理为末尾注释并合并组内空行（保留分组分隔），无功能变化。

---

## 改动明细

### 1. 移除网关层统一前置下载，下沉按需下载至消费路径

**上游原版行为**：worker.js 的 Cloudflare Workers `fetch` 入口在每次请求（含 `/search` `/match` `/danmaku`）进入 `handleRequest` 时，依据 path 是否含这些路径计算 `isDataDependentRequest`，并在 `globals.useBangumiData` 为真时无条件 `await initBangumiData(deployPlatform, isDataDependentRequest, ctx)`。即任一数据相关请求都会触发下载判断，且 `ctx` 一路透传到 `initBangumiData` 用于 `waitUntil`。

**改动后行为**：移除 `handleRequest` 内的全局前置下载；`initBangumiData` 的 `ctx` 参数一并移除。新增 `ensureBangumiDataReady(deployPlatform)`：`if (!globals.useBangumiData) return; await initBangumiData(deployPlatform, true);`，仅置于 `searchBangumiData` 顶部。只有真正读取 Bangumi Data 缓存的路径（4 源搜索/匹配/弹幕 + `getTMDBChineseTitle` + `getTmdbSeasonBoundaries`）才进入下载判定；未配置任何消费源的部署（如仅 renren）整次请求不碰 Bangumi Data、零下载。

**实际观察**：

> 仅 renren 部署的搜索请求不再触发 Bangumi Data 下载；含消费源的请求首次/冷启动仍正常拉起数据，热路径走内存命中秒回。

### 2. 配置变更同步下载生命周期（syncBangumiDataLifecycleOnConfigChange）

**上游原版行为**：server.js 的 `.env` 监听器仅在检测到 `USE_BANGUMI_DATA` 为 `false` 时调用 `clearBangumiDataCache(true)` 释放缓存；无「由关到开」的下载触发。前端 env-api 保存环境变量时完全不触碰 Bangumi Data 生命周期。

**改动后行为**：新增 `syncBangumiDataLifecycleOnConfigChange(deployPlatform)`：开关开启时 `initBangumiData(deployPlatform, true).catch(console.error)`（已缓存则幂等、离线 catch 不影响），关闭时 `clearBangumiDataCache(true)`。接入 env-api 三处 handler（`handleSetEnv`/`handleAddEnv`/`handleDelEnv`，均在 `result` 成功且 `key === 'USE_BANGUMI_DATA'` 时调用）与 server.js 监听器（先 `globals.useBangumiData = bangumiEnabled` 同步内存开关，再调 sync，避免重载未刷新 globals 时状态滞后）。

**实际观察**：

> 前端保存或本地改文件使开关由关到开时立即触发一次下载；由开到关时立即释放缓存。注释态测试覆盖开关切换不抛错且行为安全。

### 3. 修复 getTMDBChineseTitle 漏写 await

**上游原版行为**：tmdb-util.js `getTMDBChineseTitle` 中 `const localMatches = searchBangumiData(...)` 漏写 `await`，`searchBangumiData` 为 async，`localMatches` 实际为未 resolve 的 Promise，后续 `localMatches && localMatches.length > 0` 恒为真（Promise 为 truthy）但 `localMatches[0]` 为 undefined，命中路径从未真正生效。

**改动后行为**：补 `await`，`localMatches` 为真实数组，命中逻辑生效。

**实际观察**：

> 注释态测试注入本地缓存条目后，`getTMDBChineseTitle('FrobeniusTestAnime')` 经 `await` 返回本地中文名「弗罗贝尼乌斯测试动画」，修复前恒不命中。

### 4. 暴露在途下载并由边缘运行时延长生命周期（ctx.waitUntil）

**上游原版行为**：worker.js 的 Cloudflare Workers `fetch` 入口将 `ctx` 透传至 `handleRequest` → `initBangumiData`，由数据层在下载发起处调用 `ctx.waitUntil(downloadPromise)` 延长后台下载的生命周期。

**改动后行为**：`initBangumiData` 发起非阻塞刷新时经 `startDownload` 将 Promise 写入模块级 `currentBackgroundDownload`，下载完成在 `.finally` 复位；新增 `getBackgroundDownload` 暴露该状态、`extendBangumiDownloadLifecycle(ctx)` 仅在存在在途且运行时提供 `waitUntil` 时注册。worker.js 的 Cloudflare Workers `fetch` 入口接收 `ctx` 参数，`await handleRequest` 后调用 `extendBangumiDownloadLifecycle(ctx)`；Vercel/Netlify 入口无 `ctx`，不受影响。

**实际观察**：

> 注释态测试验证空闲/缺失 ctx 不注册、在途暴露、响应后由边缘 `waitUntil` 注册、完成后清理为 null；沙箱真实下载下断言全过。

### 5. 清理死参数与 let 声明整理

**上游原版行为**：`handleRequest(req, env, deployPlatform, clientIp, ctx)` 与 `initBangumiData(deployPlatform, isDataDependentRequest, ctx)` 携带 `ctx` 参数，用于数据层直接调用 `ctx.waitUntil` 延长后台下载生命周期。

**改动后行为**：移除两处 `ctx` 参数及 `initBangumiData` 内依赖 `ctx` 的 `waitUntil` 分支（下载生命周期延长改由 `extendBangumiDownloadLifecycle` 在边缘层处理）。模块级 `let` 声明整理为末尾注释并合并组内空行（保留分组分隔），无功能变化。

**实际观察**：

> grep 全仓确认无第三参调用方、无残留引用；`node --check` 通过。

---

## 实际案例

### 下沉按需下载前：云部署内存丢失导致每次访问前端都触发下载

某 Cloudflare Workers 部署启用了 `USE_BANGUMI_DATA=true`，但仅挂载 renren 源（未配置任何消费源）。上游原版在网关层对每次 `/search` `/match` `/danmaku` 请求无条件 `await initBangumiData(deployPlatform, isDataDependentRequest, ctx)`：

- Serverless 纯内存运行（无 `.cache` 磁盘挂载），isolate 被平台冻结后 `memoryCache` 丢失；
- 冻结后的冷请求进入网关前置逻辑时 `memoryCache` 为空且 `isDataDependentRequest=true`，触发一次完整网络下载并阻塞等待；
- 该前置逻辑对请求是否真正需要 Bangumi Data 无感知——仅用 renren 的搜索同样会被强制触发下载。

后果：用户每次访问前端、且落在冷 isolate 上时，都要等待一次完整下载才返回，延迟明显；同时对被冻结后反复重建的 isolate，上游 CDN 也承受不必要的请求压力。本分支将下载触发下沉至消费路径后，仅真正读取缓存的路径触发下载，未配置消费源的部署（仅 renren）零下载，热路径内存命中秒回，过期仅后台刷新不阻塞，从根本上消除该问题。

---

## 影响范围

| 场景 | 行为变化 |
|------|:--:|
| 仅 renren 部署（无消费源） | **整次请求不触碰 Bangumi Data，零下载**（原版即便无关也触发判定） |
| 含消费源的热路径请求 | **内存命中秒回，与原版一致** |
| 含消费源的冷启动/过期刷新 | **仍触发下载；边缘运行时在途刷新经 `waitUntil` 延长（机制由数据层深穿改为边缘层暴露）** |
| 前端/本地由关到开 `USE_BANGUMI_DATA` | **立即触发下载**（原版不触发，需等下次请求） |
| 由开到关 | **立即释放缓存**（原版仅关时释放，现一致且补开启路径） |
| 非 Cloudflare 运行时（Node/Vercel/Netlify/Docker） | **无 ctx，`extendBangumiDownloadLifecycle` 自然 no-op，无回归** |
| `getTMDBChineseTitle`（`TITLE_TO_CHINESE` 开启） | **本地中文名命中路径真实生效**（修复前恒不命中） |

---

## 涉及文件

| 文件 | 改动 |
|------|:--:|
| `danmu_api/utils/bangumi-data-util.js` | 新增 `ensureBangumiDataReady` / `syncBangumiDataLifecycleOnConfigChange` / `getBackgroundDownload` / `extendBangumiDownloadLifecycle` / `startDownload`；`initBangumiData` 移除 `ctx` 参数、三处刷新分支复用 `startDownload`；`searchBangumiData` 顶部 `await ensureBangumiDataReady`；`let` 声明整理 |
| `danmu_api/apis/env-api.js` | `handleSetEnv`/`handleAddEnv`/`handleDelEnv` 在保存成功后对 `USE_BANGUMI_DATA` 调 `syncBangumiDataLifecycleOnConfigChange` |
| `danmu_api/server.js` | `.env` 监听器改为先同步 `globals.useBangumiData` 再调 `syncBangumiDataLifecycleOnConfigChange('node')`；import 调整 |
| `danmu_api/utils/tmdb-util.js` | `getTMDBChineseTitle` 补 `await searchBangumiData` |
| `danmu_api/worker.js` | 移除 `handleRequest` 内全局前置下载及其 `ctx` 参数；Cloudflare Workers `fetch` 接收 `ctx` 并在响应后调 `extendBangumiDownloadLifecycle`（边缘层延长在途下载，不再深穿数据层） |
| `danmu_api/worker.test.js` | 注释态新增 bangumi 数据下载时机/配置变更/await 修复 与 在途下载暴露/边缘生命周期 两组测试 |
