### PR TITLE
feat: 增加收藏功能可用性检测

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ LogVar 弹幕 API 服务器
   - `GET /api/logs`：获取最近的日志（最多 500 行，格式为 `[时间戳] 级别: 消息`）。
   - `GET /api/cache/animes`：获取最近的 animes 缓存。
   - `POST /api/v2/favorite/add`：新增收藏。手动匹配测试使用 `{ "keyword": "火影忍者" }` 保存搜索关键词及整组搜索结果；同时兼容 `{ "fileName": "火影忍者 S01E01" }`。
-  - `GET /api/v2/favorite/list`：获取收藏摘要列表，包含收藏关键词、来源、总集数、首条搜索结果图片、收藏时间及最近刷新时间。
+  - `GET /api/v2/favorite/list`：获取收藏摘要列表，包含收藏关键词、来源、总集数、首条搜索结果图片、收藏时间及最近刷新时间；响应中的 `favoriteSupported` 表示当前部署是否具备持久化收藏能力。
   - `POST /api/v2/favorite/refresh`：使用 `{ "keyword": "火影忍者" }` 强制重新搜索并更新收藏缓存。
   - `POST /api/v2/favorite/schedule`：设置或关闭收藏的定时刷新（仅 Node/Docker 部署可用）。设置使用 `{ "keyword": "火影忍者", "schedule": { "frequency": "daily", "time": "03:00" } }`；每周模式需额外传 `"weekday": 1-7`（周一至周日），例如 `{ "frequency": "weekly", "time": "03:00", "weekday": 1 }`。关闭使用 `{ "keyword": "火影忍者", "schedule": null }`。固定按北京时间（`Asia/Shanghai`）执行，serverless 平台返回 `501`。
   - `POST /api/v2/favorite/remove`：使用 `{ "keyword": "火影忍者" }` 删除收藏及对应搜索缓存。
@@ -84,7 +84,7 @@ LogVar 弹幕 API 服务器
   - 支持定时刷新收藏：在“收藏”标签页点击“定时刷新”按钮，选择每天或每周（1-7 对应周一至周日）与执行时间，固定按北京时间（`Asia/Shanghai`）运行；已配置的条目按钮会显示类似“每天 03:00”“周一 03:00”，条目下方显示下次执行时间和最近状态。
   - 定时刷新失败会保留旧缓存并在 10 分钟后自动重试一次，仍失败则等待下一个正常周期，不再继续重试；服务停机错过执行时间时，重启后只补执行一次并重新计算下一周期。
   - 定时刷新计划随收藏一起保存在 `.cache/favoritesCache` 或 Redis 中，Node/Docker 重启后如需保留请挂载 `.cache` 目录或配置 Upstash Redis；纯内存收藏及计划会随进程重启丢失。Vercel、Cloudflare、Netlify、EdgeOne、Hugging Face 等 serverless 平台不启动调度器，按钮会禁用并提示“仅支持 Node/Docker 部署”。
-  - Node/Docker 部署会写入 `.cache/favoritesCache` 永久保存，请挂载 `.cache` 目录；serverless 未配置 Redis 时仅保存在当前实例内存中，配置 Redis 后可跨冷启动和实例恢复。
+  - Node/Docker 部署会写入 `.cache/favoritesCache` 永久保存，请挂载 `.cache` 目录；serverless 平台必须配置 Redis 才启用收藏按钮，否则界面会置灰并提示配置 `UPSTASH_REDIS_REST_URL`、`UPSTASH_REDIS_REST_TOKEN`。配置 Redis 后可跨冷启动和实例恢复。
 - **智能缓存管理**：支持内存缓存搜索结果和弹幕数据，避免短期内重复的不必要API请求。包括：
   - 搜索结果缓存（可通过 `SEARCH_CACHE_MINUTES` 配置，默认1分钟）
   - 弹幕缓存（可通过 `COMMENT_CACHE_MINUTES` 配置，默认5分钟）

