### PR TITLE
feat: 增加 DanmuX 标准渐变输出

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,11 +7,13 @@ on:
   pull_request:
     branches:
       - main
-    if: github.repository == 'huangxd-/danmu_api'
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
     steps:
       # 检出代码
@@ -33,15 +35,17 @@ jobs:
             echo "VERSION_TAG=${{ env.VERSION }}" >> $GITHUB_ENV
           fi
 
-      # ✅ 先登录，再初始化 Buildx，避免拉取 BuildKit 镜像时触发匿名限速
+      # Fork PR 没有仓库 secrets，只做构建验证，不登录或推送到 Docker Hub。
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request' && env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != ''
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          username: ${{ env.DOCKER_USERNAME }}
+          password: ${{ env.DOCKER_PASSWORD }}
 
-      # 登录后手动拉取，绕过匿名限速
+      # 登录后手动拉取，绕过匿名限速；PR 构建由 setup-buildx-action 正常拉取公开镜像。
       - name: Pull BuildKit image
+        if: github.event_name != 'pull_request' && env.DOCKER_USERNAME != '' && env.DOCKER_PASSWORD != ''
         run: docker pull moby/buildkit:buildx-stable-1
 
       - name: Set up QEMU
@@ -52,13 +56,14 @@ jobs:
 
       - name: Build and Push Docker image
         run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            docker buildx build --platform linux/amd64 \
