### PR TITLE
feat: 支持 IPv4/IPv6 双栈监听并优化服务器启动与清理逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ LogVar 弹幕 API 服务器
    ```bash
    npm start
    ```
-   服务器将在 `http://{ip}:9321` 运行，默认token是`87654321`。
+   服务器将在 `http://{ip}:9321` 运行，默认token是`87654321`。Node 服务默认通过 `::` 同时监听 IPv6 和 IPv4；不支持 IPv6 绑定时会自动回退到 `0.0.0.0`。IPv6 地址访问格式为 `http://[IPv6地址]:9321`。若操作系统强制启用了 `IPV6_V6ONLY`，需调整系统网络策略后才能通过同一监听端口接受 IPv4 连接。
    如需修改端口，可设置环境变量 `DANMU_API_PORT`（例如 `DANMU_API_PORT=8080 npm start`）。
    HTTPS 反向代理应传递 `X-Forwarded-Proto`；无法传递时可设置 `DANMU_API_PUBLIC_PROTO=https`，用于生成正确的对外弹幕链接。
 
@@ -214,6 +214,8 @@ GET http://127.0.0.1:9321/87654321/api/logs
    ```
    - 使用`-e TOKEN=87654321`设置`TOKEN`环境变量，覆盖Dockerfile中的默认值。
    - 或使用 `--env-file .env` 加载 .env 文件中的所有环境变量：`docker run -d -p 9321:9321 --name danmu-api --env-file .env danmu-api`
+
+   > 容器内服务默认启用 IPv4/IPv6 双栈监听。通过 IPv6 从宿主机访问时，Docker 守护进程及容器网络也需要启用 IPv6；否则仍可正常使用 IPv4。
 
    **热更新支持**：如需支持环境变量热更新（修改 `.env` 文件后无需重启容器），请使用 Volume 挂载：
    ```bash
@@ -720,6 +722,7 @@ API 支持返回 Bilibili 标准 XML 格式的弹幕数据，通过查询参数 
 │       ├── migu-util.js        # 咪咕工具
 │       ├── offset-util.js      # 弹幕偏移工具
 │       ├── redis-util.js       # redis工具
+│       ├── server-listen-util.js # IPv4/IPv6 双栈监听与 IPv4 回退工具
 │       ├── time-util.js        # 时间日期工具
 │       ├── tmdb-util.js        # TMDB API请求处理工具
 │       └── zh-util.js          # 中文繁简转换工具

