### PR TITLE
fix: update fork sync actions for Node.js 24

### DIFF
--- a/.github/workflows/sync_fork.yml
+++ b/.github/workflows/sync_fork.yml
@@ -16,12 +16,12 @@ jobs:
 
         steps:
             - name: Checkout target repo
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
               with:
                 token: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Sync Upstream
-              uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+              uses: aormsby/Fork-Sync-With-Upstream-action@v3.4.3
               with:
                   target_repo_token: ${{ secrets.GITHUB_TOKEN }}
                   upstream_sync_repo: huangxd-/danmu_api


### PR DESCRIPTION
## Summary

Update the fork sync workflow actions to versions that support Node.js 24.

## Changes

- Update `actions/checkout` from `v4` to `v5`
- Update `aormsby/Fork-Sync-With-Upstream-action` from `v3.4` to `v3.4.3`

## Reason

GitHub Actions now reports the following deprecation warning:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24.

`actions/checkout@v5` uses the Node.js 24 runtime, and `Fork-Sync-With-Upstream-action@v3.4.2+` has also been updated for Node.js 24.