+              -t danmu-api:pr-${{ github.sha }} \
+              --load .
+          elif [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            test -n "${DOCKER_USERNAME}" && test -n "${DOCKER_PASSWORD}" || { echo "Docker Hub credentials are required for image publishing"; exit 1; }
             docker buildx build --platform linux/amd64,linux/arm64 \
-              -t ${{ secrets.DOCKER_USERNAME }}/danmu-api:${{ env.VERSION_TAG }} \
-              -t ${{ secrets.DOCKER_USERNAME }}/danmu-api:latest \
-              --push .
-          else
-            docker buildx build --platform linux/amd64,linux/arm64 \
-              -t ${{ secrets.DOCKER_USERNAME }}/danmu-api:${{ env.VERSION_TAG }} \
+              -t "${DOCKER_USERNAME}/danmu-api:${VERSION_TAG}" \
+              -t "${DOCKER_USERNAME}/danmu-api:latest" \
               --push .
           fi

--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ LogVar 弹幕 API 服务器
   - `POST /api/v2/favorite/schedule`：设置或关闭收藏的定时刷新（仅 Node/Docker 部署可用）。设置使用 `{ "keyword": "火影忍者", "schedule": { "frequency": "daily", "time": "03:00" } }`；每周模式需额外传 `"weekday": 1-7`（周一至周日），例如 `{ "frequency": "weekly", "time": "03:00", "weekday": 1 }`。关闭使用 `{ "keyword": "火影忍者", "schedule": null }`。固定按北京时间（`Asia/Shanghai`）执行，serverless 平台返回 `501`。
   - `POST /api/v2/favorite/remove`：使用 `{ "keyword": "火影忍者" }` 删除收藏及对应搜索缓存。
 - **弹幕格式输出**：支持 JSON 和 XML 及 [@dan-uni/dan-any](https://github.com/ani-uni/dan-any)支持的全部输出格式 输出，通过以下方式配置：
-  - 环境变量：`DANMU_OUTPUT_FORMAT=json|xml|artplayer.json|baha.json|bili.xml|danuni.json|danuni.binpb|ddplay.json|dplayer.json|vod.json`（默认：json）
-  - 查询参数：`?format=xml` 或 `?format=json` ...（优先级最高）
+  - 环境变量：`DANMU_OUTPUT_FORMAT=json|xml|danmux|artplayer.json|baha.json|bili.xml|danuni.json|danuni.binpb|ddplay.json|dplayer.json|vod.json`（默认：json）
+  - 查询参数：`?format=xml`、`?format=json` 或 `?format=danmux`（优先级最高）
   - 优先级：查询参数 > 环境变量 > 默认值
   - 示例：`GET /api/v2/comment/10001?format=xml` 返回 XML 格式弹幕
   - **XML 格式说明**：完全遵循 Bilibili 标准格式，8字段标准弹幕属性
+  - **DanmuX v1 格式**：使用 `?format=danmux` 返回 `schemaVersion: 1` 的增强 JSON；每条评论保留 `p/m`，并可在 `danmux.effects` 中携带标准 `linear` 渐变。只有 `CONVERT_COLOR=color` 且 `GRADIENT_CHANCE` 命中时，普通白色弹幕才生成渐变；颜色来自 `GRADIENT_COLORS`，默认使用 `default` 皮肤。带 B 站 `color_v2/colorfulSrc` 的原生纹理弹幕不参与渐变、不会输出特效，并改标为 `[dandan]`。
 - **日志记录**：捕获 `console.log`（info 级别）和 `console.error`（error 级别），JSON 内容格式化输出。
 - **永久收藏缓存**：适合《火影忍者》《名侦探柯南》等集数较多、重复搜索耗时较长的剧集。只缓存剧集搜索结果，不缓存弹幕。
   - `GET /api/v2/favorite/list` 是公开只读接口，无需 token。其他收藏接口在自定义 `TOKEN` 时，必须使用 `/{TOKEN}/api/v2/favorite/...` 或 `/{ADMIN_TOKEN}/api/v2/favorite/...` 形式显式携带 token；使用默认 `TOKEN=87654321` 且未开启管理员限制时可省略 token。配置 `FAVORITE_REQUIRE_ADMIN=true` 后，写入和管理操作仅允许 `ADMIN_TOKEN`。
@@ -150,6 +151,15 @@ LogVar 弹幕 API 服务器
    HTTPS 反向代理应传递 `X-Forwarded-Proto`；无法传递时可设置 `DANMU_API_PUBLIC_PROTO=https`，用于生成正确的对外弹幕链接。
 
    **热更新支持**：修改 `config/.env`，应用会自动检测并重新加载配置（无需重启应用）。
+
+   要看到标准渐变，请将普通弹幕转换设为 `color`，并打开渐变概率。例如全量验证：
+   ```text
+   CONVERT_COLOR=color
+   GRADIENT_CHANCE=100
+   GRADIENT_COLORS=default
+   ```
+
+   `GRADIENT_CHANCE` 可以改为 `20` 等百分比值；只有普通白色弹幕会参与转换。`GRADIENT_COLORS=bilibili` 只是可选的粉蓝颜色皮肤，并不启用 B 站原生纹理渐变。若需要覆盖皮肤颜色，可额外设置 `DANMUX_GRADIENT_STOPS`。
 
    或者使用下面的命令
    ```bash
@@ -477,7 +487,9 @@ API 支持返回 Bilibili 标准 XML 格式的弹幕数据，通过查询参数 
 | CONVERT_COLOR    | 【可选】弹幕转换颜色配置，默认为`default`（不转换），`white` 将所有非白色的弹幕颜色转换为纯白色，`color` 将所有白色弹幕转换为随机颜色（包含白色），可选值：`default`、`white`、`color`       |
 | COLOR_POOL    | 【可选】自定义颜色池（`CONVERT_COLOR`为`color`时生效），不配置使用默认颜色池（白、红、橙、黄、绿、青、蓝、紫、粉），格式：十进制颜色值逗号分隔，例如：`16711680,65280,255,16776960`       |
 | LIKE_SWITCH    | 【可选】弹幕点赞数显示开关，默认为`true`（开启），开启后会在弹幕内容后显示点赞数标记，≥5 才显示，避免低赞干扰       |
-| DANMU_OUTPUT_FORMAT    | 【可选】弹幕输出格式，默认为`json`，可选值：`json`（JSON格式）、`xml`（XML格式）及所有`@dan-uni/dan-any`支持的输出格式，支持通过查询参数`?format=xml`或`?format=json`等覆盖此设置，优先级：查询参数 > 环境变量 > 默认值       |
+| DANMU_OUTPUT_FORMAT    | 【可选】弹幕输出格式，默认为`json`，可选值：`json`（JSON格式）、`xml`（XML格式）、`danmux`（DanmuX v1 增强格式）及所有`@dan-uni/dan-any`支持的输出格式，支持通过查询参数`?format=xml`、`?format=json`或`?format=danmux`等覆盖此设置，优先级：查询参数 > 环境变量 > 默认值       |
+| DANMUX_GRADIENT_STOPS | 【可选】覆盖 DanmuX 标准渐变的 stops；仅对已由 `CONVERT_COLOR=color` 与 `GRADIENT_CHANCE` 选中的普通白色弹幕生效，必须是 JSON 数组，例如 `[ {"position":0,"color":"#FF6B8B"}, {"position":1,"color":"#A259FF"} ]`。 |
+| DANMUX_GRADIENT_ANGLE | 【可选】DanmuX v1 线性渐变角度，默认为 `0`；对由渐变皮肤或 `DANMUX_GRADIENT_STOPS` 生成的标准渐变生效。 |
 | DANMU_SIMPLIFIED_TRADITIONAL    | 【可选】弹幕简繁体转换设置：default（默认不转换）、simplified（繁转简）、traditional（简转繁）       |
 | DANMU_OFFSET      | 【可选】弹幕时间偏移配置，用于解决弹幕与视频不同步的问题。格式：剧名:秒（全剧偏移）或 剧名/季:秒（整季偏移）或 剧名/季/集:秒（单集偏移），支持指定来源：剧名@来源:秒 或 剧名/季@来源1&来源2:秒（不指定来源则对所有来源生效），多条用逗号分隔。例如：`overlord/S01:90, re-zero/S02@bilibili:120, re-zero/S02/E03@dandan&bilibili:10`。正数表示弹幕延后（向右），负数表示弹幕提前（向左）。支持百分比模式，在路径/来源末尾添加 `%`，例如：`东方/S03/E02@tencent%:11`，按 `原时间 * (视频时长 + 偏移秒数) / 视频时长` 计算新的弹幕发送时间。       |
 | UI_THEME    | 【可选】管理界面默认主题，默认为 `lavender`（经典默认）。浏览器中选择的主题会保存在本地并优先使用。可选值：`lavender`（经典默认）、`shinyo`（新叶绿）、`sakura`（哔哩粉）、`tianyi`（天依蓝）、`hatsune`（初音青）、`sakuragi`（樱木红）、`violet`（罗兰紫）、`amber`（LCL橘）       |

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ LogVar 弹幕 API 服务器
   - 示例：`GET /api/v2/comment/10001?format=xml` 返回 XML 格式弹幕
   - **XML 格式说明**：完全遵循 Bilibili 标准格式，8字段标准弹幕属性
   - **DanmuX v1 格式**：使用 `?format=danmux` 返回 `schemaVersion: 1` 的增强 JSON；每条评论保留 `p/m`，并可在 `danmux.effects` 中携带标准 `linear` 渐变。只有 `CONVERT_COLOR=color` 且 `GRADIENT_CHANCE` 命中时，普通白色弹幕才生成渐变；颜色来自 `GRADIENT_COLORS`，默认使用 `default` 皮肤。带 B 站 `color_v2/colorfulSrc` 的原生纹理弹幕不参与渐变、不会输出特效，并改标为 `[dandan]`。
+  - **播放器渲染约定**：播放器继续使用 `p/m` 作为基础数据；当 `danmux.effects` 中存在 `type=gradient`、`target=fill` 且 `source.type=linear` 的效果时，按其中的 `angle/stops` 渲染文字填充。没有该效果或不支持 DanmuX 时直接按 `p` 中的单色显示。渐变命中概率和皮肤选择已经由服务端完成，播放器不应再次随机选择，也不应给全部弹幕统一添加渐变。
 - **日志记录**：捕获 `console.log`（info 级别）和 `console.error`（error 级别），JSON 内容格式化输出。
 - **永久收藏缓存**：适合《火影忍者》《名侦探柯南》等集数较多、重复搜索耗时较长的剧集。只缓存剧集搜索结果，不缓存弹幕。
   - `GET /api/v2/favorite/list` 是公开只读接口，无需 token。其他收藏接口在自定义 `TOKEN` 时，必须使用 `/{TOKEN}/api/v2/favorite/...` 或 `/{ADMIN_TOKEN}/api/v2/favorite/...` 形式显式携带 token；使用默认 `TOKEN=87654321` 且未开启管理员限制时可省略 token。配置 `FAVORITE_REQUIRE_ADMIN=true` 后，写入和管理操作仅允许 `ADMIN_TOKEN`。

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ LogVar 弹幕 API 服务器
   - 优先级：查询参数 > 环境变量 > 默认值
   - 示例：`GET /api/v2/comment/10001?format=xml` 返回 XML 格式弹幕
   - **XML 格式说明**：完全遵循 Bilibili 标准格式，8字段标准弹幕属性
-  - **DanmuX v1 格式**：使用 `?format=danmux` 返回 `schemaVersion: 1` 的增强 JSON；每条评论保留 `p/m`，并可在 `danmux.effects` 中携带标准 `linear` 渐变。只有 `CONVERT_COLOR=color` 且 `GRADIENT_CHANCE` 命中时，普通白色弹幕才生成渐变；颜色来自 `GRADIENT_COLORS`，默认使用 `default` 皮肤。带 B 站 `color_v2/colorfulSrc` 的原生纹理弹幕不参与渐变、不会输出特效，并改标为 `[dandan]`。
+  - **DanmuX v1 格式**：使用 `?format=danmux` 返回 `schemaVersion: 1` 的增强 JSON；每条评论保留 `p/m`，并可在 `danmux.effects` 中携带标准 `linear` 渐变。只有 `CONVERT_COLOR=color` 且 `GRADIENT_CHANCE` 命中时，普通白色弹幕才生成渐变；颜色来自 `GRADIENT_COLORS`，默认使用 `default` 皮肤。解码得到的 B 站 `color_v2` 原生纹理弹幕不参与渐变、不会输出特效，并改标为 `[dandan]`。
   - **播放器渲染约定**：播放器继续使用 `p/m` 作为基础数据；当 `danmux.effects` 中存在 `type=gradient`、`target=fill` 且 `source.type=linear` 的效果时，按其中的 `angle/stops` 渲染文字填充。没有该效果或不支持 DanmuX 时直接按 `p` 中的单色显示。渐变命中概率和皮肤选择已经由服务端完成，播放器不应再次随机选择，也不应给全部弹幕统一添加渐变。
 - **日志记录**：捕获 `console.log`（info 级别）和 `console.error`（error 级别），JSON 内容格式化输出。
 - **永久收藏缓存**：适合《火影忍者》《名侦探柯南》等集数较多、重复搜索耗时较长的剧集。只缓存剧集搜索结果，不缓存弹幕。

--- a/config/.env.example
+++ b/config/.env.example
@@ -191,16 +191,17 @@ CONVERT_COLOR=default
 COLOR_POOL=
 
 # 渐变色弹幕概率（CONVERT_COLOR为color时生效）
-# 默认值：5
+# 默认值：0
 # 说明：白色弹幕转换为随机颜色时，按该概率（百分比）改为从渐变色带上取色；颜色随弹幕出现时间平滑流转（60秒循环），相邻弹幕颜色渐变过渡；0 表示关闭
 # 可选值：0-100
 GRADIENT_CHANCE=0
 
 # 渐变色带（CONVERT_COLOR为color时生效）
-# 默认值：空（使用内置默认皮肤 bilibili：B站标准粉蓝 #FB7299→#33B8FF）
+# 默认值：default（标准粉紫 #FF6B8B→#A259FF）
 # 说明：可直接填皮肤名，或填十进制颜色值逗号分隔（至少2个，相邻颜色平滑过渡）
 # 皮肤预设：
-#   bilibili = 粉→蓝  #FB7299→#33B8FF（B站标准）
+#   default  = 粉紫   #FF6B8B→#A259FF（默认标准）
+#   bilibili = 粉→蓝  #FB7299→#33B8FF（可选皮肤）
 #   sweet    = 粉紫   #FF6B8B→#A259FF（甜美风）
 #   cyber    = 荧光绿→天青 #00FF87→#60EFFF（电竞风）
 #   sunset   = 金橙→珊瑚 #FFA726→#FF5252（日落风）
@@ -208,7 +209,7 @@ GRADIENT_CHANCE=0
 #   mint     = 薄荷绿 #43E97B→#38F9D7（清新风）
 #   rainbow  = 彩虹七色（红橙黄绿青蓝紫）
 # 示例：GRADIENT_COLORS=sweet 或 GRADIENT_COLORS=16711680,16776960,255
-GRADIENT_COLORS=
+GRADIENT_COLORS=default
 
 # 弹幕简繁体转换设置：default（默认不转换）、simplified（繁转简）、traditional（简转繁）
 # 默认值：default（不转换）
@@ -242,13 +243,22 @@ DANMU_PUSH_URL=http://127.0.0.1:9978/action?do=refresh&type=danmaku&path=
 
 # 弹幕输出格式（全局默认格式）
 # 默认值：json
-# 可选值：json, xml
+# 可选值：json, xml, danmux，以及 @dan-uni/dan-any 支持的格式
 # 说明：
 #   - json: 返回 JSON 格式的弹幕数据（默认）
 #   - xml: 返回 XML 格式的弹幕数据（兼容弹弹play等客户端）
-# 注意：可通过 API 查询参数 ?format=xml 或 ?format=json 覆盖此设置
-# 示例：GET /api/v2/comment/10001?format=xml
+#   - danmux: 返回 DanmuX v1 增强 JSON，保留 p/m 兼容字段并携带标准 linear 渐变
+# 注意：可通过 API 查询参数 ?format=xml、?format=json 或 ?format=danmux 覆盖此设置
+# 示例：GET /api/v2/comment/10001?format=danmux
 DANMU_OUTPUT_FORMAT=json
+
+# DanmuX 标准渐变 stops JSON；留空时使用 GRADIENT_COLORS 皮肤
+# 必须使用 JSON 数组且至少包含两个颜色节点。错误配置会安全回退到 GRADIENT_COLORS
+# 示例：[{"position":0,"color":"#FF6B8B"},{"position":1,"color":"#A259FF"}]
+DANMUX_GRADIENT_STOPS=
+
+# DanmuX 标准线性渐变角度，范围 0-360
+DANMUX_GRADIENT_ANGLE=0
 
 # ==================== 限流配置 ====================
 

--- a/danmu_api/configs/envs.js
+++ b/danmu_api/configs/envs.js
@@ -18,7 +18,7 @@ export class Envs {
   static rawEnvValues = null;
 
   // 允许在值中写入 # 等 dotenv 视为注释字符的文本类变量；读取时绕过 dotenv 截断以保留完整内容。仅纳入 encrypt=false 变量（带令牌/密码 URL 若入此集合会绕过加密返回明文，故禁止纳入）。
-  static RAW_ENV_KEYS = new Set(['AI_MATCH_PROMPT', 'ANIME_TITLE_FILTER', 'AUTO_MATCH_MAPPING_TABLE', 'BLOCKED_WORDS', 'COLOR_POOL', 'CUSTOM_MERGE_RULES', 'DANMU_OFFSET', 'DANMU_PUSH_URL', 'EPISODE_TITLE_FILTER', 'IP_BLACKLIST', 'OTHER_SERVER', 'TITLE_MAPPING_TABLE', 'TITLE_NOISE_FILTER', 'VOD_SERVERS']);
+  static RAW_ENV_KEYS = new Set(['AI_MATCH_PROMPT', 'ANIME_TITLE_FILTER', 'AUTO_MATCH_MAPPING_TABLE', 'BLOCKED_WORDS', 'COLOR_POOL', 'CUSTOM_MERGE_RULES', 'DANMU_OFFSET', 'DANMU_PUSH_URL', 'DANMUX_GRADIENT_STOPS', 'EPISODE_TITLE_FILTER', 'IP_BLACKLIST', 'OTHER_SERVER', 'TITLE_MAPPING_TABLE', 'TITLE_NOISE_FILTER', 'VOD_SERVERS']);
 
   static VOD_ALLOWED_PLATFORMS = ['qiyi', 'bilibili1', 'imgo', 'youku', 'qq', 'migu', 'sohu', 'leshi', 'xigua', 'maiduidui', 'aiyifan']; // vod允许的播放平台
   static ALLOWED_PLATFORMS = ['qiyi', 'bilibili1', 'imgo', 'youku', 'qq', 'migu', 'renren', 'hanjutv', 'sohu', 'leshi', 'xigua', 'maiduidui', 'aiyifan', 'hongguo', 'dandan', 'bahamut', 'animeko', 'custom']; // 全部源允许的播放平台
@@ -733,8 +733,10 @@ export class Envs {
       'CONVERT_COLOR': { category: 'danmu', type: 'select', options: ['default', 'white', 'color'], description: '弹幕转换颜色配置' },
       'COLOR_POOL': { category: 'danmu', type: 'text', description: '自定义颜色池（CONVERT_COLOR为color时生效），不配置使用默认颜色池，格式：十进制颜色值逗号分隔' },
       'GRADIENT_CHANCE': { category: 'danmu', type: 'number', min: 0, max: 100, description: '渐变色弹幕概率（CONVERT_COLOR为color时生效），单位百分比 0-100，默认 0，弹幕按此概率从渐变色带取色（随出现时间平滑流转），0 表示关闭' },
-      'GRADIENT_COLORS': { category: 'danmu', type: 'text', description: '渐变色带（CONVERT_COLOR为color时生效），可填皮肤名：bilibili(默认)/sweet/cyber/sunset/ocean/mint/rainbow，或十进制颜色值逗号分隔（至少2个）' },
-      'DANMU_OUTPUT_FORMAT': { category: 'danmu', type: 'select', options: ['json', 'xml', ...danAnyFormats], description: '弹幕输出格式，默认json' },
+      'GRADIENT_COLORS': { category: 'danmu', type: 'text', description: '渐变色带（CONVERT_COLOR为color时生效），默认使用default；可选皮肤：bilibili/sweet/cyber/sunset/ocean/mint/rainbow，或十进制颜色值逗号分隔（至少2个）' },
+      'DANMUX_GRADIENT_STOPS': { category: 'danmu', type: 'text', description: 'DanmuX 标准渐变 stops JSON；留空时使用 GRADIENT_COLORS 皮肤' },
+      'DANMUX_GRADIENT_ANGLE': { category: 'danmu', type: 'number', min: 0, max: 360, description: 'DanmuX 标准线性渐变角度，默认0' },
+      'DANMU_OUTPUT_FORMAT': { category: 'danmu', type: 'select', options: ['json', 'xml', 'danmux', ...danAnyFormats], description: '弹幕输出格式，默认json' },
       'DANMU_PUSH_URL': { category: 'danmu', type: 'text', description: '弹幕推送地址，示例 http://127.0.0.1:9978/action?do=refresh&type=danmaku&path= ' },
       'LIKE_SWITCH': { category: 'danmu', type: 'boolean', description: '弹幕点赞数显示开关，默认开启' },
       'HONGGUO_MERGE_ALL_EPISODES': { category: 'danmu', type: 'boolean', description: '红果短剧合并全集弹幕，默认关闭' },
@@ -811,7 +813,9 @@ export class Envs {
       convertColor: this.get('CONVERT_COLOR', 'default', 'string'), // 弹幕转换颜色配置，支持 default、white、color（默认 default，禁用转换）
       colorPool: this.get('COLOR_POOL', '16777215,16777215,16777215,16777215,16777215,16777215,16777215,16777215,16744319,16752762,16774799,9498256,8388564,8900346,14204888,16758465', 'string'), // 自定义颜色池，CONVERT_COLOR为color时生效
       gradientChance: this.get('GRADIENT_CHANCE', 0, 'number'), // 渐变色弹幕出现概率（百分比），CONVERT_COLOR为color时生效，0 表示关闭
-      gradientColors: this.get('GRADIENT_COLORS', '16478873,3389695', 'string'), // 渐变色带（B站标准粉蓝 #FB7299→#33B8FF），CONVERT_COLOR为color时生效
+      gradientColors: this.get('GRADIENT_COLORS', 'default', 'string'), // 普通白色弹幕使用的渐变皮肤
+      danmuxGradientStops: this.get('DANMUX_GRADIENT_STOPS', '', 'string'), // DanmuX v1 显式 stops JSON；为空时不生成普通弹幕渐变
+      danmuxGradientAngle: this.get('DANMUX_GRADIENT_ANGLE', 0, 'number'), // DanmuX v1 linear angle
       danmuOutputFormat: this.get('DANMU_OUTPUT_FORMAT', 'json', 'string'), // 弹幕输出格式配置（默认 json，可选值：json, xml, ...danAnyFormats）
       strictTitleMatch: this.get('STRICT_TITLE_MATCH', false, 'boolean'), // 严格标题匹配模式配置（默认 false，宽松模糊匹配）
       titleToChinese: this.get('TITLE_TO_CHINESE', false, 'boolean'), // 外语标题转换中文开关

--- a/danmu_api/utils/danmu-util.js
+++ b/danmu_api/utils/danmu-util.js
@@ -3,6 +3,18 @@ import { log } from './log-util.js'
 import { binResponse, jsonResponse, xmlResponse } from "./http-util.js";
 import { simplized, traditionalized } from './zh-util.js';
 import { convertDanAny } from './dan-any.js';
+import { convertCommentsToDanmux, parseDanmuxGradientStops } from './danmux-adapter.js';
+import { DANMUX_GRADIENT_META } from './danmux-meta.js';
+
+const NATIVE_GRADIENT_FIELDS = ['color_v2', 'colorV2', 'colorfulSrc', 'colorful_src', 'gradient'];
+
+function getNativeGradientValue(item) {
+  if (!item || typeof item !== 'object') return { present: false, value: undefined };
+  for (const field of NATIVE_GRADIENT_FIELDS) {
+    if (item[field] !== undefined) return { present: true, value: item[field] };
+  }
+  return { present: false, value: undefined };
+}
 
 // =====================
 // danmu处理相关函数
@@ -299,6 +311,7 @@ function lerpColor(a, b, frac) {
  */
 // 渐变皮肤预设：GRADIENT_COLORS 可填皮肤名直接使用，也可填十进制颜色值串自定义
 export const GRADIENT_SKINS = {
+  'default': '16739211,10639871', // 默认标准粉紫（#FF6B8B→#A259FF）
   'bilibili': '16478873,3389695',   // 粉→蓝（B站标准 #FB7299→#33B8FF）
   'sweet': '16739211,10639871',     // 粉紫·甜美（#FF6B8B→#A259FF）
   'cyber': '65415,6352895',         // 荧光绿→天青·电竞（#00FF87→#60EFFF）
@@ -327,11 +340,22 @@ export function buildGradientSampler(rawStops) {
   };
 }
 
+function gradientStopsForDanmux(rawStops) {
+  const colors = String(rawStops || '').split(',')
+    .map(c => parseInt(c.trim(), 10))
+    .filter(c => !isNaN(c) && c >= 0 && c <= 16777215);
+  if (colors.length < 2) return undefined;
+  return colors.map((color, index) => ({
+    position: index / (colors.length - 1),
+    color: `#${color.toString(16).padStart(6, '0').toUpperCase()}`,
+  }));
+}
+
 export function convertToDanmakuJson(contents, platform) {
   let danmus = [];
   let cidCounter = 1;
   let isMultiSource = false; // 用于记录当前弹幕集合是否为多源组合
-  let colorV2Count = 0; // 源渐变色弹幕（B站 color_v2）透传计数
+  let colorV2Count = 0; // 源渐变色弹幕（B站 color_v2）识别计数；DanmuX 不输出原生纹理
 
   // 统一处理输入为数组
   let items = [];
@@ -365,6 +389,7 @@ export function convertToDanmakuJson(contents, platform) {
   for (const item of items) {
     let attributes, m;
     let time, mode, color;
+    const nativeGradient = getNativeGradientValue(item);
 
     // 新增：处理新格式的弹幕数据
     if ("progress" in item && "mode" in item && "content" in item) {
@@ -407,6 +432,8 @@ export function convertToDanmakuJson(contents, platform) {
 
     // 优先使用弹幕自带的 _sourceLabel（应对合并工具），其次是外部传入的宏观 platform
     let currentPlatform = item._sourceLabel || platform;
+    // 原生 color_v2 由 dandan 兼容链路接管：不参与本项目渐变规则。
+    if (nativeGradient.present) currentPlatform = 'dandan';
 
     // 如果存在实时拉取的副源标签，安全追加
     if (item.realTimeSource && !currentPlatform.includes(item.realTimeSource)) {
@@ -425,18 +452,17 @@ export function convertToDanmakuJson(contents, platform) {
       `[${currentPlatform}]`
     ].join(",");
 
-    // B站渐变色弹幕透传：源数据携带 color_v2（大会员渐变弹幕扩展色）时原样保留，
-    // color 字段仍输出单色保持协议兼容，支持的播放器可读取 color_v2 渲染文字渐变
+    // 识别源数据中的 color_v2；DanmuX 输出阶段不会把 B 站原生纹理作为效果输出。
     const danmu = { p: attributes, m, cid: cidCounter++, like: item?.like };
-    if (item.color_v2) {
-      danmu.color_v2 = item.color_v2;
+    if (nativeGradient.present) {
+      danmu.color_v2 = nativeGradient.value;
       colorV2Count++;
     }
     danmus.push(danmu);
   }
 
   if (colorV2Count > 0) {
-    log("info", `[system] [danmu] [danmu convert] 透传了 ${colorV2Count} 条源渐变色弹幕（color_v2）`);
+    log("info", `[system] [danmu] [danmu convert] 识别了 ${colorV2Count} 条源渐变色弹幕（color_v2）`);
   }
 
   // 文本字段归一化为 m 后统一转换，确保所有来源及输入格式行为一致。
@@ -520,8 +546,10 @@ export function convertToDanmakuJson(contents, platform) {
     let topBottomCount = 0;
     let colorCount = 0;
     let gradientCount = 0;
-    // 渐变色带采样器与命中概率：color 模式下按概率将白色弹幕转为渐变色（以出现时间在色带上定位，颜色随时间流转）
-    const gradientSampler = globals.convertColor === 'color' ? buildGradientSampler(resolveGradientSkin(globals.gradientColors)) : null;
+    // 仅 color 模式下的普通白色弹幕按概率生成标准渐变。
+    const gradientRawStops = globals.convertColor === 'color' ? resolveGradientSkin(globals.gradientColors) : null;
+    const gradientSampler = buildGradientSampler(gradientRawStops);
+    const danmuxGradientStops = gradientStopsForDanmux(gradientRawStops);
     const gradientChance = Math.min(Math.max(globals.gradientChance || 0, 0), 100) / 100;
 
     convertedDanmus = convertedDanmus.map(danmu => {
@@ -531,6 +559,7 @@ export function convertToDanmakuJson(contents, platform) {
       let mode = parseInt(pValues[1], 10);
       let color = parseInt(pValues[2], 10);
       let modified = false;
+      let selectedGradient = false;
 
       // 1. 将顶部/底部弹幕转换为浮动弹幕
       if (globals.convertTopBottomToScroll && (mode === 4 || mode === 5)) {
@@ -555,13 +584,14 @@ export function convertToDanmakuJson(contents, platform) {
         .filter(c => !isNaN(c) && c >= 0 && c <= 16777215);
       const safeColors = colors.length > 0 ? colors : [16777215];
       let randomColor = safeColors[Math.floor(Math.random() * safeColors.length)];
-      // 源渐变弹幕（color_v2）透传优先：即使基色为白也不参与转换，保持原始渐变数据
+      // B 站原生渐变不参与本规则；这里只处理没有 color_v2 的普通白色弹幕。
       if (globals.convertColor === 'color' && color === 16777215 && danmu.color_v2 === undefined) {
         let target = randomColor;
-        if (gradientSampler && Math.random() < gradientChance) {
+        if (gradientSampler && danmuxGradientStops && Math.random() < gradientChance) {
           // 渐变色弹幕：以弹幕出现时间在色带上取色（60 秒循环一个来回），相邻弹幕颜色平滑过渡
           const appearTime = parseFloat(pValues[0]) || 0;
           target = gradientSampler((appearTime % 60) / 60);
+          selectedGradient = true;
           gradientCount++;
         }
         if (color !== target) {
@@ -573,8 +603,17 @@ export function convertToDanmakuJson(contents, platform) {
 
       if (modified) {
         const newP = [pValues[0], mode, color, ...pValues.slice(3)].join(',');
-        return { ...danmu, p: newP };
+        const converted = { ...danmu, p: newP };
+        if (selectedGradient) Object.defineProperty(converted, DANMUX_GRADIENT_META, {
+          value: { angle: globals.danmuxGradientAngle, stops: danmuxGradientStops },
+          enumerable: false,
+        });
+        return converted;
       }
+      if (selectedGradient) Object.defineProperty(danmu, DANMUX_GRADIENT_META, {
+        value: { angle: globals.danmuxGradientAngle, stops: danmuxGradientStops },
+        enumerable: false,
+      });
       return danmu;
     });
 
@@ -697,6 +736,21 @@ export function formatDanmuResponse(danmuData, queryFormat) {
   format = format.toLowerCase();
 
   log("info", `[system] [danmu] [format] Using format: ${format}`);
+
+  if (format === 'danmux') {
+    try {
+      const gradientStops = parseDanmuxGradientStops(globals.danmuxGradientStops);
+      return jsonResponse(convertCommentsToDanmux(danmuData, {
+        sourceLabel: 'danmu_api',
+        gradientStops,
+        gradientAngle: globals.danmuxGradientAngle,
+        applyGradientToAll: false,
+      }));
+    } catch (error) {
+      log("error", `[system] [danmu] Failed to convert to DanmuX: ${error.message}`);
+      return jsonResponse({ format: 'danmux', schemaVersion: 1, count: 0, comments: [], diagnostics: [{ code: 'danmux_output_failed', message: error.message }] }, 500);
+    }
+  }
 
   // 兼容旧格式转换
   if (format === 'xml') {

--- a/danmu_api/utils/danmu-util.js
+++ b/danmu_api/utils/danmu-util.js
@@ -341,6 +341,9 @@ export function buildGradientSampler(rawStops) {
 }
 
 function gradientStopsForDanmux(rawStops) {
+  // 同一套 GRADIENT_COLORS 同时产生两种表示：
+  // 1. p 字段中的采样单色，供旧播放器降级显示；
+  // 2. DanmuX linear stops，供支持增强协议的播放器绘制文字渐变。
   const colors = String(rawStops || '').split(',')
     .map(c => parseInt(c.trim(), 10))
     .filter(c => !isNaN(c) && c >= 0 && c <= 16777215);
@@ -546,7 +549,8 @@ export function convertToDanmakuJson(contents, platform) {
     let topBottomCount = 0;
     let colorCount = 0;
     let gradientCount = 0;
-    // 仅 color 模式下的普通白色弹幕按概率生成标准渐变。
+    // 渐变选择发生在服务端：仅 color 模式下的普通白色弹幕参与概率判断。
+    // 播放器不需要重复执行概率或颜色规则，只需按 danmux.effects 渲染命中的弹幕。
     const gradientRawStops = globals.convertColor === 'color' ? resolveGradientSkin(globals.gradientColors) : null;
     const gradientSampler = buildGradientSampler(gradientRawStops);
     const danmuxGradientStops = gradientStopsForDanmux(gradientRawStops);
@@ -588,7 +592,8 @@ export function convertToDanmakuJson(contents, platform) {
       if (globals.convertColor === 'color' && color === 16777215 && danmu.color_v2 === undefined) {
         let target = randomColor;
         if (gradientSampler && danmuxGradientStops && Math.random() < gradientChance) {
-          // 渐变色弹幕：以弹幕出现时间在色带上取色（60 秒循环一个来回），相邻弹幕颜色平滑过渡
+          // p 中写入沿色带采样的单色作为兼容回退；非枚举 metadata 会在 danmux 输出时升级为完整 linear 渐变。
+          // 采样位置由弹幕时间决定（60 秒循环），因此旧播放器看到的相邻弹幕也能保持平滑色彩过渡。
           const appearTime = parseFloat(pValues[0]) || 0;
           target = gradientSampler((appearTime % 60) / 60);
           selectedGradient = true;
@@ -739,6 +744,8 @@ export function formatDanmuResponse(danmuData, queryFormat) {
 
   if (format === 'danmux') {
     try {
+      // DanmuX 响应保留 p/m，并只为服务端已选中的弹幕附加 effects。
+      // 下层播放器应优先读取 gradient/linear；不认识增强层时可安全忽略并继续显示 p/m。
       const gradientStops = parseDanmuxGradientStops(globals.danmuxGradientStops);
       return jsonResponse(convertCommentsToDanmux(danmuData, {
         sourceLabel: 'danmu_api',

--- a/danmu_api/utils/danmu-util.js
+++ b/danmu_api/utils/danmu-util.js
@@ -6,14 +6,11 @@ import { convertDanAny } from './dan-any.js';
 import { convertCommentsToDanmux, parseDanmuxGradientStops } from './danmux-adapter.js';
 import { DANMUX_GRADIENT_META } from './danmux-meta.js';
 
-const NATIVE_GRADIENT_FIELDS = ['color_v2', 'colorV2', 'colorfulSrc', 'colorful_src', 'gradient'];
-
 function getNativeGradientValue(item) {
-  if (!item || typeof item !== 'object') return { present: false, value: undefined };
-  for (const field of NATIVE_GRADIENT_FIELDS) {
-    if (item[field] !== undefined) return { present: true, value: item[field] };
+  if (!item || typeof item !== 'object' || item.color_v2 === undefined) {
+    return { present: false, value: undefined };
   }
-  return { present: false, value: undefined };
+  return { present: true, value: item.color_v2 };
 }
 
 // =====================

--- a/danmu_api/utils/danmu-util.js
+++ b/danmu_api/utils/danmu-util.js
@@ -3,15 +3,8 @@ import { log } from './log-util.js'
 import { binResponse, jsonResponse, xmlResponse } from "./http-util.js";
 import { simplized, traditionalized } from './zh-util.js';
 import { convertDanAny } from './dan-any.js';
-import { convertCommentsToDanmux, parseDanmuxGradientStops } from './danmux-adapter.js';
+import { convertCommentsToDanmux, getNativeGradientValue, parseDanmuxGradientStops } from './danmux-adapter.js';
 import { DANMUX_GRADIENT_META } from './danmux-meta.js';
-
-function getNativeGradientValue(item) {
-  if (!item || typeof item !== 'object' || item.color_v2 === undefined) {
-    return { present: false, value: undefined };
-  }
-  return { present: true, value: item.color_v2 };
-}
 
 // =====================
 // danmu处理相关函数
@@ -389,7 +382,10 @@ export function convertToDanmakuJson(contents, platform) {
   for (const item of items) {
     let attributes, m;
     let time, mode, color;
-    const nativeGradient = getNativeGradientValue(item);
+    // 只按当前弹幕的真实来源识别 Bilibili 原生字段，避免其它来源的扩展字段
+    // 被误当成需要 dandan 兼容的原生渐变。
+    const sourceLabel = item?._sourceLabel || platform;
+    const nativeGradient = getNativeGradientValue(item, sourceLabel);
 
     // 新增：处理新格式的弹幕数据
     if ("progress" in item && "mode" in item && "content" in item) {
@@ -431,7 +427,7 @@ export function convertToDanmakuJson(contents, platform) {
     }
 
     // 优先使用弹幕自带的 _sourceLabel（应对合并工具），其次是外部传入的宏观 platform
-    let currentPlatform = item._sourceLabel || platform;
+    let currentPlatform = sourceLabel;
     // 原生 color_v2 由 dandan 兼容链路接管：不参与本项目渐变规则。
     if (nativeGradient.present) currentPlatform = 'dandan';
 
@@ -743,7 +739,8 @@ export function formatDanmuResponse(danmuData, queryFormat) {
     try {
       // DanmuX 响应保留 p/m，并只为服务端已选中的弹幕附加 effects。
       // 下层播放器应优先读取 gradient/linear；不认识增强层时可安全忽略并继续显示 p/m。
-      const gradientStops = parseDanmuxGradientStops(globals.danmuxGradientStops);
+      const fallbackStops = gradientStopsForDanmux(resolveGradientSkin(globals.gradientColors));
+      const gradientStops = parseDanmuxGradientStops(globals.danmuxGradientStops, fallbackStops);
       return jsonResponse(convertCommentsToDanmux(danmuData, {
         sourceLabel: 'danmu_api',
         gradientStops,

--- a/danmu_api/utils/danmux-adapter.js
+++ b/danmu_api/utils/danmux-adapter.js
@@ -1,0 +1,92 @@
+import {
+  createDanmuX,
+  fromBilibili,
+  applyGradient,
+  toCompatibilityWire,
+} from 'danmux';
+import { DANMUX_GRADIENT_META } from './danmux-meta.js';
+
+const NATIVE_GRADIENT_FIELDS = ['color_v2', 'colorV2', 'colorfulSrc', 'colorful_src', 'gradient'];
+
+function hasNativeGradient(comment) {
+  return NATIVE_GRADIENT_FIELDS.some((field) => comment?.[field] !== undefined);
+}
+
+function parseComment(comment, sourceLabel) {
+  const fields = String(comment.p ?? '').split(',');
+  const xmlProfile = fields.length >= 8;
+  const colorIndex = xmlProfile ? 3 : 2;
+  const fontSize = xmlProfile ? Number(fields[2]) : 25;
+  const result = fromBilibili({
+    id: comment.cid ?? `${sourceLabel}:${fields[0] ?? '0'}:${comment.m ?? ''}`,
+    time: Number(fields[0]),
+    mode: Number(fields[1]),
+    fontSize,
+    color: fields[colorIndex],
+    content: String(comment.m ?? ''),
+  });
+  if (!result.value) return result;
+  const normalized = createDanmuX({
+    ...result.value,
+    source: { platform: sourceLabel, id: String(comment.cid ?? result.value.id) },
+  });
+  return {
+    ...normalized,
+    diagnostics: [...(result.diagnostics ?? []), ...(normalized.diagnostics ?? [])],
+  };
+}
+
+export function parseDanmuxGradientStops(value) {
+  if (Array.isArray(value)) return value;
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function convertCommentsToDanmux(danmuData, {
+  sourceLabel = 'danmu_api',
+  gradientStops,
+  gradientAngle = 0,
+  applyGradientToAll = true,
+} = {}) {
+  const comments = Array.isArray(danmuData?.comments) ? danmuData.comments : [];
+  const diagnostics = [];
+  const converted = [];
+  for (let index = 0; index < comments.length; index++) {
+    const comment = comments[index];
+    const nativeGradient = hasNativeGradient(comment);
+    const commentSourceLabel = nativeGradient ? 'dandan' : sourceLabel;
+    const parsed = parseComment(comment, String(commentSourceLabel).slice(0, 64) || 'danmu_api');
+    diagnostics.push(...(parsed.diagnostics ?? []).map((entry) => ({ ...entry, index })));
+    if (!parsed.value) continue;
+    let item = parsed.value;
+    const selectedGradient = comment[DANMUX_GRADIENT_META];
+    const stops = nativeGradient
+      ? undefined
+      : selectedGradient
+        ? (gradientStops ?? selectedGradient.stops)
+        : (applyGradientToAll ? gradientStops : undefined);
+    if (stops !== undefined) {
+      const generated = applyGradient(item, { angle: selectedGradient?.angle ?? gradientAngle, stops });
+      diagnostics.push(...(generated.diagnostics ?? []).map((entry) => ({ ...entry, index })));
+      item = generated.value ?? item;
+    }
+    const wire = toCompatibilityWire(item);
+    converted.push({
+      ...wire,
+      ...(comment.cid !== undefined ? { cid: comment.cid } : {}),
+      ...(comment.like !== undefined ? { like: comment.like } : {}),
+    });
+  }
+  return {
+    format: 'danmux',
+    schemaVersion: 1,
+    count: converted.length,
+    comments: converted,
+    diagnostics,
+  };
+}

--- a/danmu_api/utils/danmux-adapter.js
+++ b/danmu_api/utils/danmux-adapter.js
@@ -8,12 +8,16 @@ import { DANMUX_GRADIENT_META } from './danmux-meta.js';
 
 const NATIVE_GRADIENT_FIELDS = ['color_v2', 'colorV2', 'colorfulSrc', 'colorful_src', 'gradient'];
 
+// 上游原生渐变通常引用平台纹理，不能直接等价为本项目生成的 linear 渐变。
+// 这里只识别其存在性，后续将弹幕交给 dandan 兼容链路，并禁止叠加人工渐变。
 function hasNativeGradient(comment) {
   return NATIVE_GRADIENT_FIELDS.some((field) => comment?.[field] !== undefined);
 }
 
 function parseComment(comment, sourceLabel) {
   const fields = String(comment.p ?? '').split(',');
+  // 同时接受 DanDanPlay 四字段 JSON 和 Bilibili 八/九字段 XML 的 p 结构。
+  // 两种结构的颜色位置不同，必须先确定 profile，避免把字号误当成颜色。
   const xmlProfile = fields.length >= 8;
   const colorIndex = xmlProfile ? 3 : 2;
   const fontSize = xmlProfile ? Number(fields[2]) : 25;
@@ -59,11 +63,14 @@ export function convertCommentsToDanmux(danmuData, {
   for (let index = 0; index < comments.length; index++) {
     const comment = comments[index];
     const nativeGradient = hasNativeGradient(comment);
+    // 原生纹理不由当前播放器协议加载；标记为 dandan 后仍保留 p/m 单色降级能力。
     const commentSourceLabel = nativeGradient ? 'dandan' : sourceLabel;
     const parsed = parseComment(comment, String(commentSourceLabel).slice(0, 64) || 'danmu_api');
     diagnostics.push(...(parsed.diagnostics ?? []).map((entry) => ({ ...entry, index })));
     if (!parsed.value) continue;
     let item = parsed.value;
+    // DANMUX_GRADIENT_META 是服务端筛选阶段写入的非枚举标记，只在当前转换链路内传递。
+    // 这保证播放器只渲染已命中的普通白色弹幕，而不是给所有弹幕统一套渐变。
     const selectedGradient = comment[DANMUX_GRADIENT_META];
     const stops = nativeGradient
       ? undefined
@@ -75,6 +82,7 @@ export function convertCommentsToDanmux(danmuData, {
       diagnostics.push(...(generated.diagnostics ?? []).map((entry) => ({ ...entry, index })));
       item = generated.value ?? item;
     }
+    // 兼容线同时输出 p/m 和可选 danmux.effects：旧播放器读取单色，新播放器读取增强层。
     const wire = toCompatibilityWire(item);
     converted.push({
       ...wire,

--- a/danmu_api/utils/danmux-adapter.js
+++ b/danmu_api/utils/danmux-adapter.js
@@ -6,12 +6,10 @@ import {
 } from 'danmux';
 import { DANMUX_GRADIENT_META } from './danmux-meta.js';
 
-const NATIVE_GRADIENT_FIELDS = ['color_v2', 'colorV2', 'colorfulSrc', 'colorful_src', 'gradient'];
-
 // 上游原生渐变通常引用平台纹理，不能直接等价为本项目生成的 linear 渐变。
-// 这里只识别其存在性，后续将弹幕交给 dandan 兼容链路，并禁止叠加人工渐变。
+// 解码器只会产出 color_v2；后续将该弹幕交给 dandan 兼容链路，并禁止叠加人工渐变。
 function hasNativeGradient(comment) {
-  return NATIVE_GRADIENT_FIELDS.some((field) => comment?.[field] !== undefined);
+  return comment?.color_v2 !== undefined;
 }
 
 function parseComment(comment, sourceLabel) {

--- a/danmu_api/utils/danmux-adapter.js
+++ b/danmu_api/utils/danmux-adapter.js
@@ -3,50 +3,103 @@ import {
   fromBilibili,
   applyGradient,
   toCompatibilityWire,
+  validateGradientEffect,
 } from 'danmux';
 import { DANMUX_GRADIENT_META } from './danmux-meta.js';
 
+const NATIVE_GRADIENT_FIELDS = ['color_v2', 'colorV2', 'colorfulSrc', 'colorful_src'];
+
 // 上游原生渐变通常引用平台纹理，不能直接等价为本项目生成的 linear 渐变。
-// 解码器只会产出 color_v2；后续将该弹幕交给 dandan 兼容链路，并禁止叠加人工渐变。
-function hasNativeGradient(comment) {
-  return comment?.color_v2 !== undefined;
+// 只有 Bilibili 的原生字段才走 dandan 兼容链路；通用的 gradient 字段不属于
+// 本项目的 Bilibili 输入契约，不能据此误判其它来源的弹幕。
+function sourceTokens(value) {
+  return String(value ?? '')
+    .replace(/^\[|\]$/gu, '')
+    .split(/[&＆]/u)
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function isNativeGradientSource(comment, sourceLabel) {
+  const wireSource = String(comment?.p ?? '').match(/\[([^\]]*)\]$/u)?.[1];
+  return [...sourceTokens(sourceLabel), ...sourceTokens(wireSource)]
+    .some((token) => token === 'dandan' || /^bilibili\d*$/u.test(token));
+}
+
+export function getNativeGradientValue(comment, sourceLabel) {
+  if (!comment || typeof comment !== 'object' || !isNativeGradientSource(comment, sourceLabel)) {
+    return { present: false, value: undefined, field: undefined };
+  }
+  for (const field of NATIVE_GRADIENT_FIELDS) {
+    if (comment[field] !== undefined) return { present: true, value: comment[field], field };
+  }
+  return { present: false, value: undefined, field: undefined };
 }
 
 function parseComment(comment, sourceLabel) {
-  const fields = String(comment.p ?? '').split(',');
-  // 同时接受 DanDanPlay 四字段 JSON 和 Bilibili 八/九字段 XML 的 p 结构。
-  // 两种结构的颜色位置不同，必须先确定 profile，避免把字号误当成颜色。
-  const xmlProfile = fields.length >= 8;
-  const colorIndex = xmlProfile ? 3 : 2;
-  const fontSize = xmlProfile ? Number(fields[2]) : 25;
-  const result = fromBilibili({
-    id: comment.cid ?? `${sourceLabel}:${fields[0] ?? '0'}:${comment.m ?? ''}`,
-    time: Number(fields[0]),
-    mode: Number(fields[1]),
-    fontSize,
-    color: fields[colorIndex],
-    content: String(comment.m ?? ''),
-  });
-  if (!result.value) return result;
-  const normalized = createDanmuX({
-    ...result.value,
-    source: { platform: sourceLabel, id: String(comment.cid ?? result.value.id) },
-  });
-  return {
-    ...normalized,
-    diagnostics: [...(result.diagnostics ?? []), ...(normalized.diagnostics ?? [])],
-  };
+  try {
+    const fields = String(comment.p ?? '').split(',');
+    // 同时接受 DanDanPlay 四字段 JSON 和 Bilibili 八/九字段 XML 的 p 结构。
+    // 两种结构的颜色位置不同，必须先确定 profile，避免把字号误当成颜色。
+    const xmlProfile = fields.length >= 8;
+    const colorIndex = xmlProfile ? 3 : 2;
+    const fontSize = xmlProfile ? Number(fields[2]) : 25;
+    const result = fromBilibili({
+      id: comment.cid ?? `${sourceLabel}:${fields[0] ?? '0'}:${comment.m ?? ''}`,
+      time: Number(fields[0]),
+      mode: Number(fields[1]),
+      fontSize,
+      color: fields[colorIndex],
+      content: String(comment.m ?? ''),
+    });
+    if (!result.value) return result;
+    const normalized = createDanmuX({
+      ...result.value,
+      source: { platform: sourceLabel, id: String(comment.cid ?? result.value.id) },
+    });
+    return {
+      ...normalized,
+      diagnostics: [...(result.diagnostics ?? []), ...(normalized.diagnostics ?? [])],
+    };
+  } catch (error) {
+    return {
+      value: undefined,
+      diagnostics: [{
+        code: 'comment_parse_failed',
+        message: error instanceof Error ? error.message : String(error),
+      }],
+    };
+  }
 }
 
-export function parseDanmuxGradientStops(value) {
-  if (Array.isArray(value)) return value;
-  if (typeof value !== 'string' || !value.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(value);
-    return Array.isArray(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
+function isValidGradientStops(stops) {
+  if (!Array.isArray(stops)) return false;
+  return validateGradientEffect({
+    type: 'gradient',
+    target: 'fill',
+    origin: 'generated',
+    source: { type: 'linear', angle: 0, stops },
+  }).ok;
+}
+
+/**
+ * Parse configured DanmuX stops. Invalid or missing configuration uses the
+ * supplied fallback, which is normally generated from GRADIENT_COLORS.
+ */
+export function parseDanmuxGradientStops(value, fallbackStops) {
+  let parsed;
+  if (Array.isArray(value)) {
+    parsed = value;
+  } else if (typeof value === 'string' && value.trim()) {
+    try {
+      const candidate = JSON.parse(value);
+      parsed = Array.isArray(candidate) ? candidate : undefined;
+    } catch {
+      parsed = undefined;
+    }
   }
+  if (isValidGradientStops(parsed)) return parsed;
+  return isValidGradientStops(fallbackStops) ? fallbackStops : undefined;
 }
 
 export function convertCommentsToDanmux(danmuData, {
@@ -60,33 +113,41 @@ export function convertCommentsToDanmux(danmuData, {
   const converted = [];
   for (let index = 0; index < comments.length; index++) {
     const comment = comments[index];
-    const nativeGradient = hasNativeGradient(comment);
-    // 原生纹理不由当前播放器协议加载；标记为 dandan 后仍保留 p/m 单色降级能力。
-    const commentSourceLabel = nativeGradient ? 'dandan' : sourceLabel;
-    const parsed = parseComment(comment, String(commentSourceLabel).slice(0, 64) || 'danmu_api');
-    diagnostics.push(...(parsed.diagnostics ?? []).map((entry) => ({ ...entry, index })));
-    if (!parsed.value) continue;
-    let item = parsed.value;
-    // DANMUX_GRADIENT_META 是服务端筛选阶段写入的非枚举标记，只在当前转换链路内传递。
-    // 这保证播放器只渲染已命中的普通白色弹幕，而不是给所有弹幕统一套渐变。
-    const selectedGradient = comment[DANMUX_GRADIENT_META];
-    const stops = nativeGradient
-      ? undefined
-      : selectedGradient
-        ? (gradientStops ?? selectedGradient.stops)
-        : (applyGradientToAll ? gradientStops : undefined);
-    if (stops !== undefined) {
-      const generated = applyGradient(item, { angle: selectedGradient?.angle ?? gradientAngle, stops });
-      diagnostics.push(...(generated.diagnostics ?? []).map((entry) => ({ ...entry, index })));
-      item = generated.value ?? item;
+    try {
+      const nativeGradient = getNativeGradientValue(comment, sourceLabel);
+      // 原生纹理不由当前播放器协议加载；标记为 dandan 后仍保留 p/m 单色降级能力。
+      const commentSourceLabel = nativeGradient.present ? 'dandan' : sourceLabel;
+      const parsed = parseComment(comment, String(commentSourceLabel).slice(0, 64) || 'danmu_api');
+      diagnostics.push(...(parsed.diagnostics ?? []).map((entry) => ({ ...entry, index })));
+      if (!parsed.value) continue;
+      let item = parsed.value;
+      // DANMUX_GRADIENT_META 是服务端筛选阶段写入的非枚举标记，只在当前转换链路内传递。
+      // 这保证播放器只渲染已命中的普通白色弹幕，而不是给所有弹幕统一套渐变。
+      const selectedGradient = comment[DANMUX_GRADIENT_META];
+      const stops = nativeGradient.present
+        ? undefined
+        : selectedGradient
+          ? (gradientStops ?? selectedGradient.stops)
+          : (applyGradientToAll ? gradientStops : undefined);
+      if (stops !== undefined) {
+        const generated = applyGradient(item, { angle: selectedGradient?.angle ?? gradientAngle, stops });
+        diagnostics.push(...(generated.diagnostics ?? []).map((entry) => ({ ...entry, index })));
+        item = generated.value ?? item;
+      }
+      // 兼容线同时输出 p/m 和可选 danmux.effects：旧播放器读取单色，新播放器读取增强层。
+      const wire = toCompatibilityWire(item);
+      converted.push({
+        ...wire,
+        ...(comment.cid !== undefined ? { cid: comment.cid } : {}),
+        ...(comment.like !== undefined ? { like: comment.like } : {}),
+      });
+    } catch (error) {
+      diagnostics.push({
+        code: 'comment_conversion_failed',
+        message: error instanceof Error ? error.message : String(error),
+        index,
+      });
     }
-    // 兼容线同时输出 p/m 和可选 danmux.effects：旧播放器读取单色，新播放器读取增强层。
-    const wire = toCompatibilityWire(item);
-    converted.push({
-      ...wire,
-      ...(comment.cid !== undefined ? { cid: comment.cid } : {}),
-      ...(comment.like !== undefined ? { like: comment.like } : {}),
-    });
   }
   return {
     format: 'danmux',

--- a/danmu_api/utils/danmux-meta.js
+++ b/danmu_api/utils/danmux-meta.js
@@ -1,0 +1,3 @@
+// DanmuX-only metadata carried between the legacy conversion stage and the
+// DanmuX adapter without leaking into JSON/XML/other legacy outputs.
+export const DANMUX_GRADIENT_META = Symbol('danmux-gradient-meta');

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -34,7 +34,8 @@ import { apitestJsContent } from './ui/js/apitest.js';
 import { systemSettingsJsContent } from './ui/js/systemsettings.js';
 import { previewJsContent } from './ui/js/preview.js';
 import { convertToAsciiSum } from "./utils/codec-util.js";
-import { convertToDanmakuJson, handleDanmusLike, splitBlockedWords, parseBlockedWord } from "./utils/danmu-util.js";
+import { convertToDanmakuJson, formatDanmuResponse, handleDanmusLike, splitBlockedWords, parseBlockedWord } from "./utils/danmu-util.js";
+import { convertCommentsToDanmux } from './utils/danmux-adapter.js';
 import { Segment, SegmentListResponse } from "./models/dandan-model.js"
 import { initBangumiData, searchBangumiData, clearBangumiDataCache, dedupeBangumiSearchResults } from "./utils/bangumi-data-util.js";
 import { generateNipaplaySignature, parseNipaplayRelatedLinks, resolveNipaplayLink, applyShiftToDanmu } from "./utils/nipaplay-util.js";
@@ -612,6 +613,133 @@ test('worker.js API endpoints', async (t) => {
       { p: '1,1,16777215,[test]', m: '来看能不能发弹幕' }
     ], 'test');
     assert.equal(traditional[0].m, '來看能不能發彈幕');
+
+    resetSearchState();
+  });
+
+  await t.test('DanmuX v1 standard gradient output', async (t) => {
+    const explicitStops = [
+      { position: 0, color: '#FB7299', alpha: 0.85 },
+      { position: 1, color: '#33B8FF', alpha: 0.85 },
+    ];
+
+    await t.test('formal API applies configured stops to selected white comments', async () => {
+      Globals.init({
+        CONVERT_COLOR: 'color',
+        GRADIENT_CHANCE: '100',
+        GRADIENT_COLORS: 'default',
+        DANMUX_GRADIENT_STOPS: JSON.stringify(explicitStops),
+        DANMUX_GRADIENT_ANGLE: '0',
+        DANMU_OUTPUT_FORMAT: 'json',
+      });
+      const comments = convertToDanmakuJson([
+        { p: '12.5,1,16777215,[bilibili]', m: 'API integration', cid: 9 },
+      ], 'bilibili');
+      const response = formatDanmuResponse({ comments }, 'danmux');
+      const payload = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(payload.schemaVersion, 1);
+      assert.equal(payload.comments[0].danmux.effects[0].source.type, 'linear');
+      assert.match(payload.comments[0].p, /^12\.5,1,\d+,\[danmu_api\]$/u);
+    });
+
+    await t.test('default skin affects only ordinary white comments', async () => {
+      Globals.init({
+        CONVERT_COLOR: 'color',
+        GRADIENT_CHANCE: '100',
+        GRADIENT_COLORS: 'default',
+        DANMUX_GRADIENT_STOPS: '',
+        DANMU_OUTPUT_FORMAT: 'json',
+      });
+      const comments = convertToDanmakuJson([
+        { p: '1,1,16777215,[bilibili]', m: 'white comment' },
+        { p: '2,1,16711680,[bilibili]', m: 'red comment' },
+        {
+          p: '3,1,16777215,[bilibili]',
+          m: 'native comment',
+          color_v2: JSON.stringify({ stroke_color: 'https://cdn.example.test/stroke.png' }),
+        },
+      ], 'bilibili');
+      const payload = await (formatDanmuResponse({ comments }, 'danmux')).json();
+
+      assert.equal(payload.comments[0].danmux.effects[0].source.type, 'linear');
+      assert.equal(payload.comments[0].danmux.effects[0].origin, 'generated');
+      assert.equal(payload.comments[1].danmux.effects, undefined);
+      assert.equal(payload.comments[2].danmux.effects, undefined);
+      assert.equal(payload.comments[2].p, '3,1,16777215,[dandan]');
+    });
+
+    await t.test('invalid explicit stops fall back without failing the response', async () => {
+      Globals.init({
+        CONVERT_COLOR: 'color',
+        GRADIENT_CHANCE: '100',
+        GRADIENT_COLORS: 'default',
+        DANMUX_GRADIENT_STOPS: '{invalid json',
+        DANMU_OUTPUT_FORMAT: 'danmux',
+      });
+      const comments = convertToDanmakuJson([
+        { p: '3.5,1,16777215,[bilibili]', m: 'fallback gradient' },
+      ], 'bilibili');
+      const response = formatDanmuResponse({ comments });
+      const payload = await response.json();
+
+      assert.equal(response.status, 200);
+      assert.equal(payload.comments.length, 1);
+      assert.equal(payload.comments[0].danmux.effects[0].source.type, 'linear');
+    });
+
+    await t.test('native aliases and empty color_v2 stay dandan without effects', async () => {
+      Globals.init({
+        CONVERT_COLOR: 'color',
+        GRADIENT_CHANCE: '100',
+        GRADIENT_COLORS: 'default',
+        DANMUX_GRADIENT_STOPS: '',
+        DANMU_OUTPUT_FORMAT: 'danmux',
+      });
+      const comments = convertToDanmakuJson([
+        { p: '7,1,16777215,[bilibili]', m: 'empty native', color_v2: '' },
+        { p: '8,1,16777215,[bilibili]', m: 'camel alias', colorV2: '{}' },
+        { p: '9,1,16777215,[bilibili]', m: 'colorful alias', colorfulSrc: '{}' },
+      ], 'bilibili');
+      const payload = await (formatDanmuResponse({ comments }, 'danmux')).json();
+
+      assert.equal(payload.comments.length, 3);
+      for (const comment of payload.comments) {
+        assert.match(comment.p, /\[dandan\]$/u);
+        assert.equal(comment.danmux.effects, undefined);
+      }
+    });
+
+    await t.test('adapter keeps p/m fallback and ignores native color_v2 effects', () => {
+      const enhanced = convertCommentsToDanmux({
+        comments: [{ p: '4,1,16777215,[bilibili]', m: 'enhanced', cid: 42 }]
+      }, { sourceLabel: 'danmu_api', gradientStops: explicitStops });
+      assert.equal(enhanced.comments[0].p, '4,1,16777215,[danmu_api]');
+      assert.equal(enhanced.comments[0].m, 'enhanced');
+      assert.equal(enhanced.comments[0].danmux.effects[0].source.type, 'linear');
+
+      const fallback = convertCommentsToDanmux({
+        comments: [{ p: '5,1,16777215,[bilibili]', m: 'fallback' }]
+      });
+      assert.equal(fallback.comments[0].danmux.effects, undefined);
+
+      const native = convertCommentsToDanmux({ comments: [{
+        p: '6,1,16777215,[bilibili]',
+        m: 'native ignored',
+        color_v2: JSON.stringify({ stroke_color: 'https://cdn.example.test/stroke.png' }),
+      }] }, { gradientStops: explicitStops });
+      assert.equal(native.comments[0].p, '6,1,16777215,[dandan]');
+      assert.equal(native.comments[0].danmux.effects, undefined);
+
+      const alias = convertCommentsToDanmux({ comments: [{
+        p: '7,1,16777215,[bilibili]',
+        m: 'native alias ignored',
+        colorfulSrc: '{}',
+      }] }, { gradientStops: explicitStops });
+      assert.equal(alias.comments[0].p, '7,1,16777215,[dandan]');
+      assert.equal(alias.comments[0].danmux.effects, undefined);
+    });
 
     resetSearchState();
   });

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -379,9 +379,9 @@ test('worker.js API endpoints', async (t) => {
     });
 
     await t.test('maps match input, honors qualifiers and manual season preference, then falls back to original', async () => {
-      const originalSearch = TencentSource.prototype.search;
-      const originalHandleAnimes = TencentSource.prototype.handleAnimes;
-      const originalGetComments = TencentSource.prototype.getComments;
+      const originalSearch = tencentSource.search;
+      const originalHandleAnimes = tencentSource.handleAnimes;
+      const originalGetComments = tencentSource.getComments;
       const originalAiAsk = AIClient.prototype.ask;
       const originalOrder = Globals.envs.sourceOrderArr;
       const originalAiValid = Globals.aiValid;
@@ -389,11 +389,11 @@ test('worker.js API endpoints', async (t) => {
       let aiMatchInput = null;
       let scenario = 'open';
 
-      TencentSource.prototype.search = async keyword => {
+      tencentSource.search = async keyword => {
         searchKeywords.push(keyword);
         return [{ keyword }];
       };
-      TencentSource.prototype.handleAnimes = async (_source, title, results, details) => {
+      tencentSource.handleAnimes = async (_source, title, results, details) => {
         const add = anime => {
           results.push(anime);
           details.set(String(anime.animeId), anime);
@@ -424,7 +424,7 @@ test('worker.js API endpoints', async (t) => {
         }
         add(createFavoriteAnime(title, 70, 930003));
       };
-      TencentSource.prototype.getComments = async () => [{ p: '1,1,16777215,test', m: 'mapping-test' }];
+      tencentSource.getComments = async () => [{ p: '1,1,16777215,test', m: 'mapping-test' }];
       Globals.envs.sourceOrderArr = ['tencent'];
 
       const runMatch = async (env, fileName, useAi = false) => {
@@ -561,9 +561,9 @@ test('worker.js API endpoints', async (t) => {
         assert.equal(body.matches[0].animeTitle, '原始剧');
         assert.deepEqual(searchKeywords, ['缺失目标', '原始剧']);
       } finally {
-        TencentSource.prototype.search = originalSearch;
-        TencentSource.prototype.handleAnimes = originalHandleAnimes;
-        TencentSource.prototype.getComments = originalGetComments;
+        tencentSource.search = originalSearch;
+        tencentSource.handleAnimes = originalHandleAnimes;
+        tencentSource.getComments = originalGetComments;
         AIClient.prototype.ask = originalAiAsk;
         Globals.envs.sourceOrderArr = originalOrder;
         Globals.aiValid = originalAiValid;
@@ -689,7 +689,7 @@ test('worker.js API endpoints', async (t) => {
       assert.equal(payload.comments[0].danmux.effects[0].source.type, 'linear');
     });
 
-    await t.test('native aliases and empty color_v2 stay dandan without effects', async () => {
+    await t.test('empty decoded color_v2 stays dandan without effects', async () => {
       Globals.init({
         CONVERT_COLOR: 'color',
         GRADIENT_CHANCE: '100',
@@ -699,12 +699,10 @@ test('worker.js API endpoints', async (t) => {
       });
       const comments = convertToDanmakuJson([
         { p: '7,1,16777215,[bilibili]', m: 'empty native', color_v2: '' },
-        { p: '8,1,16777215,[bilibili]', m: 'camel alias', colorV2: '{}' },
-        { p: '9,1,16777215,[bilibili]', m: 'colorful alias', colorfulSrc: '{}' },
       ], 'bilibili');
       const payload = await (formatDanmuResponse({ comments }, 'danmux')).json();
 
-      assert.equal(payload.comments.length, 3);
+      assert.equal(payload.comments.length, 1);
       for (const comment of payload.comments) {
         assert.match(comment.p, /\[dandan\]$/u);
         assert.equal(comment.danmux.effects, undefined);
@@ -732,13 +730,6 @@ test('worker.js API endpoints', async (t) => {
       assert.equal(native.comments[0].p, '6,1,16777215,[dandan]');
       assert.equal(native.comments[0].danmux.effects, undefined);
 
-      const alias = convertCommentsToDanmux({ comments: [{
-        p: '7,1,16777215,[bilibili]',
-        m: 'native alias ignored',
-        colorfulSrc: '{}',
-      }] }, { gradientStops: explicitStops });
-      assert.equal(alias.comments[0].p, '7,1,16777215,[dandan]');
-      assert.equal(alias.comments[0].danmux.effects, undefined);
     });
 
     resetSearchState();
@@ -1105,15 +1096,15 @@ test('worker.js API endpoints', async (t) => {
       favorite.timestamp = originalTimestamp;
       favorite.lastRefreshAt = originalTimestamp;
 
-      const originalSearch = TencentSource.prototype.search;
-      const originalHandleAnimes = TencentSource.prototype.handleAnimes;
+      const originalSearch = tencentSource.search;
+      const originalHandleAnimes = tencentSource.handleAnimes;
       const originalOrder = Globals.envs.sourceOrderArr;
       let searchCount = 0;
-      TencentSource.prototype.search = async () => {
+      tencentSource.search = async () => {
         searchCount++;
         return [{}];
       };
-      TencentSource.prototype.handleAnimes = async (_source, _title, results, details) => {
+      tencentSource.handleAnimes = async (_source, _title, results, details) => {
         results.push(refreshedAnime);
         details.set(String(refreshedAnime.animeId), refreshedAnime);
       };
@@ -1134,8 +1125,8 @@ test('worker.js API endpoints', async (t) => {
         assert.ok(resolveFavoriteForKeyword('刷新测试').entry.lastRefreshAt > originalTimestamp);
         assert.equal(listFavorites()[0].lastRefreshAt, resolveFavoriteForKeyword('刷新测试').entry.lastRefreshAt);
       } finally {
-        TencentSource.prototype.search = originalSearch;
-        TencentSource.prototype.handleAnimes = originalHandleAnimes;
+        tencentSource.search = originalSearch;
+        tencentSource.handleAnimes = originalHandleAnimes;
         Globals.envs.sourceOrderArr = originalOrder;
       }
     });

--- a/danmu_api/worker.test.js
+++ b/danmu_api/worker.test.js
@@ -687,6 +687,10 @@ test('worker.js API endpoints', async (t) => {
       assert.equal(response.status, 200);
       assert.equal(payload.comments.length, 1);
       assert.equal(payload.comments[0].danmux.effects[0].source.type, 'linear');
+      assert.deepEqual(
+        payload.comments[0].danmux.effects[0].source.stops.map((stop) => stop.color),
+        ['#FF6B8B', '#A259FF'],
+      );
     });
 
     await t.test('empty decoded color_v2 stays dandan without effects', async () => {
@@ -729,6 +733,22 @@ test('worker.js API endpoints', async (t) => {
       }] }, { gradientStops: explicitStops });
       assert.equal(native.comments[0].p, '6,1,16777215,[dandan]');
       assert.equal(native.comments[0].danmux.effects, undefined);
+
+      const generic = convertCommentsToDanmux({ comments: [{
+        p: '7,1,16777215,[other]',
+        m: 'generic gradient field',
+        gradient: JSON.stringify({ fill: 'https://cdn.example.test/gradient.png' }),
+      }] }, { gradientStops: explicitStops });
+      assert.equal(generic.comments[0].p, '7,1,16777215,[danmu_api]');
+      assert.equal(generic.comments[0].danmux.effects[0].source.type, 'linear');
+
+      const malformed = convertCommentsToDanmux({ comments: [
+        { p: '8,1,not-a-color,[bilibili]', m: 'bad color' },
+        { p: '9,1,16777215,[bilibili]', m: 'still present' },
+      ] }, { sourceLabel: 'bilibili', gradientStops: explicitStops });
+      assert.equal(malformed.comments.length, 2);
+      assert.equal(malformed.comments[0].m, 'bad color');
+      assert.equal(malformed.comments[1].m, 'still present');
 
     });
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@dan-uni/dan-any": "^2.3.9",
+    "danmux": "https://codeload.github.com/xlmc/danmux/tar.gz/db52b8dbebadbabdcad06983ceab909bd45220da",
     "brotli": "^1.3.3",
     "chokidar": "^4.0.3",
     "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "ISC",
   "dependencies": {
     "@dan-uni/dan-any": "^2.3.9",
-    "danmux": "https://codeload.github.com/xlmc/danmux/tar.gz/db52b8dbebadbabdcad06983ceab909bd45220da",
+    "danmux": "^0.3.0",
     "brotli": "^1.3.3",
     "chokidar": "^4.0.3",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
## 变更内容

- 新增 `format=danmux` / `DANMU_OUTPUT_FORMAT=danmux`，输出 DanmuX v1 增强 JSON，并保留兼容的 `p/m` 字段
- 仅在 `CONVERT_COLOR=color` 且 `GRADIENT_CHANCE` 命中时，为普通白色弹幕生成标准 `linear` 渐变
- 渐变颜色沿用 `GRADIENT_COLORS`；支持 `DANMUX_GRADIENT_STOPS` 和 `DANMUX_GRADIENT_ANGLE` 覆盖
- 解码器真实产出的 `color_v2` 原生纹理弹幕不加载纹理、不生成特效，并按 `[dandan]` 输出
- 错误的 stops JSON 安全回退到当前渐变皮肤，不中断整批弹幕响应
- 补齐管理端配置字段、环境变量示例和接入说明

## 兼容性

- DanmuX 支持 Node.js 18/20/22
- 依赖固定到不可变提交的 GitHub codeload tarball，不要求 Alpine 镜像安装 Git
- 默认 `GRADIENT_CHANCE=0`，未开启时不改变现有弹幕显示

## 验证

- `node --test danmu_api/worker.test.js`：47/47 通过
- 只测试生产解码链路存在的 `color_v2`，不声明或模拟其他原生纹理别名
- DanmuX Node.js 18/20/22 CI 全部通过
- 无 Git 环境安装固定 tarball成功
- `git diff --check` 通过

## 提交范围

仅包含正式源码、配置、文档及现有测试文件；不包含 Demo、模拟器、独立测试目录、锁文件、本地配置、缓存或开发环境记录。