--- a/danmu_api/apis/favorite-api.js
+++ b/danmu_api/apis/favorite-api.js
@@ -128,8 +128,15 @@ export async function handleFavoriteAdd(req, url) {
 }
 
 export function handleFavoriteList() {
+  // Node/Docker 可以使用本地文件缓存；无持久化存储的 serverless 实例
+  // 会在冷启动或实例切换后丢失收藏，因此不向前端开放收藏写入按钮。
+  const favoriteSupported = globals.deployPlatform === 'node' || globals.redisValid === true;
   return jsonResponse({
     success: true,
+    favoriteSupported,
+    favoriteSupportMessage: favoriteSupported
+      ? ''
+      : '当前云部署未配置 Redis，收藏功能不可用。请配置 UPSTASH_REDIS_REST_URL 和 UPSTASH_REDIS_REST_TOKEN 后重新部署。',
     scheduledRefreshSupported: globals.deployPlatform === 'node',
     favorites: listFavorites()
   });

--- a/danmu_api/configs/globals.js
+++ b/danmu_api/configs/globals.js
@@ -13,7 +13,7 @@ export const Globals = {
   accessedEnvVars: {},
 
   // 静态常量
-  VERSION: '1.20.7',
+  VERSION: '1.20.8',
   MAX_LOGS: 1000, // 日志存储，最多保存 1000 行
   MAX_RECORDS: 100, // 请求记录最大数量
 

--- a/danmu_api/ui/js/apitest.js
+++ b/danmu_api/ui/js/apitest.js
@@ -85,7 +85,11 @@ let danmuTestState = {
     isFavorite: false
 };
 
-let favoriteState = { items: [], loading: false, error: '', loaded: false, searchQuery: '', scheduledRefreshSupported: false };
+let favoriteState = {
+    items: [], loading: false, error: '', loaded: false, searchQuery: '',
+    scheduledRefreshSupported: false, favoriteSupported: false,
+    favoriteSupportMessage: ''
+};
 
 // 初始化接口调试界面
 function initApiTestInterface() {
@@ -789,13 +793,23 @@ function resetManualFavoriteButton() {
     button.classList.add('btn-success');
     button.disabled = true;
     button.textContent = '收藏';
-    button.title = '请先完成手动搜索';
+    button.title = favoriteState.favoriteSupported
+        ? '请先完成手动搜索'
+        : (favoriteState.favoriteSupportMessage || '当前部署未配置 Redis，收藏功能不可用');
 }
 
 function renderManualFavoriteButton() {
     const button = document.getElementById('manual-favorite-btn');
     if (!button || !danmuTestState.favoriteSearchKeyword) return;
     const title = danmuTestState.favoriteAnimeTitle || danmuTestState.favoriteSearchKeyword;
+    if (!favoriteState.favoriteSupported) {
+        button.disabled = true;
+        button.classList.remove('btn-danger');
+        button.classList.add('btn-success');
+        button.textContent = '收藏（需 Redis）';
+        button.title = favoriteState.favoriteSupportMessage || '当前云部署未配置 Redis，收藏功能不可用';
+        return;
+    }
     button.disabled = false;
     button.classList.toggle('btn-success', !danmuTestState.isFavorite);
     button.classList.toggle('btn-danger', danmuTestState.isFavorite);
@@ -830,6 +844,10 @@ async function favoriteManualSearch() {
     const inputKeyword = document.getElementById('manual-search-keyword')?.value.trim() || '';
     if (!button || !inputKeyword) {
         resetManualFavoriteButton();
+        return;
+    }
+    if (!favoriteState.favoriteSupported) {
+        customAlert(favoriteState.favoriteSupportMessage || '当前云部署未配置 Redis，收藏功能不可用');
         return;
     }
     if (inputKeyword !== danmuTestState.favoriteSearchKeyword) {
@@ -960,6 +978,14 @@ function renderFavoriteListView() {
         return;
     }
 
+    if (!favoriteState.favoriteSupported) {
+        if (status) status.textContent = '收藏不可用 · 未配置 Redis';
+        list.innerHTML = '<div class="preview-empty"><strong>当前部署未启用收藏</strong><span>' +
+            escapeHtml(favoriteState.favoriteSupportMessage || '云平台请配置 UPSTASH_REDIS_REST_URL 和 UPSTASH_REDIS_REST_TOKEN 后重新部署') +
+            '</span></div>';
+        return;
+    }
+
     const normalizedQuery = favoriteState.searchQuery.toLocaleLowerCase();
     const items = normalizedQuery
         ? favoriteState.items.filter(item => [item.keyword, item.animeTitle, item.source].join(' ').toLocaleLowerCase().includes(normalizedQuery))
@@ -984,6 +1010,11 @@ async function loadFavoriteList(shouldRender = true) {
         const data = await response.json();
         if (!response.ok || !data.success) throw new Error(data.message || 'HTTP ' + response.status);
         favoriteState.items = Array.isArray(data.favorites) ? data.favorites : [];
+        // serverless 平台只有在 Redis 可用时才能跨冷启动持久化收藏。
+        // 兼容旧版本接口：缺少字段时按 Node 平台推断，避免误禁用本地部署。
+        favoriteState.favoriteSupported = data.favoriteSupported === true
+            || (data.favoriteSupported === undefined && data.scheduledRefreshSupported === true);
+        favoriteState.favoriteSupportMessage = String(data.favoriteSupportMessage || '');
         favoriteState.scheduledRefreshSupported = data.scheduledRefreshSupported === true;
         favoriteState.loaded = true;
     } catch (error) {

--- a/danmu_api/ui/template.js
+++ b/danmu_api/ui/template.js
@@ -205,7 +205,7 @@ export const HTML_TEMPLATE = /* html */ `
                     </div>
 
                     <div class="danmu-test-panel" id="favorite-panel">
-                        <p style="color: #666; margin-bottom: 15px;">收藏后的剧集会永久缓存，后续匹配可秒级返回缓存结果；对于《火影忍者》《名侦探柯南》等集数较多的剧集尤其有用，无需每次重新搜索。可在“手动匹配测试”界面搜索剧集后，点击“收藏”按钮添加搜索结果收藏。只缓存剧集搜索结果，不缓存弹幕。</p>
+                        <p style="color: #666; margin-bottom: 15px;">收藏后的剧集会永久缓存，后续匹配可秒级返回缓存结果；对于《火影忍者》《名侦探柯南》等集数较多的剧集尤其有用，无需每次重新搜索。可在“手动匹配测试”界面搜索剧集后，点击“收藏”按钮添加搜索结果收藏。只缓存剧集搜索结果，不缓存弹幕。Vercel、Netlify、Cloudflare 等云平台需配置 UPSTASH_REDIS_REST_URL 和 UPSTASH_REDIS_REST_TOKEN 才能使用收藏。</p>
                         <div class="form-group" style="margin-bottom: 15px;">
                             <label>搜索收藏</label>
                             <div style="display:flex;gap:10px;margin-top:5px;">


### PR DESCRIPTION
## 变更内容

- 收藏列表接口新增 avoriteSupported 字段
- Node/Docker 使用本地缓存时支持收藏
- 云部署仅在 Redis 可用时开放收藏功能
- 未配置 Redis 时，前端禁用收藏按钮并提示配置 Upstash Redis
- 更新 README 相关说明
- 版本号升级至 1.20.8

## 范围说明

本 PR 不包含远程剧名映射表，也不包含屏蔽词增强。