--- a/danmu_api/configs/globals.js
+++ b/danmu_api/configs/globals.js
@@ -13,7 +13,7 @@ export const Globals = {
   accessedEnvVars: {},
 
   // 静态常量
-  VERSION: '1.20.6',
+  VERSION: '1.20.7',
   MAX_LOGS: 1000, // 日志存储，最多保存 1000 行
   MAX_RECORDS: 100, // 请求记录最大数量
 

--- a/danmu_api/server.js
+++ b/danmu_api/server.js
@@ -15,6 +15,7 @@ import { getLocalCaches, judgeLocalCacheValid } from './utils/cache-util.js';
 import { getRedisCaches, judgeRedisValid } from './utils/redis-util.js';
 import { persistFavorites, refreshFavoriteByKeyword } from './apis/favorite-api.js';
 import { startFavoriteScheduler, stopFavoriteScheduler } from './utils/favorite-schedule-util.js';
+import { formatHostForUrl, listenOnAllInterfaces } from './utils/server-listen-util.js';
 
 // =====================
 // server.js - 本地node智能启动脚本：根据 Node.js 环境自动选择最优启动模式
@@ -252,7 +253,7 @@ async function setupEnvWatcher() {
 /**
  * 优雅关闭：清理文件监听器并关闭服务器
  */
-function cleanupWatcher() {
+function cleanupWatcher(exitCode = 0) {
   stopFavoriteScheduler();
   if (envWatcher) {
     console.log('[server] Closing file watcher...');
@@ -264,14 +265,14 @@ function cleanupWatcher() {
     reloadTimer = null;
   }
   // 优雅关闭主服务器
-  if (mainServer) {
+  if (mainServer?.listening) {
     console.log('[server] Closing main server...');
     mainServer.close(() => {
       console.log('[server] Main server closed');
     });
   }
   // 优雅关闭代理服务器
-  if (proxyServer) {
+  if (proxyServer?.listening) {
     console.log('[server] Closing proxy server...');
     proxyServer.close(() => {
       console.log('[server] Proxy server closed');
@@ -280,13 +281,13 @@ function cleanupWatcher() {
   // 给服务器一点时间关闭后退出
   setTimeout(() => {
     console.log('[server] Exit complete.');
-    process.exit(0);
+    process.exit(exitCode);
   }, 500);
 }
 
 // 监听进程退出信号
-process.on('SIGTERM', cleanupWatcher);
-process.on('SIGINT', cleanupWatcher);
+process.on('SIGTERM', () => cleanupWatcher(0));
+process.on('SIGINT', () => cleanupWatcher(0));
 
 /**
  * 创建主业务服务器实例 (默认端口 9321，可通过 DANMU_API_PORT 配置)
@@ -507,23 +508,25 @@ async function startServer() {
   const configuredMainPort = Number.parseInt(process.env.DANMU_API_PORT ?? '', 10);
   const mainPort = Number.isNaN(configuredMainPort) ? 9321 : configuredMainPort;
   mainServer = createServer();
-  mainServer.listen(mainPort, '0.0.0.0', () => {
-    console.log(`Server running on http://0.0.0.0:${mainPort}`);
-    if (detectNodeDeployPlatform() === 'node') {
-      initializeFavoriteScheduler(mainPort).catch(error => {
-        console.error('[server] Favorite scheduler initialization failed:', error.message);
-      });
-    }
+  const mainBinding = await listenOnAllInterfaces(mainServer, mainPort, {
+    serviceName: 'main server'
   });
+  console.log(`Server running on http://${formatHostForUrl(mainBinding.address)}:${mainBinding.port}`);
+  if (detectNodeDeployPlatform() === 'node') {
+    initializeFavoriteScheduler(mainPort).catch(error => {
+      console.error('[server] Favorite scheduler initialization failed:', error.message);
+    });
+  }
 
   // 启动5321端口的代理服务
   proxyServer = createProxyServer();
-  proxyServer.listen(5321, '0.0.0.0', () => {
-    console.log('Proxy server running on http://0.0.0.0:5321');
-
-    // 异步初始化 Bangumi Data 缓存
-    setTimeout(() => initBangumiData('node', true).catch(console.error), 1000);
+  const proxyBinding = await listenOnAllInterfaces(proxyServer, 5321, {
+    serviceName: 'proxy server'
   });
+  console.log(`Proxy server running on http://${formatHostForUrl(proxyBinding.address)}:${proxyBinding.port}`);
+
+  // 异步初始化 Bangumi Data 缓存
+  setTimeout(() => initBangumiData('node', true).catch(console.error), 1000);
 }
 
 async function initializeFavoriteScheduler(mainPort) {
@@ -542,4 +545,7 @@ async function initializeFavoriteScheduler(mainPort) {
 }
 
 // 启动
-startServer();
+startServer().catch(error => {
+  console.error('[server] Failed to start server:', error);
+  cleanupWatcher(1);
+});

--- a/danmu_api/utils/server-listen-util.js
+++ b/danmu_api/utils/server-listen-util.js
@@ -1,0 +1,85 @@
+const IPV6_UNAVAILABLE_ERROR_CODES = new Set([
+  'EAFNOSUPPORT',
+  'EADDRNOTAVAIL'
+]);
+
+function listenOnce(server, options) {
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      server.off('error', onError);
+    };
+
+    const onError = (error) => {
+      cleanup();
+      reject(error);
+    };
+
+    const onListening = () => {
+      cleanup();
+      resolve(server.address());
+    };
+
+    server.once('error', onError);
+
+    try {
+      server.listen(options, onListening);
+    } catch (error) {
+      cleanup();
+      reject(error);
+    }
+  });
+}
+
+function createBinding(address, requestedHost, requestedPort, fallback) {
+  if (address && typeof address === 'object') {
+    return {
+      address: address.address,
+      family: address.family,
+      port: address.port,
+      fallback
+    };
+  }
+
+  return {
+    address: requestedHost,
+    family: requestedHost === '::' ? 'IPv6' : 'IPv4',
+    port: requestedPort,
+    fallback
+  };
+}
+
+/**
+ * Listen on all IPv6 and IPv4 interfaces through a dual-stack IPv6 socket.
+ * IPv4-only environments fall back to 0.0.0.0, while unrelated bind errors
+ * are propagated to the caller.
+ */
+export async function listenOnAllInterfaces(server, port, options = {}) {
+  const logger = options.logger || console;
+  const serviceName = options.serviceName || 'server';
+
+  try {
+    const address = await listenOnce(server, {
+      port,
+      host: '::',
+      ipv6Only: false
+    });
+    return createBinding(address, '::', port, false);
+  } catch (error) {
+    if (!IPV6_UNAVAILABLE_ERROR_CODES.has(error?.code)) {
+      throw error;
+    }
+
+    logger.warn(
+      `[server] ${serviceName} cannot bind to IPv6 (${error.code}); falling back to IPv4`
+    );
+    const address = await listenOnce(server, {
+      port,
+      host: '0.0.0.0'
+    });
+    return createBinding(address, '0.0.0.0', port, true);
+  }
+}
+
+export function formatHostForUrl(host) {
+  return String(host).includes(':') ? `[${host}]` : String(host);
+}


### PR DESCRIPTION
- 新增 server-listen-util.js 工具，实现 IPv4/IPv6 双栈监听及 IPv4 自动回退
- server.js 改用 listenOnAllInterfaces 替代硬编码 0.0.0.0，提升网络兼容性
- 优化 cleanupWatcher 函数，增加 listening 检查及退出码参数，避免重复关闭
- README 补充 IPv6 访问格式、Docker 双栈说明及相关工具文件描述
- 版本号升级至 1.20.7

Close #442 